### PR TITLE
feat: add TradingView webhook ingest and alert queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,8 @@ TRADOVATE_CLIENT_SECRET=your_client_secret
 
 # ---- Node runtime ----
 NODE_ENV=production
+
+# ---- TradingView Webhook Ingest ----
+TRADINGVIEW_WEBHOOK_SECRET=change_me
+# Optional: enable HMAC signature verification (sha256)
+# TRADINGVIEW_HMAC_SECRET=change_me_hmac

--- a/apps/api/src/__tests__/ingest_tv.spec.ts
+++ b/apps/api/src/__tests__/ingest_tv.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+let buildServer: any;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = '/tmp/prism-test';
+  try { fs.rmSync(process.env.DATA_DIR, { recursive: true, force: true }); } catch {}
+  process.env.TRADINGVIEW_WEBHOOK_SECRET = 's3cr3t';
+  delete process.env.TRADINGVIEW_HMAC_SECRET; // default off in tests
+  process.env.TRADOVATE_BASE_URL = 'https://example.test/v1';
+  process.env.TRADOVATE_USERNAME = 'u';
+  process.env.TRADOVATE_PASSWORD = 'p';
+  process.env.TRADOVATE_CLIENT_ID = 'cid';
+  process.env.TRADOVATE_CLIENT_SECRET = 'sec';
+  const mod = await import('../server');
+  buildServer = mod.buildServer;
+});
+
+describe('TradingView ingest', () => {
+  it('rejects missing secret', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST', url: '/ingest/tradingview',
+      payload: { message: 'ES BUY 5000' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('accepts with correct secret and enqueues', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST', url: '/ingest/tradingview',
+      headers: { 'x-webhook-secret': 's3cr3t', 'content-type': 'application/json' },
+      payload: { alert_id: 'abc', symbol: 'ES', side: 'BUY', price: 5000.25, reason: 'VWAP touch' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ok).toBe(true);
+
+    const q = await app.inject({ method: 'GET', url: '/alerts/queue?limit=10' });
+    expect(q.statusCode).toBe(200);
+    const arr = q.json() as any[];
+    expect(arr.length).toBeGreaterThan(0);
+    expect(arr[0].symbol).toBe('ES');
+
+    const ack = await app.inject({ method: 'POST', url: '/alerts/ack', payload: { id: arr[0].id } });
+    expect(ack.statusCode).toBe(200);
+  });
+
+  it('deduplicates within 24h window', async () => {
+    const app = buildServer();
+    const payload = { alert_id: 'dup', ts: '2025-08-17T14:00:00.000Z', message: 'ES BUY 5000 [reason: OR break]' };
+    const headers = { 'x-webhook-secret': 's3cr3t', 'content-type': 'application/json' };
+
+    await app.inject({ method: 'POST', url: '/ingest/tradingview', headers, payload });
+    await app.inject({ method: 'POST', url: '/ingest/tradingview', headers, payload });
+
+    const q = await app.inject({ method: 'GET', url: '/alerts/queue?limit=50' });
+    const arr = q.json() as any[];
+    expect(arr.length).toBe(1);
+  });
+});

--- a/apps/api/src/routes/ingest.ts
+++ b/apps/api/src/routes/ingest.ts
@@ -1,0 +1,50 @@
+import type { FastifyInstance } from 'fastify';
+import crypto from 'node:crypto';
+import { parseTradingViewPayload } from '../../../../packages/adapters-tradingview/src/parser';
+import { store } from '../store';
+
+const SecretHeader = 'x-webhook-secret';
+const SigHeader = 'x-signature'; // expects 'sha256=HEX'
+
+function verifyHmac(raw: string, signatureHeader: string | undefined, secret: string): boolean {
+  if (!signatureHeader) return false;
+  const [algo, sigHex] = signatureHeader.split('=');
+  if (algo !== 'sha256' || !sigHex) return false;
+  const mac = crypto.createHmac('sha256', secret).update(raw).digest('hex');
+  try { return crypto.timingSafeEqual(Buffer.from(sigHex, 'hex'), Buffer.from(mac, 'hex')); }
+  catch { return false; }
+}
+
+export async function ingestRoutes(app: FastifyInstance) {
+  app.addHook('onRequest', async (req, reply) => {
+    // Require JSON
+    if ((req.headers['content-type'] || '').indexOf('application/json') === -1) {
+      // Let Fastify parse JSON since we registered default parsers; fallback safe
+    }
+  });
+
+  app.post('/ingest/tradingview', { config: { rawBody: true } }, async (req, reply) => {
+    const secretEnv = process.env.TRADINGVIEW_WEBHOOK_SECRET || '';
+    if (!secretEnv) return reply.code(500).send({ error: 'Server not configured (missing TRADINGVIEW_WEBHOOK_SECRET)' });
+
+    const givenSecret = String(req.headers[SecretHeader] || '');
+    if (givenSecret !== secretEnv) return reply.code(401).send({ error: 'Unauthorized' });
+
+    // Optional HMAC
+    const hmacSecret = process.env.TRADINGVIEW_HMAC_SECRET;
+    if (hmacSecret) {
+      // @ts-ignore fastify rawBody if enabled by serializer/ajv plugin; fallback stringify
+      const rawBody: string = typeof req.rawBody === 'string' ? req.rawBody : JSON.stringify(req.body || {});
+      const ok = verifyHmac(rawBody, req.headers[SigHeader] as string | undefined, hmacSecret);
+      if (!ok) return reply.code(401).send({ error: 'Invalid signature' });
+    }
+
+    // Validate body (allow any JSON)
+    const body = req.body as unknown;
+    const receivedAt = new Date().toISOString();
+    const { alert, human, candidate } = parseTradingViewPayload(body, receivedAt);
+
+    const queued = store.enqueueAlert({ alert, human, candidate });
+    return reply.send({ ok: true, queued });
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4,6 +4,8 @@ import { marketRoutes } from './routes/market';
 import { signalRoutes } from './routes/signals';
 import { rulesRoutes } from './routes/rules';
 import { reportRoutes } from './routes/report';
+import { ingestRoutes } from './routes/ingest';
+import { alertsRoutes } from './routes/alerts';
 
 export function buildServer() {
   const app = Fastify({ logger: true });
@@ -16,6 +18,8 @@ export function buildServer() {
   app.register(signalRoutes);
   app.register(rulesRoutes);
   app.register(reportRoutes);
+  app.register(ingestRoutes);
+  app.register(alertsRoutes);
 
   return app;
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,14 +1,30 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { Ticket } from '../../../packages/shared/src/types.ts';
+import crypto from 'node:crypto';
+import type { Ticket } from '../../../packages/shared/src/types';
+import type { ParseResult } from '../../../packages/adapters-tradingview/src/types';
 
 const DATA_DIR = process.env.DATA_DIR || '/var/lib/prism-apex-tool';
 const DATA_FILE = path.join(DATA_DIR, 'data.json');
 
 type TicketEntry = { when: string; ticket: Ticket; reasons: string[] };
 
+type AlertEntry = {
+  id: string;
+  ts: string;
+  symbol?: string;
+  side?: 'BUY'|'SELL';
+  price?: number;
+  reason?: string;
+  human: string;
+  raw: unknown;
+  acknowledged: boolean;
+  hash: string; // for dedup window
+};
+
 type DataShape = {
   tickets: TicketEntry[];
+  alerts: AlertEntry[];
   riskContext: {
     netLiqHigh: number;
     ddAmount: number;
@@ -26,6 +42,7 @@ function load(): DataShape {
   if (!fs.existsSync(DATA_FILE)) {
     const init: DataShape = {
       tickets: [],
+      alerts: [],
       riskContext: {
         netLiqHigh: 52000,
         ddAmount: 3000,
@@ -48,6 +65,14 @@ function save(d: DataShape) {
 }
 
 let state: DataShape = load();
+
+function hash(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+function dedupKey(a: { id: string; ts: string; symbol?: string; side?: string; price?: number; human: string }): string {
+  return hash([a.id, a.ts, a.symbol || '', a.side || '', a.price ?? '', a.human].join('|'));
+}
 
 export const store = {
   getRiskContext() { return state.riskContext; },
@@ -72,5 +97,45 @@ export const store = {
       bufferAchieved: state.riskContext.bufferAchieved,
       notes: 'MVP report (extend post-MVP)',
     };
+  },
+
+  // ---- Alerts queue ----
+  enqueueAlert(parsed: ParseResult): AlertEntry {
+    const a = parsed.alert;
+    const entry: AlertEntry = {
+      id: a.id,
+      ts: a.ts,
+      symbol: a.symbol,
+      side: a.side,
+      price: a.price,
+      reason: a.reason,
+      human: parsed.human.text,
+      raw: parsed.alert.raw,
+      acknowledged: false,
+      hash: dedupKey({ id: a.id, ts: a.ts, symbol: a.symbol, side: a.side, price: a.price, human: parsed.human.text }),
+    };
+
+    // Deduplicate within 24h (same hash)
+    const dayAgo = Date.now() - 24 * 60 * 60 * 1000;
+    state.alerts = state.alerts.filter(x => new Date(x.ts).getTime() >= dayAgo);
+    if (state.alerts.some(x => x.hash === entry.hash)) {
+      return entry; // ignore duplicate; do not store again
+    }
+
+    state.alerts.push(entry);
+    save(state);
+    return entry;
+  },
+
+  peekAlerts(limit: number): AlertEntry[] {
+    return state.alerts.filter(a => !a.acknowledged).slice(0, limit);
+  },
+
+  ackAlert(id: string): boolean {
+    const a = state.alerts.find(x => x.id === id && !x.acknowledged);
+    if (!a) return false;
+    a.acknowledged = true;
+    save(state);
+    return true;
   },
 };

--- a/packages/adapters-tradingview/package.json
+++ b/packages/adapters-tradingview/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@prism-apex-tool/adapters-tradingview",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint . --ext .ts --max-warnings=0 --no-error-on-unmatched-pattern",
+    "test": "vitest",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "eslint-plugin-import": "2.32.0",
+    "eslint-plugin-prettier": "5.5.4",
+    "eslint-plugin-simple-import-sort": "10.0.0",
+    "zod": "3.25.76"
+  }
+}

--- a/packages/adapters-tradingview/src/__tests__/parser.spec.ts
+++ b/packages/adapters-tradingview/src/__tests__/parser.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { parseTradingViewPayload } from '../parser';
+
+const now = '2025-08-17T14:00:00.000Z';
+
+describe('TradingView parser', () => {
+  it('parses well-formed JSON payloads', () => {
+    const p = {
+      alert_id: 'abc123',
+      symbol: 'ES',
+      side: 'BUY',
+      price: 5000.25,
+      reason: 'VWAP touch',
+      ts: '2025-08-17T13:59:00.000Z'
+    };
+    const r = parseTradingViewPayload(p, now);
+    expect(r.alert.symbol).toBe('ES');
+    expect(r.alert.side).toBe('BUY');
+    expect(r.alert.price).toBe(5000.25);
+    expect(r.human.text).toMatch(/VWAP touch/);
+    expect(r.candidate).toBeTruthy();
+  });
+
+  it('extracts from free text when keys are missing', () => {
+    const txt = { message: 'Alert: ES LONG possible at 4998.5 [reason: Opening Range break]' };
+    const r = parseTradingViewPayload(txt, now);
+    expect(r.alert.symbol).toBe('ES');
+    expect(r.alert.side).toBe('BUY');
+    expect(r.alert.price).toBeCloseTo(4998.5, 3);
+    expect(r.human.text).toMatch(/Opening Range/);
+  });
+
+  it('produces stable id and has ISO timestamp fallback', () => {
+    const r1 = parseTradingViewPayload({ message: 'ES BUY 5000' }, now);
+    const r2 = parseTradingViewPayload({ message: 'ES BUY 5000' }, now);
+    expect(r1.alert.id).toBe(r2.alert.id);
+    expect(r1.alert.ts).toBe(now);
+  });
+
+  it('ignores unknown symbols and sides safely', () => {
+    const r = parseTradingViewPayload({ message: 'ABC go up 123.4' }, now);
+    expect(r.alert.symbol).toBeUndefined();
+    expect(r.alert.side).toBeUndefined();
+    expect(r.candidate).toBeUndefined();
+  });
+});

--- a/packages/adapters-tradingview/src/parser.ts
+++ b/packages/adapters-tradingview/src/parser.ts
@@ -1,0 +1,144 @@
+import crypto from 'node:crypto';
+import { TvPayloadSchema, type TvPayload, type ParseResult, type TvAlert, type HumanAlert } from './types';
+
+/**
+ * Normalize arbitrary TradingView alert payloads (JSON or free text) into a TvAlert + HumanAlert.
+ * - Robust to keys: {alert_id, symbol, side, price, reason, ts}
+ * - If only free-text available, try to recognize: symbol (A-Z futures like ES, NQ, MES, MNQ),
+ *   side (BUY/SELL/LONG/SHORT), and a price number.
+ * - Candidate generation (optional): only when symbol, side, and price are present.
+ */
+export function parseTradingViewPayload(input: unknown, receivedAtISO: string): ParseResult {
+  const payload = TvPayloadSchema.parse(input) as TvPayload;
+
+  // Extract fields if object-like
+  const obj = payload as Record<string, unknown>;
+  const msg = String((obj.message ?? '') || '');
+
+  const textBlob = stringifyCompact(obj);
+
+  const symbol = normalizeSymbol(
+    (obj.symbol as string) || extractSymbolFromText(msg) || extractSymbolFromText(textBlob)
+  );
+
+  const side = normalizeSide(
+    (obj.side as string) || extractSideFromText(msg) || extractSideFromText(textBlob)
+  );
+
+  const price = toNumber(obj.price) ?? extractPriceFromText(msg) ?? extractPriceFromText(textBlob);
+
+  const reason: string | undefined =
+    (obj.reason as string) ||
+    extractReasonFromText(msg) ||
+    undefined;
+
+  const ts = (typeof obj.ts === 'string' && isIso(obj.ts)) ? obj.ts : receivedAtISO;
+
+  const idSeed = [
+    (obj.alert_id as string) || '',
+    ts,
+    symbol || '',
+    side || '',
+    price != null ? String(price) : '',
+    hash(textBlob).slice(0, 12),
+  ].join('|');
+
+  const id = hash(idSeed);
+
+  const alert: TvAlert = {
+    id,
+    symbol: symbol || undefined,
+    side: side || undefined,
+    price: price ?? undefined,
+    reason,
+    ts,
+    raw: input,
+  };
+
+  const human: HumanAlert = {
+    id,
+    text: humanize(alert),
+  };
+
+  const candidate =
+    symbol && side && typeof price === 'number'
+      ? { symbol, side, entry: price }
+      : undefined;
+
+  return { alert, human, candidate };
+}
+
+// ---------- helpers ----------
+
+function stringifyCompact(obj: unknown): string {
+  try { return JSON.stringify(obj); } catch { return String(obj); }
+}
+
+function extractSymbolFromText(t: string): string | null {
+  // Simple match for ES|NQ|MES|MNQ (case-insensitive). Extend as needed.
+  const m = t.match(/\b(ES|NQ|MES|MNQ)\b/i);
+  return m ? m[1].toUpperCase() : null;
+}
+
+function normalizeSymbol(s?: string | null): string | null {
+  if (!s) return null;
+  const u = s.toUpperCase();
+  if (['ES','NQ','MES','MNQ'].includes(u)) return u;
+  // Accept futures root like ESU5 -> return ES
+  const root = u.replace(/[^A-Z]/g, '');
+  if (['ES','NQ','MES','MNQ'].includes(root)) return root;
+  return null;
+}
+
+function extractSideFromText(t: string): 'BUY' | 'SELL' | null {
+  if (/\b(BUY|LONG)\b/i.test(t)) return 'BUY';
+  if (/\b(SELL|SHORT)\b/i.test(t)) return 'SELL';
+  return null;
+}
+function normalizeSide(s?: string | null): 'BUY' | 'SELL' | null {
+  if (!s) return null;
+  const u = s.toUpperCase();
+  if (u === 'BUY' || u === 'LONG') return 'BUY';
+  if (u === 'SELL' || u === 'SHORT') return 'SELL';
+  return null;
+}
+
+function extractPriceFromText(t: string): number | null {
+  // Pick first numeric with decimal, typical futures price ranges handled by later layers.
+  const m = t.match(/(\d{3,5}(?:\.\d+)?)/);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+function extractReasonFromText(t: string): string | null {
+  // Capture sentence around 'reason:' or any bracketed detail
+  const r1 = t.match(/reason[:=]\s*([^\n\r]+)/i);
+  if (r1) return r1[1].trim();
+  const r2 = t.match(/\[(.*?)\]/);
+  if (r2) return r2[1].trim();
+  return null;
+}
+
+function isIso(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}T/.test(s);
+}
+
+function toNumber(v: unknown): number | null {
+  const n = typeof v === 'string' ? Number(v) : typeof v === 'number' ? v : NaN;
+  return Number.isFinite(n) ? n : null;
+}
+
+function humanize(a: TvAlert): string {
+  const parts = [];
+  parts.push(a.symbol ? a.symbol : 'Unknown symbol');
+  parts.push(a.side ? (a.side === 'BUY' ? 'BUY' : 'SELL') : 'NO-SIDE');
+  parts.push(a.price != null ? `@ ${a.price}` : '@ ?');
+  if (a.reason) parts.push(`— ${a.reason}`);
+  parts.push(`(${a.ts})`);
+  return parts.join(' ');
+}
+
+function hash(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}

--- a/packages/adapters-tradingview/src/types.ts
+++ b/packages/adapters-tradingview/src/types.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+export const TvPayloadSchema = z.union([
+  z.object({
+    // Common JSON alert style from Pine v5
+    alert_id: z.string().optional(),
+    symbol: z.string().optional(),
+    side: z.enum(['BUY', 'SELL']).optional(),
+    price: z.number().optional(),
+    reason: z.string().optional(),
+    ts: z.string().optional(),   // ISO if provided by alert
+    data: z.record(z.unknown()).optional(),
+    message: z.string().optional(),
+  }),
+  // Fallback: anything -> we will try to parse from free text
+  z.record(z.unknown())
+]);
+
+export type TvPayload = z.infer<typeof TvPayloadSchema>;
+
+export interface TvAlert {
+  id: string;          // stable id derived from fields
+  symbol?: string;
+  side?: 'BUY' | 'SELL';
+  price?: number;
+  reason?: string;
+  ts: string;          // ISO timestamp (ingest time if missing)
+  raw: unknown;        // raw payload for audit
+}
+
+export interface HumanAlert {
+  id: string;
+  text: string;        // plain English summary
+}
+
+export interface Candidate {
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  entry: number;
+  stop?: number;
+  targets?: number[];
+}
+
+export interface ParseResult {
+  alert: TvAlert;
+  human: HumanAlert;
+  candidate?: Candidate;
+}

--- a/packages/adapters-tradingview/tsconfig.json
+++ b/packages/adapters-tradingview/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/packages/adapters-tradingview/vitest.config.ts
+++ b/packages/adapters-tradingview/vitest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-default-export */
+/* eslint-disable import/no-unresolved */
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- parse and normalize TradingView webhook alerts into human-readable entries
- ingest alerts via `/ingest/tradingview` with secret/HMAC checks and store queue with dedup
- expose `/alerts/queue` and `/alerts/ack` for operator consumption

## Testing
- `npm run test -w packages/adapters-tradingview -- --run --coverage`
- `npm run test -w apps/api -- --run`
- `npx eslint packages/adapters-tradingview/src/**/*.ts` *(fails: No files matching pattern)*

------
https://chatgpt.com/codex/tasks/task_b_68a31633c7b4832cacc06e165095ab52