### PR TITLE
feat(rules-apex): add trailing DD guardrails

### DIFF
--- a/packages/rules-apex/src/__tests__/dd.spec.ts
+++ b/packages/rules-apex/src/__tests__/dd.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { computeTrailingDDLine } from '../computeTrailingDDLine';
+import { projectStopBreach } from '../projectStopBreach';
+import type { Ticket, AccountState } from '../../../shared/src/types';
+
+const baseState: AccountState = {
+  netLiq: 52000,
+  cash: 52000,
+  margin: 0,
+  dayPnlRealized: 0,
+  dayPnlUnrealized: 0,
+};
+
+function ticket(perTradeUsd: number): Ticket {
+  return {
+    id: 't1',
+    symbol: 'ES',
+    contract: 'ESU5',
+    side: 'BUY',
+    qty: 1,
+    order: {
+      type: 'LIMIT',
+      entry: 5000,
+      stop: 4995,
+      targets: [5005],
+      tif: 'DAY',
+      oco: true,
+    },
+    risk: { perTradeUsd, rMultipleByTarget: [1] },
+    apex: {
+      stopRequired: true,
+      rrLeq5: true,
+      ddHeadroom: true,
+      halfSize: true,
+      eodReady: true,
+      consistency30: 'OK',
+    },
+  };
+}
+
+describe('computeTrailingDDLine', () => {
+  it('computes ddLine = netLiqHigh - ddAmount', () => {
+    expect(computeTrailingDDLine(52000, 2500)).toBe(49500);
+  });
+
+  it('throws on invalid inputs', () => {
+    expect(() => computeTrailingDDLine(NaN as any, 2500)).toThrow();
+    expect(() => computeTrailingDDLine(52000, -1)).toThrow();
+  });
+
+  it('clamps if ddAmount > netLiqHigh', () => {
+    expect(computeTrailingDDLine(1000, 5000)).toBeCloseTo(0.01);
+  });
+});
+
+describe('projectStopBreach', () => {
+  it('OK when projected netLiq at stop remains above ddLine', () => {
+    const ddLine = computeTrailingDDLine(52000, 3000); // 49000
+    const res = projectStopBreach(ticket(500), baseState, ddLine); // 52000-500=51500 > 49000
+    expect(res.ok).toBe(true);
+  });
+
+  it('FAIL when projected netLiq at stop would breach ddLine', () => {
+    const ddLine = computeTrailingDDLine(52000, 5000); // 47000
+    const res = projectStopBreach(ticket(6000), baseState, ddLine); // 52000-6000=46000 < 47000
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/breaches DD line/i);
+  });
+
+  it('FAIL conservatively if perTradeUsd missing/invalid', () => {
+    const ddLine = computeTrailingDDLine(52000, 3000);
+    const bad: Ticket = ticket(NaN as any);
+    (bad.risk as any).perTradeUsd = NaN;
+    const res = projectStopBreach(bad, baseState, ddLine);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/invalid per-trade risk/i);
+  });
+
+  it('FAIL on invalid account state or ddLine', () => {
+    const ddLine = computeTrailingDDLine(52000, 3000);
+    const res1 = projectStopBreach(ticket(500), { ...baseState, netLiq: NaN as any }, ddLine);
+    expect(res1.ok).toBe(false);
+
+    const res2 = projectStopBreach(ticket(500), baseState, NaN as any);
+    expect(res2.ok).toBe(false);
+  });
+});

--- a/packages/rules-apex/src/computeTrailingDDLine.ts
+++ b/packages/rules-apex/src/computeTrailingDDLine.ts
@@ -1,0 +1,18 @@
+/**
+ * Compute the current trailing drawdown liquidation line.
+ * For Apex-style trailing DD: ddLine = netLiqHigh - ddAmount.
+ * Assumes both inputs are positive and ddAmount <= netLiqHigh.
+ */
+export function computeTrailingDDLine(netLiqHigh: number, ddAmount: number): number {
+  if (!Number.isFinite(netLiqHigh) || netLiqHigh <= 0) {
+    throw new Error('Invalid netLiqHigh');
+  }
+  if (!Number.isFinite(ddAmount) || ddAmount <= 0) {
+    throw new Error('Invalid ddAmount');
+  }
+  if (ddAmount > netLiqHigh) {
+    // In practice this should not happen; clamp at small positive line.
+    return 0.01;
+  }
+  return netLiqHigh - ddAmount;
+}

--- a/packages/rules-apex/src/projectStopBreach.ts
+++ b/packages/rules-apex/src/projectStopBreach.ts
@@ -1,0 +1,52 @@
+import type { Ticket, AccountState } from '../../shared/src/types';
+
+export interface RuleResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Guardrail: Block any ticket whose *projected stop-out* would take equity below the DD line.
+ *
+ * Projection model (MVP, market-agnostic):
+ * - Use ticket.risk.perTradeUsd as the total max loss if the stop is hit (already qty-aware).
+ * - Projected net liq at stop = state.netLiq - perTradeUsd.
+ * - If projected < ddLine => FAIL (block).
+ *
+ * Conservative default:
+ * - If perTradeUsd is missing/invalid, FAIL with reason to avoid underestimating risk.
+ */
+export function projectStopBreach(
+  ticket: Ticket,
+  state: AccountState,
+  ddLine: number
+): RuleResult {
+  const netLiq = state?.netLiq;
+
+  if (!Number.isFinite(netLiq) || netLiq <= 0) {
+    return { ok: false, reason: 'Invalid account state (netLiq)' };
+  }
+  if (!Number.isFinite(ddLine) || ddLine < 0) {
+    return { ok: false, reason: 'Invalid drawdown line' };
+  }
+
+  const perTradeUsd = ticket?.risk?.perTradeUsd;
+  if (!Number.isFinite(perTradeUsd) || perTradeUsd! <= 0) {
+    return {
+      ok: false,
+      reason: 'Unknown or invalid per-trade risk; cannot verify DD headroom',
+    };
+  }
+
+  const projectedAtStop = netLiq - perTradeUsd!;
+  if (projectedAtStop < ddLine - Number.EPSILON) {
+    return {
+      ok: false,
+      reason: `Projected stop-out (${projectedAtStop.toFixed(
+        2
+      )}) breaches DD line (${ddLine.toFixed(2)})`,
+    };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- add computeTrailingDDLine helper
- add projectStopBreach guardrail for DD breaches
- cover new functions with unit tests

## Testing
- `npx eslint packages/rules-apex/src --ext .ts --config .eslintrc.cjs --no-error-on-unmatched-pattern --max-warnings=0`
- `npm test -w packages/rules-apex -- --run --coverage`

------
https://chatgpt.com/codex/tasks/task_b_68a271889a70832cba0a163496565f42