### PR TITLE
feat: add daily reporting exports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,10 @@ NODE_ENV=production
 TRADINGVIEW_WEBHOOK_SECRET=change_me
 # Optional: enable HMAC signature verification (sha256)
 # TRADINGVIEW_HMAC_SECRET=change_me_hmac
+
+# ---- Email (optional) ----
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=prism-apex@localhost

--- a/apps/api/src/__tests__/reporting.spec.ts
+++ b/apps/api/src/__tests__/reporting.spec.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildServer } from '../server';
+import { store } from '../store';
+
+// Mock env for Tradovate client
+beforeEach(() => {
+  process.env.TRADOVATE_BASE_URL = 'https://example.test/v1';
+  process.env.TRADOVATE_USERNAME = 'u';
+  process.env.TRADOVATE_PASSWORD = 'p';
+  process.env.TRADOVATE_CLIENT_ID = 'cid';
+  process.env.TRADOVATE_CLIENT_SECRET = 'sec';
+  vi.useRealTimers();
+
+  // Seed store with synthetic data for 2025-08-17
+  const date = '2030-01-01';
+  // @ts-ignore internal access to mutate for tests
+  const d = (store as any);
+  // Reset state by reloading file? Instead patch via public API:
+  // We'll append ticket entries with specific date stamps
+  // (In a real test, we might isolate store; keeping MVP-simple here)
+});
+
+function mockFetchSequence(responses: { status: number; json: any }[]) {
+  let i = 0;
+  (globalThis as any).fetch = vi.fn(async () => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i++;
+    return {
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: async () => r.json,
+    } as Response;
+  });
+}
+
+describe('Reporting exports', () => {
+  it('exports daily JSON and CSV and supports email dry-run', async () => {
+    const date = '2030-01-01';
+    // Seed store via direct appendTicket + enqueueAlert
+    const now1 = `${date}T14:10:00.000Z`;
+    store.appendTicket({
+      when: now1,
+      ticket: {
+        id: 't1',
+        symbol: 'ES',
+        contract: 'ESU5',
+        side: 'BUY',
+        qty: 1,
+        order: { type: 'LIMIT', entry: 5000, stop: 4995, targets: [5005], tif: 'DAY', oco: true },
+        risk: { perTradeUsd: 5, rMultipleByTarget: [1] },
+        apex: { stopRequired: true, rrLeq5: true, ddHeadroom: true, halfSize: true, eodReady: true, consistency30: 'OK' },
+      },
+      reasons: [],
+    });
+
+    const now2 = `${date}T15:30:00.000Z`;
+    store.appendTicket({
+      when: now2,
+      ticket: {
+        id: 't2',
+        symbol: 'NQ',
+        contract: 'NQU5',
+        side: 'SELL',
+        qty: 1,
+        order: { type: 'LIMIT', entry: 18000, stop: 18010, targets: [17990], tif: 'DAY', oco: true },
+        risk: { perTradeUsd: 10, rMultipleByTarget: [1] },
+        apex: { stopRequired: true, rrLeq5: true, ddHeadroom: true, halfSize: true, eodReady: true, consistency30: 'OK' },
+      },
+      reasons: ['Half-size until buffer'],
+    });
+
+    (store as any).enqueueAlert({
+      alert: { id: 'a1', ts: `${date}T14:00:00.000Z`, symbol: 'ES', side: 'BUY', price: 5000, reason: 'VWAP', raw: {} },
+      human: { id: 'a1', text: 'ES BUY @ 5000 — VWAP' },
+    });
+
+    // Mock Tradovate account
+    mockFetchSequence([
+      { status: 200, json: { accessToken: 'a', refreshToken: 'r', expiresIn: 3600 } },
+      { status: 200, json: { netLiq: 52050, cash: 52050, margin: 0, dayPnlRealized: 150.25, dayPnlUnrealized: -25.5 } }, // account for daily.json
+      { status: 200, json: { accessToken: 'a', refreshToken: 'r', expiresIn: 3600 } },
+      { status: 200, json: { netLiq: 52050, cash: 52050, margin: 0, dayPnlRealized: 150.25, dayPnlUnrealized: -25.5 } }, // account for daily.csv
+      { status: 200, json: { accessToken: 'a', refreshToken: 'r', expiresIn: 3600 } },
+      { status: 200, json: { netLiq: 52050, cash: 52050, margin: 0, dayPnlRealized: 150.25, dayPnlUnrealized: -25.5 } }, // account for email
+    ]);
+
+    const app = buildServer();
+
+    const j = await app.inject({ method: 'GET', url: `/export/daily.json?date=${date}` });
+    expect(j.statusCode).toBe(200);
+    const body = j.json();
+    expect(body.summary.ticketsCount).toBe(2);
+    expect(body.summary.blockedCount).toBe(1);
+    expect(body.summary.pnl.realized).toBeCloseTo(150.25, 2);
+
+    const c = await app.inject({ method: 'GET', url: `/export/daily.csv?date=${date}` });
+    expect(c.statusCode).toBe(200);
+    expect(c.headers['content-type']).toContain('text/csv');
+    expect(c.body).toContain('symbol,side,qty,entry');
+
+    // No SMTP env -> dry run
+    const e = await app.inject({
+      method: 'POST',
+      url: '/report/email-daily',
+      payload: { date, to: 'ops@example.com' }
+    });
+    expect(e.statusCode).toBe(200);
+    const er = e.json();
+    expect(er.transport).toBe('dry-run');
+    expect(er.preview).toContain('TO: ops@example.com');
+  });
+});

--- a/apps/api/src/routes/export.ts
+++ b/apps/api/src/routes/export.ts
@@ -1,0 +1,100 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { TradovateClient } from '../../../../packages/clients-tradovate/src/rest.ts';
+import { store } from '../store';
+import type { DailyJson, DailyTicketRow } from '../../../../packages/reporting/src/types.ts';
+import { toDailyCSV } from '../../../../packages/reporting/src/csv.ts';
+import { sendDailyEmail } from '../../../../packages/reporting/src/email.ts';
+
+function toDailyJson(date: string, acct: { dayPnlRealized: number; dayPnlUnrealized: number; netLiq: number }): DailyJson {
+  const dayTickets = store.getTicketsForDate(date);
+  const tickets: DailyTicketRow[] = dayTickets.map(t => ({
+    when: t.when,
+    symbol: t.ticket.symbol,
+    side: t.ticket.side,
+    qty: t.ticket.qty,
+    entry: t.ticket.order.entry,
+    stop: t.ticket.order.stop,
+    targets: t.ticket.order.targets,
+    apex_blocked: t.reasons.length > 0,
+    reasons: t.reasons,
+  }));
+
+  const alerts = store.getAlertsForDate(date).map(a => ({
+    id: a.id,
+    ts: a.ts,
+    symbol: a.symbol,
+    side: a.side,
+    price: a.price,
+    reason: a.reason,
+    acknowledged: a.acknowledged,
+  }));
+
+  const summary = {
+    date,
+    ticketsCount: tickets.length,
+    blockedCount: tickets.filter(t => t.apex_blocked).length,
+    alertsAcked: alerts.filter(a => a.acknowledged).length,
+    alertsQueued: alerts.length,
+    pnl: {
+      realized: acct.dayPnlRealized || 0,
+      unrealized: acct.dayPnlUnrealized || 0,
+      netLiq: acct.netLiq || 0,
+    },
+  };
+
+  const breaches = tickets.filter(t => t.apex_blocked).map(t => ({ when: t.when, reasons: t.reasons }));
+
+  return { summary, tickets, alerts, breaches };
+}
+
+export async function exportRoutes(app: FastifyInstance) {
+  const client = new TradovateClient();
+
+  app.get('/export/daily.json', async (req, reply) => {
+    const q = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) }).safeParse(req.query);
+    if (!q.success) return reply.code(400).send({ error: 'Invalid date' });
+
+    const acct = await client.getAccount() as any;
+    const json = toDailyJson(q.data.date, {
+      dayPnlRealized: acct.dayPnlRealized ?? 0,
+      dayPnlUnrealized: acct.dayPnlUnrealized ?? 0,
+      netLiq: acct.netLiq ?? 0,
+    });
+    return json;
+  });
+
+  app.get('/export/daily.csv', async (req, reply) => {
+    const q = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) }).safeParse(req.query);
+    if (!q.success) return reply.code(400).send({ error: 'Invalid date' });
+
+    const acct = await client.getAccount() as any;
+    const json = toDailyJson(q.data.date, {
+      dayPnlRealized: acct.dayPnlRealized ?? 0,
+      dayPnlUnrealized: acct.dayPnlUnrealized ?? 0,
+      netLiq: acct.netLiq ?? 0,
+    });
+    const csv = toDailyCSV(json);
+    reply.header('content-type', 'text/csv; charset=utf-8');
+    reply.header('content-disposition', `attachment; filename="daily-${q.data.date}.csv"`);
+    return csv;
+  });
+
+  app.post('/report/email-daily', async (req, reply) => {
+    const p = z.object({
+      date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      to: z.string().email(),
+    }).safeParse(req.body);
+    if (!p.success) return reply.code(400).send({ error: 'Invalid payload' });
+
+    const acct = await client.getAccount() as any;
+    const json = toDailyJson(p.data.date, {
+      dayPnlRealized: acct.dayPnlRealized ?? 0,
+      dayPnlUnrealized: acct.dayPnlUnrealized ?? 0,
+      netLiq: acct.netLiq ?? 0,
+    });
+    const csv = toDailyCSV(json);
+    const res = await sendDailyEmail(p.data.date, p.data.to, json, csv);
+    return res;
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -6,6 +6,7 @@ import { rulesRoutes } from './routes/rules';
 import { reportRoutes } from './routes/report';
 import { ingestRoutes } from './routes/ingest';
 import { alertsRoutes } from './routes/alerts';
+import { exportRoutes } from './routes/export';
 
 export function buildServer() {
   const app = Fastify({ logger: true });
@@ -20,6 +21,7 @@ export function buildServer() {
   app.register(reportRoutes);
   app.register(ingestRoutes);
   app.register(alertsRoutes);
+  app.register(exportRoutes);
 
   return app;
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -138,4 +138,12 @@ export const store = {
     save(state);
     return true;
   },
+
+  getTicketsForDate(date: string) {
+    return state.tickets.filter(t => t.when.startsWith(date));
+  },
+
+  getAlertsForDate(date: string) {
+    return state.alerts.filter(a => a.ts.startsWith(date));
+  },
 };

--- a/packages/reporting/package.json
+++ b/packages/reporting/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@prism-apex-tool/reporting",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint . --ext .ts --max-warnings=0 --no-error-on-unmatched-pattern",
+    "test": "vitest",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "nodemailer": "^6.9.11"
+  }
+}

--- a/packages/reporting/src/__tests__/basic.spec.ts
+++ b/packages/reporting/src/__tests__/basic.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { toDailyCSV } from '../csv';
+import { sendDailyEmail } from '../email';
+import type { DailyJson } from '../types';
+
+describe('reporting utils', () => {
+  it('formats CSV and dry-run email', async () => {
+    const json: DailyJson = {
+      summary: {
+        date: '2025-08-17',
+        ticketsCount: 1,
+        blockedCount: 0,
+        alertsAcked: 0,
+        alertsQueued: 0,
+        pnl: { realized: 1, unrealized: 0, netLiq: 1000 },
+      },
+      tickets: [{
+        when: '2025-08-17T14:00:00.000Z',
+        symbol: 'ES',
+        side: 'BUY',
+        qty: 1,
+        entry: 5000,
+        stop: 4995,
+        targets: [5005],
+        apex_blocked: false,
+        reasons: [],
+      }],
+      alerts: [],
+      breaches: [],
+    };
+    const csv = toDailyCSV(json);
+    expect(csv).toContain('date,time,symbol');
+    const res = await sendDailyEmail(json.summary.date, 'ops@example.com', json, csv);
+    expect(res.transport).toBe('dry-run');
+    expect(res.preview).toContain('TO: ops@example.com');
+  });
+});

--- a/packages/reporting/src/csv.ts
+++ b/packages/reporting/src/csv.ts
@@ -1,0 +1,42 @@
+import type { DailyJson } from './types';
+
+function csvEscape(s: string): string {
+  if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+export function toDailyCSV(j: DailyJson): string {
+  const lines: string[] = [];
+  // Header
+  lines.push(['date','time','symbol','side','qty','entry','stop','targets','apex_blocked','reasons'].join(','));
+  // Rows
+  for (const t of j.tickets) {
+    const d = new Date(t.when);
+    const date = d.toISOString().slice(0,10);
+    const time = d.toISOString().slice(11,19);
+    const row = [
+      date,
+      time,
+      t.symbol,
+      t.side,
+      String(t.qty),
+      String(t.entry),
+      String(t.stop),
+      csvEscape(t.targets.join('|')),
+      String(t.apex_blocked),
+      csvEscape(t.reasons.join(' | ')),
+    ];
+    lines.push(row.join(','));
+  }
+  // Footer summary as commented lines
+  lines.push('# ---- SUMMARY ----');
+  lines.push(`# date=${j.summary.date}`);
+  lines.push(`# tickets=${j.summary.ticketsCount}`);
+  lines.push(`# blocked=${j.summary.blockedCount}`);
+  lines.push(`# alerts_acked=${j.summary.alertsAcked}`);
+  lines.push(`# alerts_queued=${j.summary.alertsQueued}`);
+  lines.push(`# pnl_realized=${j.summary.pnl.realized}`);
+  lines.push(`# pnl_unrealized=${j.summary.pnl.unrealized}`);
+  lines.push(`# netLiq=${j.summary.pnl.netLiq}`);
+  return lines.join('\n');
+}

--- a/packages/reporting/src/email.ts
+++ b/packages/reporting/src/email.ts
@@ -1,0 +1,43 @@
+import nodemailer from 'nodemailer';
+import type { DailyJson } from './types';
+
+export type EmailResult = { ok: true; transport: 'smtp' | 'dry-run'; preview?: string };
+
+export async function sendDailyEmail(date: string, to: string, report: DailyJson, csvAttachment?: string): Promise<EmailResult> {
+  const smtpHost = process.env.SMTP_HOST;
+  const smtpPort = process.env.SMTP_PORT ? Number(process.env.SMTP_PORT) : undefined;
+  const smtpUser = process.env.SMTP_USER;
+  const smtpPass = process.env.SMTP_PASS;
+  const from = process.env.SMTP_FROM || 'prism-apex@localhost';
+
+  const subject = `Prism Apex — Daily Report ${date}`;
+  const text = [
+    `Date: ${report.summary.date}`,
+    `Tickets: ${report.summary.ticketsCount} (blocked ${report.summary.blockedCount})`,
+    `Alerts: acked ${report.summary.alertsAcked}, queued ${report.summary.alertsQueued}`,
+    `PnL: realized ${report.summary.pnl.realized.toFixed(2)}, unrealized ${report.summary.pnl.unrealized.toFixed(2)}, netLiq ${report.summary.pnl.netLiq.toFixed(2)}`,
+  ].join('\n');
+
+  // Dry-run when SMTP not configured
+  if (!smtpHost || !smtpPort || !smtpUser || !smtpPass) {
+    const preview = [
+      `TO: ${to}`,
+      `SUBJECT: ${subject}`,
+      `BODY:\n${text}`,
+      csvAttachment ? `\nATTACHMENT:\n${csvAttachment.slice(0, 500)}\n...` : ''
+    ].join('\n');
+    return { ok: true, transport: 'dry-run', preview };
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: smtpHost,
+    port: smtpPort,
+    secure: smtpPort === 465,
+    auth: { user: smtpUser, pass: smtpPass },
+  });
+
+  const attachments = csvAttachment ? [{ filename: `daily-${date}.csv`, content: csvAttachment }] : [];
+
+  await transporter.sendMail({ from, to, subject, text, attachments });
+  return { ok: true, transport: 'smtp' };
+}

--- a/packages/reporting/src/index.ts
+++ b/packages/reporting/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './csv';
+export * from './email';

--- a/packages/reporting/src/types.ts
+++ b/packages/reporting/src/types.ts
@@ -1,0 +1,39 @@
+export type DailyTicketRow = {
+  when: string;            // ISO
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  qty: number;
+  entry: number;
+  stop: number;
+  targets: number[];
+  apex_blocked: boolean;
+  reasons: string[];
+};
+
+export type DailySummary = {
+  date: string;
+  ticketsCount: number;
+  blockedCount: number;
+  alertsAcked: number;
+  alertsQueued: number;
+  pnl: {
+    realized: number;
+    unrealized: number;
+    netLiq: number;
+  };
+};
+
+export type DailyJson = {
+  summary: DailySummary;
+  tickets: DailyTicketRow[];
+  alerts: {
+    id: string;
+    ts: string;
+    symbol?: string;
+    side?: 'BUY'|'SELL';
+    price?: number;
+    reason?: string;
+    acknowledged: boolean;
+  }[];
+  breaches: { when: string; reasons: string[] }[];
+};

--- a/packages/reporting/tsconfig.json
+++ b/packages/reporting/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/packages/reporting/vitest.config.ts
+++ b/packages/reporting/vitest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-default-export */
+/* eslint-disable import/no-unresolved */
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add reporting package for daily ticket and alert exports
- expose API endpoints for JSON, CSV, and email daily reports
- document SMTP email configuration

## Testing
- `CI=1 npm test -w packages/reporting`
- `CI=1 npm test -w apps/api`

------
https://chatgpt.com/codex/tasks/task_b_68a31c21076c832c931ac17e287c7f7d