### PR TITLE
feat(rules-apex): enforce stop-loss on tickets

### DIFF
--- a/packages/rules-apex/src/__tests__/checkStopRequired.spec.ts
+++ b/packages/rules-apex/src/__tests__/checkStopRequired.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type { Ticket } from '../../../shared/src/types.js';
+// eslint-disable-next-line import/no-unresolved
+import { checkStopRequired } from '../checkStopRequired.js';
+
+function baseTicket(partial?: Partial<Ticket>): Ticket {
+  const base: Ticket = {
+    id: 't1',
+    symbol: 'ES',
+    contract: 'ESU5',
+    side: 'BUY',
+    qty: 1,
+    order: {
+      type: 'LIMIT',
+      entry: 5000,
+      stop: 4990,
+      targets: [5010] as readonly number[],
+      tif: 'DAY',
+      oco: true,
+    },
+    risk: { perTradeUsd: 100, rMultipleByTarget: [1] as readonly number[] },
+    apex: {
+      stopRequired: true,
+      rrLeq5: true,
+      ddHeadroom: true,
+      halfSize: true,
+      eodReady: true,
+      consistency30: 'OK',
+    },
+  };
+
+  return {
+    ...base,
+    ...partial,
+    order: (partial?.order as Ticket['order'] | undefined) ?? base.order,
+    risk: partial?.risk ?? base.risk,
+    apex: partial?.apex ?? base.apex,
+  } as Ticket;
+}
+
+describe('checkStopRequired', () => {
+  it('OK when stop is present and not equal to entry', () => {
+    const t = baseTicket();
+    const res = checkStopRequired(t);
+    expect(res.ok).toBe(true);
+  });
+
+  it('FAIL when stop is missing', () => {
+    const t = baseTicket({
+      order: {
+        type: 'LIMIT',
+        entry: 5000,
+        // @ts-expect-error testing missing stop
+        targets: [5010],
+        tif: 'DAY',
+        oco: true,
+      } as any,
+    });
+    const res = checkStopRequired(t);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/Stop-loss is required/i);
+  });
+
+  it('FAIL when stop equals entry', () => {
+    const t = baseTicket({
+      order: {
+        type: 'LIMIT',
+        entry: 5000,
+        stop: 5000,
+        targets: [5010],
+        tif: 'DAY',
+        oco: true,
+      } as any,
+    });
+    const res = checkStopRequired(t);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/cannot equal entry/i);
+  });
+
+  it('FAIL when entry is invalid', () => {
+    const t = baseTicket({
+      order: {
+        type: 'LIMIT',
+        entry: Number.NaN,
+        stop: 4990,
+        targets: [5010],
+        tif: 'DAY',
+        oco: true,
+      } as any,
+    });
+    const res = checkStopRequired(t);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/Invalid entry/i);
+  });
+
+  it('FAIL when stop <= 0', () => {
+    const t = baseTicket({
+      order: {
+        type: 'LIMIT',
+        entry: 5000,
+        stop: 0,
+        targets: [5010],
+        tif: 'DAY',
+        oco: true,
+      } as any,
+    });
+    const res = checkStopRequired(t);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/must be > 0/i);
+  });
+});

--- a/packages/rules-apex/src/checkStopRequired.ts
+++ b/packages/rules-apex/src/checkStopRequired.ts
@@ -1,0 +1,30 @@
+import type { Ticket } from '../../shared/src/types';
+
+/**
+ * Guardrail: Apex requires a stop-loss on every trade.
+ * Returns OK if a valid stop is present and distinct from entry; FAIL otherwise.
+ */
+export interface RuleResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export function checkStopRequired(ticket: Ticket): RuleResult {
+  const entry = ticket?.order?.entry;
+  const stop = ticket?.order?.stop;
+
+  if (typeof entry !== 'number' || !Number.isFinite(entry)) {
+    return { ok: false, reason: 'Invalid entry price' };
+  }
+  if (typeof stop !== 'number' || !Number.isFinite(stop)) {
+    return { ok: false, reason: 'Stop-loss is required' };
+  }
+  if (stop === entry) {
+    return { ok: false, reason: 'Stop-loss cannot equal entry' };
+  }
+  // Additional sanity: stop cannot be negative or zero in futures price terms
+  if (stop <= 0) {
+    return { ok: false, reason: 'Stop-loss must be > 0' };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- add `checkStopRequired` rule to ensure stop-loss is present and valid
- cover stop-loss guardrail with unit tests

## Testing
- `npx -y eslint@8.56.0 packages/rules-apex/src --ext .ts --max-warnings=0 --no-error-on-unmatched-pattern`
- `npx -y prettier@3.1.1 --check /workspace/prism-apex-tool/packages/rules-apex/src/checkStopRequired.ts /workspace/prism-apex-tool/packages/rules-apex/src/__tests__/checkStopRequired.spec.ts`
- `npm run test -w packages/rules-apex -- --run --coverage`


------
https://chatgpt.com/codex/tasks/task_b_68a26951ca0c832c8c375f4442e4aa88