### PR TITLE
feat: add rule enforcement skeleton for evaluation and funded phases

### DIFF
--- a/docs/rules/overview.md
+++ b/docs/rules/overview.md
@@ -1,0 +1,49 @@
+# PrismOne Rules Overview
+
+PrismOne embeds Apex Trader Funding rules to maintain profitability and
+operational discipline. The platform differentiates between evaluation
+and funded accounts, applying appropriate controls for each stage.
+
+## Evaluation Accounts
+
+- **Profit Target** – account must reach the configured profit target
+  before advancing.
+- **Trailing Drawdown** – balance may not fall more than the defined
+  amount below the high-water mark.
+- **Minimum Trading Days** – at least seven unique trading days are
+  required.
+- **End-of-Day Flat** – no positions may remain open after the allowed
+  trading session.
+- **Allowed Trading Times** – trades outside the configured session are
+  flagged for review.
+
+## Funded Accounts
+
+- **30% Consistency Rule** – profit from any single day may not exceed
+  30% of total profits.
+- **Stop-Loss Requirement** – every trade must carry a protective
+  stop-loss order.
+- **Scaling Limits** – contract counts are capped until trailing
+  drawdown is cleared.
+- **Payout Rules** – eligibility requires minimum trading days,
+  profitable days, and observes payout caps.
+- **Forbidden Strategies** – predefined strategies are automatically
+  rejected.
+
+## Operator Checklist
+
+| Rule / Control | Enforced Automatically | Notes |
+| -------------- | --------------------- | ----- |
+| Trailing Drawdown | ✅ | Both phases emit violations when breached |
+| Minimum Trading Days | ✅ | Evaluation module tracks unique trading days |
+| End-of-Day Flat | ✅ | Evaluation module raises events for open positions |
+| Consistency Rule | ✅ | Funded module validates 30% limit |
+| Stop-Loss Presence | ✅ | Funded module requires stop-loss on each trade |
+| Payout Caps | ✅ | Funded module computes capped payouts |
+| Discretionary Conduct | ⚠️ | Operators monitor for reckless behaviour |
+
+## Technical References
+
+- [Evaluation Rules Module](../../rules/evaluation.py)
+- [Funded Rules Module](../../rules/funded.py)
+- [Unified Rule Engine](../../rules/engine.py)

--- a/rules/__init__.py
+++ b/rules/__init__.py
@@ -1,0 +1,6 @@
+"""PrismOne trading rules package."""
+from .evaluation import EvaluationRules
+from .funded import FundedRules
+from .engine import RuleEngine
+
+__all__ = ["EvaluationRules", "FundedRules", "RuleEngine"]

--- a/rules/engine.py
+++ b/rules/engine.py
@@ -1,0 +1,59 @@
+"""Unified Rule Engine for PrismOne.
+
+Provides a single API for validating trades against the active rule set.
+Supports mode switching and includes hooks for operator dashboard
+integration.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+from .evaluation import EvaluationRules
+from .funded import FundedRules
+
+logger = logging.getLogger(__name__)
+
+
+class RuleEngine:
+    """Dispatch trades to the appropriate rule set."""
+
+    def __init__(self, mode: str, config: Dict) -> None:
+        self.dashboard_client = None
+        self.switch_mode(mode, config)
+
+    def switch_mode(self, mode: str, config: Optional[Dict] = None) -> None:
+        """Switch the active rule set."""
+        mode = mode.lower()
+        config = config or {}
+        if mode == "evaluation":
+            self.rules = EvaluationRules(**config)
+        elif mode == "funded":
+            self.rules = FundedRules(**config)
+        elif mode == "live":
+            self.rules = FundedRules(**config)
+        else:
+            raise ValueError(f"Unsupported mode: {mode}")
+        self.mode = mode
+        logger.info("Rule engine switched to %s mode", mode)
+
+    def attach_dashboard(self, client) -> None:
+        """Attach an operator dashboard client implementing ``publish``."""
+        self.dashboard_client = client
+
+    def validate_trade(self, trade: Dict) -> List[Dict]:
+        """Validate a trade against the current rule set."""
+        events = self.rules.record_trade(trade)
+        if events:
+            logger.debug("Rule engine events: %s", events)
+            if self.dashboard_client:
+                self._emit_dashboard(events)
+        return events
+
+    def _emit_dashboard(self, events: List[Dict]) -> None:
+        """Transmit rule events to the operator dashboard."""
+        try:
+            payload = {"mode": self.mode, "events": events}
+            self.dashboard_client.publish(payload)
+        except Exception as exc:  # pragma: no cover - safety catch
+            logger.error("Dashboard emission failed: %s", exc)

--- a/rules/evaluation.py
+++ b/rules/evaluation.py
@@ -1,0 +1,118 @@
+"""Evaluation Phase Rules for Apex Trader Funding.
+
+This module enforces the evaluation-phase constraints used by PrismOne.
+Rules include profit targets, trailing drawdown, minimum trading days,
+end-of-day flat requirements, and allowed trading times.
+
+All violations emit structured events suitable for audit logging and
+operator dashboards.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, time
+from typing import Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+class EvaluationRules:
+    """Rule set for evaluation accounts.
+
+    Parameters
+    ----------
+    profit_target:
+        Required profit in account currency before evaluation passes.
+    trailing_drawdown:
+        Maximum distance from high-water mark allowed before failure.
+    min_days:
+        Minimum number of trading days required.
+    allowed_start / allowed_end:
+        Inclusive trading window as UTC time objects.
+    """
+
+    def __init__(
+        self,
+        profit_target: float,
+        trailing_drawdown: float,
+        min_days: int = 7,
+        allowed_start: time = time(0, 0),
+        allowed_end: time = time(23, 59),
+    ) -> None:
+        self.profit_target = profit_target
+        self.trailing_drawdown = trailing_drawdown
+        self.min_days = min_days
+        self.allowed_start = allowed_start
+        self.allowed_end = allowed_end
+
+        self.start_balance: Optional[float] = None
+        self.high_watermark: Optional[float] = None
+        self.trading_days: Set[datetime.date] = set()
+        self.events: List[Dict] = []
+
+    def record_trade(self, trade: Dict) -> List[Dict]:
+        """Process a trade and evaluate rule compliance.
+
+        Parameters
+        ----------
+        trade:
+            Dictionary containing at least ``timestamp`` (datetime),
+            ``balance`` (float), ``profit`` (float) and ``position`` (int).
+
+        Returns
+        -------
+        list of dict
+            Structured events for any rule violations or milestones.
+        """
+        timestamp: datetime = trade["timestamp"]
+        balance: float = trade["balance"]
+        profit: float = trade.get("profit", 0.0)
+        position: int = trade.get("position", 0)
+
+        if self.start_balance is None:
+            self.start_balance = balance
+            self.high_watermark = balance
+
+        self.trading_days.add(timestamp.date())
+        if self.high_watermark is not None:
+            self.high_watermark = max(self.high_watermark, balance)
+
+        events: List[Dict] = []
+
+        if not self.allowed_start <= timestamp.time() <= self.allowed_end:
+            events.append(self._event("time_window", "trade outside allowed session"))
+
+        if self.high_watermark is not None and balance < self.high_watermark - self.trailing_drawdown:
+            events.append(self._event("trailing_drawdown", "trailing drawdown breached"))
+
+        if (
+            profit
+            and self.start_balance is not None
+            and balance >= self.start_balance + self.profit_target
+        ):
+            events.append(self._event("profit_target", "profit target achieved"))
+
+        if timestamp.time() >= self.allowed_end and position != 0:
+            events.append(self._event("eod_flat", "position open past end of day"))
+
+        if events:
+            logger.info("Evaluation rule events: %s", events)
+            self.events.extend(events)
+
+        return events
+
+    def _event(self, rule: str, message: str) -> Dict:
+        """Create a structured event for downstream consumers."""
+        return {"timestamp": datetime.utcnow(), "rule": rule, "message": message}
+
+    def days_traded(self) -> int:
+        """Return the count of unique trading days."""
+        return len(self.trading_days)
+
+    def check_minimum_days(self) -> bool:
+        """Determine if minimum day requirement is met."""
+        return self.days_traded() >= self.min_days
+
+    def violations(self) -> List[Dict]:
+        """Return all recorded rule violations."""
+        return [e for e in self.events if e["rule"] != "profit_target"]

--- a/rules/funded.py
+++ b/rules/funded.py
@@ -1,0 +1,111 @@
+"""Funded Phase Rules for Apex Trader Funding.
+
+This module enforces rules for funded accounts, covering consistency,
+mandatory stop-loss usage, scaling limits, payout eligibility, and
+forbidden strategies. All checks produce audit-ready events.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class FundedRules:
+    """Rule set for funded accounts."""
+
+    def __init__(
+        self,
+        trailing_drawdown: float,
+        consistency_threshold: float = 0.30,
+        profit_split: float = 0.9,
+        scaling_limit: int = 1,
+        forbidden_strategies: Optional[List[str]] = None,
+    ) -> None:
+        self.trailing_drawdown = trailing_drawdown
+        self.consistency_threshold = consistency_threshold
+        self.profit_split = profit_split
+        self.scaling_limit = scaling_limit
+        self.forbidden_strategies = forbidden_strategies or []
+
+        self.daily_profits: Dict[datetime.date, float] = {}
+        self.start_balance: Optional[float] = None
+        self.high_watermark: Optional[float] = None
+        self.events: List[Dict] = []
+
+    def record_trade(self, trade: Dict) -> List[Dict]:
+        """Record a trade and evaluate rule compliance."""
+        timestamp: datetime = trade["timestamp"]
+        balance: float = trade["balance"]
+        profit: float = trade.get("profit", 0.0)
+        contracts: int = trade.get("contracts", 0)
+        strategy: str = trade.get("strategy", "")
+        stop_loss: bool = trade.get("stop_loss", False)
+
+        if self.start_balance is None:
+            self.start_balance = balance
+            self.high_watermark = balance
+
+        day = timestamp.date()
+        self.daily_profits[day] = self.daily_profits.get(day, 0.0) + profit
+        if self.high_watermark is not None:
+            self.high_watermark = max(self.high_watermark, balance)
+
+        events: List[Dict] = []
+
+        if self.high_watermark is not None and balance < self.high_watermark - self.trailing_drawdown:
+            events.append(self._event("trailing_drawdown", "trailing drawdown breached"))
+
+        if not stop_loss:
+            events.append(self._event("stop_loss", "trade submitted without stop loss"))
+
+        if contracts > self.scaling_limit:
+            events.append(
+                self._event(
+                    "scaling",
+                    f"{contracts} contracts exceeds limit {self.scaling_limit}",
+                )
+            )
+
+        if strategy in self.forbidden_strategies:
+            events.append(
+                self._event(
+                    "forbidden_strategy", f"use of forbidden strategy '{strategy}'",
+                )
+            )
+
+        if events:
+            logger.info("Funded rule events: %s", events)
+            self.events.extend(events)
+
+        return events
+
+    def _event(self, rule: str, message: str) -> Dict:
+        """Create a structured event for downstream consumers."""
+        return {"timestamp": datetime.utcnow(), "rule": rule, "message": message}
+
+    def check_consistency(self) -> bool:
+        """Validate the 30% consistency rule across daily profits."""
+        total_profit = sum(p for p in self.daily_profits.values() if p > 0)
+        if total_profit <= 0:
+            return True
+        return all(
+            profit / total_profit <= self.consistency_threshold
+            for profit in self.daily_profits.values()
+            if profit > 0
+        )
+
+    def payout_eligibility(self, min_days: int, min_profitable_days: int, cap: float) -> Dict:
+        """Assess payout eligibility and calculate capped amount."""
+        days = len(self.daily_profits)
+        profitable_days = len([p for p in self.daily_profits.values() if p > 0])
+        total_profit = sum(self.daily_profits.values())
+        eligible = days >= min_days and profitable_days >= min_profitable_days and total_profit > 0
+        payout = min(total_profit * self.profit_split, cap) if eligible else 0.0
+        return {"eligible": eligible, "payout": payout}
+
+    def audit_log(self) -> List[Dict]:
+        """Return all recorded events for audit purposes."""
+        return list(self.events)


### PR DESCRIPTION
## Summary
- add evaluation-phase rule module with profit target, drawdown and trading window checks
- add funded-phase rule module including consistency, stop-loss, scaling, and payout logic
- introduce unified rule engine and operator documentation

## Testing
- `python -m py_compile rules/*.py`
- `npm test` *(fails: Cannot find package '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_b_68a320152e50832ca125870adcd9aeae