### PR TITLE
feat(shared): add domain models and time/session utilities

### DIFF
--- a/packages/shared/src/__tests__/series.spec.ts
+++ b/packages/shared/src/__tests__/series.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { openingRange, sessionVWAP } from '../series.js';
+import type { Bar } from '../types.js';
+
+describe('series utilities', () => {
+  const bars: Bar[] = [
+    {
+      ts: '2024-05-13T13:30:00Z',
+      symbol: 'ES',
+      interval: '1m',
+      o: 10,
+      h: 12,
+      l: 9,
+      c: 11,
+      v: 100,
+    },
+    {
+      ts: '2024-05-13T13:31:00Z',
+      symbol: 'ES',
+      interval: '1m',
+      o: 11,
+      h: 13,
+      l: 10,
+      c: 12,
+      v: 200,
+    },
+    {
+      ts: '2024-05-13T13:32:00Z',
+      symbol: 'ES',
+      interval: '1m',
+      o: 12,
+      h: 14,
+      l: 11,
+      c: 13,
+      v: 300,
+    },
+  ];
+
+  it('computes opening range', () => {
+    const start = new Date('2024-05-13T13:30:00Z');
+    const end = new Date('2024-05-13T13:31:00Z');
+    const { high, low } = openingRange(bars, start, end);
+    expect(high).toBe(13);
+    expect(low).toBe(9);
+  });
+
+  it('computes session VWAP', () => {
+    const start = new Date('2024-05-13T13:30:00Z');
+    const end = new Date('2024-05-13T13:32:00Z');
+    const vwap = sessionVWAP(bars, start, end);
+    expect(vwap).toBeCloseTo(12, 10);
+  });
+
+  it('throws on empty window', () => {
+    const start = new Date('2024-05-13T13:33:00Z');
+    const end = new Date('2024-05-13T13:34:00Z');
+    expect(() => openingRange(bars, start, end)).toThrow();
+    expect(() => sessionVWAP(bars, start, end)).toThrow();
+  });
+
+  it('guards against zero volume', () => {
+    const zeroBars = bars.map((b) => ({ ...b, v: 0 }));
+    const start = new Date('2024-05-13T13:30:00Z');
+    const end = new Date('2024-05-13T13:32:00Z');
+    expect(() => sessionVWAP(zeroBars, start, end)).toThrow('Total volume is zero');
+  });
+});

--- a/packages/shared/src/__tests__/time.spec.ts
+++ b/packages/shared/src/__tests__/time.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isWithinRTH_GMT, todayCutoff2059GMT, toGMT } from '../time.js';
+
+describe('time utilities', () => {
+  it('converts input to GMT Date', () => {
+    const iso = '2024-05-13T10:00:00.000Z';
+    const fromString = toGMT(iso);
+    expect(fromString.toISOString()).toBe(iso);
+    const fromDate = toGMT(new Date(iso));
+    expect(fromDate.toISOString()).toBe(iso);
+    expect(fromDate).not.toBe(fromString); // new instance
+  });
+
+  it('throws on invalid date', () => {
+    expect(() => toGMT('bad')).toThrow('Invalid date input');
+  });
+
+  it('detects RTH correctly', () => {
+    expect(
+      isWithinRTH_GMT(toGMT('2024-05-13T14:00:00Z'), 'ES'),
+    ).toBe(true);
+    expect(
+      isWithinRTH_GMT(toGMT('2024-05-13T13:29:00Z'), 'ES'),
+    ).toBe(false);
+    expect(
+      isWithinRTH_GMT(toGMT('2024-05-13T21:00:00Z'), 'ES'),
+    ).toBe(false);
+  });
+
+  it('provides daily cutoff at 20:59 GMT', () => {
+    const cutoff = todayCutoff2059GMT(toGMT('2024-05-13T10:00:00Z'));
+    expect(cutoff.toISOString()).toBe('2024-05-13T20:59:00.000Z');
+  });
+
+  it('is stable across DST boundaries', () => {
+    const spring = toGMT('2024-03-10T15:00:00Z');
+    const fall = toGMT('2024-11-03T15:00:00Z');
+    expect(isWithinRTH_GMT(spring, 'ES')).toBe(true);
+    expect(isWithinRTH_GMT(fall, 'ES')).toBe(true);
+  });
+});

--- a/packages/shared/src/__tests__/types.spec.ts
+++ b/packages/shared/src/__tests__/types.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type Bar,
+  isBar,
+  type Ticket,
+} from '../types.js';
+
+describe('types', () => {
+  it('constructs valid bar and guards', () => {
+    const bar: Bar = {
+      ts: '2024-05-13T13:30:00Z',
+      symbol: 'ES',
+      interval: '1m',
+      o: 10,
+      h: 12,
+      l: 9,
+      c: 11,
+      v: 100,
+    };
+    expect(isBar(bar)).toBe(true);
+    expect(
+      isBar({ ...bar, symbol: 'BAD' }),
+    ).toBe(false);
+    expect(isBar(null)).toBe(false);
+    expect(isBar(42)).toBe(false);
+  });
+
+  it('creates a ticket structure', () => {
+    const ticket: Ticket = {
+      id: 't1',
+      symbol: 'ES',
+      contract: 'ESU5',
+      side: 'BUY',
+      qty: 1,
+      order: {
+        type: 'LIMIT',
+        entry: 10,
+        stop: 9,
+        targets: [11, 12],
+        tif: 'DAY',
+        oco: true,
+      },
+      risk: {
+        perTradeUsd: 100,
+        rMultipleByTarget: [1, 2],
+      },
+      apex: {
+        stopRequired: true,
+        rrLeq5: true,
+        ddHeadroom: true,
+        halfSize: false,
+        eodReady: true,
+        consistency30: 'OK',
+      },
+      notes: 'test',
+    };
+    expect(ticket.apex.eodReady).toBe(true);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,3 +5,7 @@ export type Placeholder = {
 export function hello(name: string): string {
   return `Hello, ${name}!`;
 }
+
+export * from './types.js';
+export * from './time.js';
+export * from './series.js';

--- a/packages/shared/src/series.ts
+++ b/packages/shared/src/series.ts
@@ -1,0 +1,44 @@
+import type { Bar } from './types.js';
+
+function inWindow(bar: Bar, start: Date, end: Date): boolean {
+  const ts = Date.parse(bar.ts);
+  return ts >= start.getTime() && ts <= end.getTime();
+}
+
+/** Compute opening range high/low from bars between [start, end]. */
+export function openingRange(
+  bars: readonly Bar[],
+  start: Date,
+  end: Date,
+): { high: number; low: number } {
+  const window = bars.filter((b) => inWindow(b, start, end));
+  if (window.length === 0) {
+    throw new Error('No bars in range for opening range');
+  }
+  let high = -Infinity;
+  let low = Infinity;
+  for (const b of window) {
+    if (b.h > high) high = b.h;
+    if (b.l < low) low = b.l;
+  }
+  return { high, low };
+}
+
+/** Compute session VWAP from bars in [start, end] using sum(P*V)/sum(V). */
+export function sessionVWAP(bars: readonly Bar[], start: Date, end: Date): number {
+  const window = bars.filter((b) => inWindow(b, start, end));
+  if (window.length === 0) {
+    throw new Error('No bars in range for VWAP');
+  }
+  let sumPV = 0;
+  let sumV = 0;
+  for (const b of window) {
+    const typical = (b.h + b.l + b.c) / 3;
+    sumPV += typical * b.v;
+    sumV += b.v;
+  }
+  if (sumV === 0) {
+    throw new Error('Total volume is zero for VWAP');
+  }
+  return sumPV / sumV;
+}

--- a/packages/shared/src/time.ts
+++ b/packages/shared/src/time.ts
@@ -1,0 +1,40 @@
+import type { SymbolCode } from './types.js';
+
+/** Ensure a Date instance in GMT (UTC). */
+export function toGMT(input: Date | string): Date {
+  const date = typeof input === 'string' ? new Date(input) : new Date(input.getTime());
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Invalid date input');
+  }
+  return date;
+}
+
+/**
+ * Returns true if date is within RTH (Regular Trading Hours) for the symbol.
+ * Default RTH for ES/NQ: 13:30–20:59 GMT (configurable via ENV later).
+ */
+export function isWithinRTH_GMT(date: Date, symbol: SymbolCode): boolean {
+  // symbol currently unused but kept for future configurability
+  void symbol;
+  const minutes = date.getUTCHours() * 60 + date.getUTCMinutes();
+  const start = 13 * 60 + 30; // 13:30
+  const end = 20 * 60 + 59; // 20:59
+  return minutes >= start && minutes <= end;
+}
+
+/**
+ * Utility: returns Date at today’s 20:59 GMT (EOD cutoff), used by EOD logic.
+ */
+export function todayCutoff2059GMT(now: Date): Date {
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate(),
+      20,
+      59,
+      0,
+      0,
+    ),
+  );
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,91 @@
+export type SymbolCode = 'ES' | 'NQ' | 'MES' | 'MNQ';
+export type Interval = '1m' | '5m';
+
+export interface Bar {
+  /** ISO 8601 timestamp in UTC */
+  readonly ts: string;
+  readonly symbol: SymbolCode;
+  readonly interval: Interval;
+  readonly o: number;
+  readonly h: number;
+  readonly l: number;
+  readonly c: number;
+  readonly v: number;
+}
+
+export interface AccountState {
+  readonly netLiq: number;
+  readonly cash: number;
+  readonly margin: number;
+  readonly dayPnlRealized: number;
+  readonly dayPnlUnrealized: number;
+}
+
+export interface Position {
+  readonly symbol: SymbolCode;
+  readonly qty: number;
+  readonly avgPrice: number;
+  readonly unrealizedPnl: number;
+}
+
+export type Side = 'BUY' | 'SELL';
+export type OrderType = 'LIMIT' | 'MARKET';
+export type OrderStatus = 'WORKING' | 'FILLED' | 'CANCELED';
+
+export interface Order {
+  readonly id: string;
+  readonly symbol: SymbolCode;
+  readonly side: Side;
+  readonly type: OrderType;
+  readonly limitPrice?: number;
+  readonly stopPrice?: number;
+  readonly status: OrderStatus;
+  readonly ocoGroupId?: string;
+}
+
+export interface Ticket {
+  readonly id: string;
+  readonly symbol: SymbolCode;
+  readonly contract: string; // e.g., ESU5
+  readonly side: Side;
+  readonly qty: number;
+  readonly order: {
+    readonly type: OrderType;
+    readonly entry: number;
+    readonly stop: number;
+    readonly targets: readonly number[];
+    readonly tif: 'DAY';
+    readonly oco: true;
+  };
+  readonly risk: {
+    readonly perTradeUsd: number;
+    readonly rMultipleByTarget: readonly number[];
+  };
+  readonly apex: {
+    readonly stopRequired: boolean;
+    readonly rrLeq5: boolean;
+    readonly ddHeadroom: boolean;
+    readonly halfSize: boolean;
+    readonly eodReady: boolean;
+    readonly consistency30: 'OK' | 'WARN' | 'FAIL';
+  };
+  readonly notes?: string;
+}
+
+/** Runtime type guard for {@link Bar}. */
+export function isBar(value: unknown): value is Bar {
+  if (typeof value !== 'object' || value === null) return false;
+  const b = value as Record<string, unknown>;
+  const symbols: readonly SymbolCode[] = ['ES', 'NQ', 'MES', 'MNQ'];
+  const intervals: readonly Interval[] = ['1m', '5m'];
+  return (
+    typeof b.ts === 'string' &&
+    symbols.includes(b.symbol as SymbolCode) &&
+    intervals.includes(b.interval as Interval) &&
+    typeof b.o === 'number' &&
+    typeof b.h === 'number' &&
+    typeof b.l === 'number' &&
+    typeof b.c === 'number' &&
+    typeof b.v === 'number'
+  );
+}


### PR DESCRIPTION
## Summary
- add domain types for bars, accounts, positions, orders, and tickets
- provide GMT-safe time helpers and session utilities
- include opening range and VWAP calculations with runtime guards

## Testing
- `npm run typecheck -w packages/shared`
- `npm run lint -w packages/shared` *(fails: ESLint couldn't find a configuration file)*
- `npm run test -w packages/shared -- --coverage`


------
https://chatgpt.com/codex/tasks/task_b_68a266e48b40832c95cd4b83d4aae8f5