### PR TITLE
feat(rules-apex): add Apex guardrail checks

### DIFF
--- a/packages/rules-apex/src/__tests__/scaling_consistency_eod.spec.ts
+++ b/packages/rules-apex/src/__tests__/scaling_consistency_eod.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+// eslint-disable-next-line import/no-unresolved
+import { enforceHalfSizeUntilBuffer } from '../enforceHalfSizeUntilBuffer.js';
+// eslint-disable-next-line import/no-unresolved
+import { checkConsistency30 } from '../checkConsistency30.js';
+// eslint-disable-next-line import/no-unresolved
+import { checkEODCutoff } from '../checkEODCutoff.js';
+
+// ---- enforceHalfSizeUntilBuffer ----
+describe('enforceHalfSizeUntilBuffer', () => {
+  it('fails on invalid qty or maxContracts', () => {
+    expect(enforceHalfSizeUntilBuffer(0, 4, false).ok).toBe(false);
+    expect(enforceHalfSizeUntilBuffer(1.5 as any, 4, false).ok).toBe(false);
+    expect(enforceHalfSizeUntilBuffer(1, 0, false).ok).toBe(false);
+  });
+
+  it('allows up to floor(max/2) before buffer achieved', () => {
+    // max=5 => half=floor(5/2)=2
+    expect(enforceHalfSizeUntilBuffer(1, 5, false).ok).toBe(true);
+    expect(enforceHalfSizeUntilBuffer(2, 5, false).ok).toBe(true);
+    const res = enforceHalfSizeUntilBuffer(3, 5, false);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toMatch(/half-size/i);
+  });
+
+  it('allows full size after buffer achieved but blocks above max', () => {
+    expect(enforceHalfSizeUntilBuffer(5, 5, true).ok).toBe(true);
+    expect(enforceHalfSizeUntilBuffer(6, 5, true).ok).toBe(false);
+  });
+});
+
+// ---- checkConsistency30 ----
+describe('checkConsistency30', () => {
+  it('OK when total <= 0 (no profits yet)', () => {
+    expect(checkConsistency30(0, 0)).toBe('OK');
+    expect(checkConsistency30(-100, -50)).toBe('OK');
+  });
+
+  it('OK below 25% share', () => {
+    // today=100, period=500 => share=100/600 = 16.6%
+    expect(checkConsistency30(100, 500)).toBe('OK');
+  });
+
+  it('WARN at >=25%', () => {
+    // today=150, period=450 => share=25%
+    expect(checkConsistency30(150, 450)).toBe('WARN');
+  });
+
+  it('FAIL at >=30%', () => {
+    // today=300, period=700 => 30%
+    expect(checkConsistency30(300, 700)).toBe('FAIL');
+    // even if period small
+    expect(checkConsistency30(30, 70)).toBe('FAIL');
+  });
+
+  it('ignores negative today/period for ratio (uses positives only)', () => {
+    // today = 100, period = -100 => total = 100 => 100/100 = 100% -> FAIL
+    expect(checkConsistency30(100, -100)).toBe('FAIL');
+    // today = -50, period = 500 => share = 0/500 = 0 -> OK
+    expect(checkConsistency30(-50, 500)).toBe('OK');
+  });
+
+  it('handles non-finite inputs conservatively', () => {
+    expect(checkConsistency30(Number.NaN, 100)).toBe('OK');
+    expect(checkConsistency30(100, Number.NaN)).toBe('FAIL');
+  });
+});
+
+// ---- checkEODCutoff ----
+describe('checkEODCutoff', () => {
+  function d(iso: string) { return new Date(iso); }
+
+  it('OK well before cutoff', () => {
+    // 20:50:00Z is OK (more than 5 minutes before 20:59)
+    expect(checkEODCutoff(d('2025-08-17T20:50:00.000Z'))).toBe('OK');
+  });
+
+  it('BLOCK_NEW within last 5 minutes before 20:59', () => {
+    // 20:55:00Z is within T-5 window
+    expect(checkEODCutoff(d('2025-08-17T20:55:00.000Z'))).toBe('BLOCK_NEW');
+  });
+
+  it('BLOCK_NEW at/after cutoff', () => {
+    expect(checkEODCutoff(d('2025-08-17T20:59:00.000Z'))).toBe('BLOCK_NEW');
+    expect(checkEODCutoff(d('2025-08-17T21:05:00.000Z'))).toBe('BLOCK_NEW');
+  });
+});

--- a/packages/rules-apex/src/checkConsistency30.ts
+++ b/packages/rules-apex/src/checkConsistency30.ts
@@ -1,0 +1,28 @@
+export type ConsistencyState = 'OK' | 'WARN' | 'FAIL';
+
+/**
+ * Consistency rule: today's profit should not exceed 30% of total period profits.
+ * - We WARN at >= 25% to keep a safety buffer.
+ * - We FAIL at >= 30%.
+ *
+ * Inputs:
+ *  - todayProfit: profit realized today (can be negative or zero).
+ *  - periodProfit: cumulative profit for the rest of the period (excluding today).
+ *
+ * Behavior:
+ *  - Only positive profits count toward the ratio.
+ *  - If total <= 0, return 'OK' (no consistency pressure).
+ *  - share = todayPos / (todayPos + periodPos)
+ */
+export function checkConsistency30(todayProfit: number, periodProfit: number): ConsistencyState {
+  const todayPos = Math.max(0, Number.isFinite(todayProfit) ? todayProfit : 0);
+  const periodPos = Math.max(0, Number.isFinite(periodProfit) ? periodProfit : 0);
+  const total = todayPos + periodPos;
+
+  if (!(total > 0)) return 'OK'; // nothing to compare against
+  const share = todayPos / total;
+
+  if (share >= 0.30 - Number.EPSILON) return 'FAIL';
+  if (share >= 0.25 - Number.EPSILON) return 'WARN';
+  return 'OK';
+}

--- a/packages/rules-apex/src/checkEODCutoff.ts
+++ b/packages/rules-apex/src/checkEODCutoff.ts
@@ -1,0 +1,17 @@
+import { todayCutoff2059GMT } from '../../shared/src/time';
+
+export type EodState = 'OK' | 'BLOCK_NEW';
+
+/**
+ * Block new tickets within the last 5 minutes before 20:59 GMT, and after cutoff.
+ * Returns 'BLOCK_NEW' if now >= (cutoff - 5 minutes), else 'OK'.
+ * Pure function with injected 'now'.
+ */
+export function checkEODCutoff(now: Date, cutoffGMT: '20:59' = '20:59'): EodState {
+  // For MVP we use 20:59 as hard cutoff; if different cutoff is needed later,
+  // provide another helper. We reuse shared todayCutoff2059GMT() for determinism.
+  const cutoff = todayCutoff2059GMT(now);
+  const fiveMinutesMs = 5 * 60 * 1000;
+  if (now.getTime() >= cutoff.getTime() - fiveMinutesMs) return 'BLOCK_NEW';
+  return 'OK';
+}

--- a/packages/rules-apex/src/enforceHalfSizeUntilBuffer.ts
+++ b/packages/rules-apex/src/enforceHalfSizeUntilBuffer.ts
@@ -1,0 +1,41 @@
+export interface RuleResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Enforce Apex-style scaling: until the profit buffer is achieved,
+ * you can only use up to HALF of the max allowed contracts.
+ * - If bufferAchieved === false, allowed = floor(maxContracts/2)
+ * - qty must be a positive integer; maxContracts must be >= 1.
+ * Fails conservatively on invalid inputs.
+ */
+export function enforceHalfSizeUntilBuffer(
+  qty: number,
+  maxContracts: number,
+  bufferAchieved: boolean
+): RuleResult {
+  if (!Number.isInteger(qty) || qty <= 0) {
+    return { ok: false, reason: 'Invalid qty (must be positive integer)' };
+  }
+  if (!Number.isInteger(maxContracts) || maxContracts < 1) {
+    return { ok: false, reason: 'Invalid maxContracts (must be >= 1 integer)' };
+  }
+
+  if (bufferAchieved) {
+    // Full size allowed, as long as qty <= maxContracts
+    if (qty > maxContracts) {
+      return { ok: false, reason: `Qty ${qty} exceeds max contracts ${maxContracts}` };
+    }
+    return { ok: true };
+  }
+
+  const half = Math.max(1, Math.floor(maxContracts / 2));
+  if (qty > half) {
+    return {
+      ok: false,
+      reason: `Qty ${qty} exceeds half-size limit ${half} until buffer is achieved`,
+    };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- add enforceHalfSizeUntilBuffer to enforce half-size scaling until buffer
- add checkConsistency30 to warn/fail on outsized daily profits
- add checkEODCutoff to block new tickets near end-of-day

## Testing
- `npm run test -w packages/rules-apex -- --run --coverage`
- `npm run lint -w packages/rules-apex` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_68a2747c549c832cb35c18bb3c60398e