### PR TITLE
Add bar-level risk simulator and backtest harness

### DIFF
--- a/docs/simulator/overview.md
+++ b/docs/simulator/overview.md
@@ -1,0 +1,25 @@
+# Prism Apex Risk Simulator
+
+## What It Does
+The simulator replays historical market data (bars) to test PrismOne strategies under Apex rules. It demonstrates profitability **and** whether the strategy stays within guardrails.
+
+## How to Use
+1. Collect historical OHLCV bar data (1m or 5m).
+2. Run:
+
+```bash
+python -m simulator.run --strategy ORB --data data/ES_5m.csv --mode evaluation
+```
+
+This writes `results.json` and `results.csv` for review.
+
+## Design
+- **Bar-level**: Fast MVP using OHLCV bars.
+- **Tick-level**: Future enhancement for precision.
+
+## Outputs
+- Trade log with PnL and balance.
+- Metrics: win rate, average R, drawdown, daily PnL.
+- Breach log: any Apex rule violations.
+
+Operators can load the CSV/JSON into spreadsheets; engineers can reproduce backtests via the CLI.

--- a/simulator/__init__.py
+++ b/simulator/__init__.py
@@ -1,0 +1,3 @@
+"""Prism Apex bar-level risk simulator package."""
+
+__all__ = ["core", "metrics"]

--- a/simulator/core.py
+++ b/simulator/core.py
@@ -1,0 +1,102 @@
+"""Risk Simulator Core.
+
+Bar-level replay engine for strategies under Apex rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from rules.engine import RuleEngine
+
+
+@dataclass
+class Position:
+    """Track an open position during simulation."""
+
+    side: str
+    entry_price: float
+    stop_loss: float
+    target: float
+    size: int
+    entry_time: pd.Timestamp
+
+
+class Simulator:
+    """Replay OHLCV bars, apply strategies and Apex rules."""
+
+    def __init__(self, strategy, rules: RuleEngine, starting_balance: float = 0.0) -> None:
+        self.strategy = strategy
+        self.rules = rules
+        self.balance = starting_balance
+        self.open_positions: List[Position] = []
+        self.trades: List[Dict] = []
+        self.logs: List[Dict] = []
+
+    def run(self, data: pd.DataFrame) -> Dict[str, List[Dict]]:
+        """Replay OHLCV bars sequentially, run strategy, validate with rules."""
+        df = data.reset_index(drop=True)
+        for i, bar in df.iterrows():
+            history = df.iloc[: i + 1]
+            candidates = self.strategy.on_bar(bar, history)
+            for c in candidates:
+                pos = Position(
+                    side=c["side"],
+                    entry_price=c["entry_price"],
+                    stop_loss=c["stop_loss"],
+                    target=c["target"],
+                    size=c.get("size", 1),
+                    entry_time=bar["date"],
+                )
+                self.open_positions.append(pos)
+
+            remaining: List[Position] = []
+            for pos in self.open_positions:
+                exit_price: Optional[float] = None
+                if pos.side == "long":
+                    if bar["low"] <= pos.stop_loss:
+                        exit_price = pos.stop_loss
+                    elif bar["high"] >= pos.target:
+                        exit_price = pos.target
+                else:
+                    if bar["high"] >= pos.stop_loss:
+                        exit_price = pos.stop_loss
+                    elif bar["low"] <= pos.target:
+                        exit_price = pos.target
+
+                if exit_price is not None:
+                    profit = (
+                        (exit_price - pos.entry_price) * pos.size
+                        if pos.side == "long"
+                        else (pos.entry_price - exit_price) * pos.size
+                    )
+                    self.balance += profit
+                    trade = {
+                        "side": pos.side,
+                        "entry_time": pos.entry_time,
+                        "exit_time": bar["date"],
+                        "entry_price": pos.entry_price,
+                        "exit_price": exit_price,
+                        "stop_loss": pos.stop_loss,
+                        "target": pos.target,
+                        "size": pos.size,
+                        "profit": profit,
+                        "balance": self.balance,
+                    }
+                    events = self.rules.validate_trade(
+                        {
+                            "timestamp": pd.to_datetime(bar["date"]),
+                            "balance": self.balance,
+                            "profit": profit,
+                            "position": 0,
+                        }
+                    )
+                    if events:
+                        self.logs.extend(events)
+                    self.trades.append(trade)
+                else:
+                    remaining.append(pos)
+            self.open_positions = remaining
+        return {"trades": self.trades, "logs": self.logs}

--- a/simulator/metrics.py
+++ b/simulator/metrics.py
@@ -1,0 +1,44 @@
+"""Risk Simulator Metrics.
+
+Compute profitability and risk statistics along with Apex rule adherence."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pandas as pd
+
+
+def compute_metrics(trades: List[Dict], logs: List[Dict]) -> Dict:
+    """Compute win rate, average R multiple, drawdown and daily PnL."""
+    df = pd.DataFrame(trades)
+    if df.empty:
+        return {
+            "win_rate": 0.0,
+            "avg_r": 0.0,
+            "max_drawdown": 0.0,
+            "daily_pnl": {},
+            "rule_breaches": len(logs),
+        }
+
+    df["risk"] = (df["entry_price"] - df["stop_loss"]).abs()
+    df["r_multiple"] = df["profit"] / df["risk"]
+
+    win_rate = float((df["profit"] > 0).mean())
+    avg_r = float(df["r_multiple"].mean())
+
+    pnl_cum = df["profit"].cumsum()
+    drawdown = pnl_cum - pnl_cum.cummax()
+    max_drawdown = float(drawdown.min())
+
+    daily_pnl = (
+        df.groupby(pd.to_datetime(df["exit_time"]).dt.date)["profit"].sum().to_dict()
+    )
+
+    return {
+        "win_rate": win_rate,
+        "avg_r": avg_r,
+        "max_drawdown": max_drawdown,
+        "daily_pnl": daily_pnl,
+        "rule_breaches": len(logs),
+    }

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -1,0 +1,49 @@
+"""CLI entry point for the Prism Apex risk simulator."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from rules.engine import RuleEngine
+from simulator.core import Simulator
+from simulator.metrics import compute_metrics
+from strategy.orb import OpeningRangeStrategy
+from strategy.vwap import VWAPStrategy
+
+STRATEGIES = {"ORB": OpeningRangeStrategy, "VWAP": VWAPStrategy}
+
+
+def main() -> None:
+    """Parse CLI arguments and execute a backtest."""
+    parser = argparse.ArgumentParser(description="Prism Apex Risk Simulator")
+    parser.add_argument("--strategy", required=True, choices=STRATEGIES.keys())
+    parser.add_argument("--data", required=True, help="CSV file with OHLCV data")
+    parser.add_argument("--mode", required=True, choices=["evaluation", "funded"])
+    parser.add_argument(
+        "--output", default="results", help="Base path for output CSV/JSON"
+    )
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.data, parse_dates=["date"])
+    strategy = STRATEGIES[args.strategy]()
+    rules = RuleEngine(
+        mode=args.mode,
+        config={"profit_target": 1000.0, "trailing_drawdown": 500.0},
+    )
+    sim = Simulator(strategy, rules)
+    result = sim.run(df)
+
+    metrics = compute_metrics(result["trades"], result["logs"])
+    base = Path(args.output)
+    pd.DataFrame(result["trades"]).to_csv(base.with_suffix(".csv"), index=False)
+    with open(base.with_suffix(".json"), "w", encoding="utf-8") as fh:
+        json.dump({"metrics": metrics, "logs": result["logs"]}, fh, indent=2, default=str)
+    print(json.dumps(metrics, indent=2, default=str))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/strategy/__init__.py
+++ b/strategy/__init__.py
@@ -1,0 +1,6 @@
+"""Strategy implementations for the risk simulator."""
+
+from .orb import OpeningRangeStrategy
+from .vwap import VWAPStrategy
+
+__all__ = ["OpeningRangeStrategy", "VWAPStrategy"]

--- a/strategy/orb.py
+++ b/strategy/orb.py
@@ -1,0 +1,49 @@
+"""Opening Range Breakout strategy."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pandas as pd
+
+
+class OpeningRangeStrategy:
+    """Enter on break of the first bar's high or low."""
+
+    def __init__(self, range_bars: int = 1, r_multiple: float = 2.0) -> None:
+        self.range_bars = range_bars
+        self.r_multiple = r_multiple
+        self.open_high: float | None = None
+        self.open_low: float | None = None
+
+    def on_bar(self, bar: pd.Series, history: pd.DataFrame) -> List[Dict]:
+        trades: List[Dict] = []
+        if len(history) == self.range_bars:
+            self.open_high = history["high"].max()
+            self.open_low = history["low"].min()
+            return trades
+        if len(history) < self.range_bars:
+            return trades
+
+        assert self.open_high is not None and self.open_low is not None
+        if bar["close"] > self.open_high:
+            risk = bar["close"] - self.open_low
+            trades.append(
+                {
+                    "side": "long",
+                    "entry_price": bar["close"],
+                    "stop_loss": self.open_low,
+                    "target": bar["close"] + self.r_multiple * risk,
+                }
+            )
+        elif bar["close"] < self.open_low:
+            risk = self.open_high - bar["close"]
+            trades.append(
+                {
+                    "side": "short",
+                    "entry_price": bar["close"],
+                    "stop_loss": self.open_high,
+                    "target": bar["close"] - self.r_multiple * risk,
+                }
+            )
+        return trades

--- a/strategy/vwap.py
+++ b/strategy/vwap.py
@@ -1,0 +1,46 @@
+"""VWAP cross strategy."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pandas as pd
+
+
+class VWAPStrategy:
+    """Enter when price crosses VWAP."""
+
+    def __init__(self, r_multiple: float = 2.0) -> None:
+        self.r_multiple = r_multiple
+
+    def on_bar(self, bar: pd.Series, history: pd.DataFrame) -> List[Dict]:
+        trades: List[Dict] = []
+        if len(history) < 2:
+            return trades
+        tp = (history["high"] + history["low"] + history["close"]) / 3
+        vwap_series = (tp * history["volume"]).cumsum() / history["volume"].cumsum()
+        current_vwap = vwap_series.iloc[-1]
+        prev_close = history["close"].iloc[-2]
+        prev_vwap = vwap_series.iloc[-2]
+
+        if prev_close <= prev_vwap and bar["close"] > current_vwap:
+            risk = bar["close"] - bar["low"]
+            trades.append(
+                {
+                    "side": "long",
+                    "entry_price": bar["close"],
+                    "stop_loss": bar["low"],
+                    "target": bar["close"] + self.r_multiple * risk,
+                }
+            )
+        elif prev_close >= prev_vwap and bar["close"] < current_vwap:
+            risk = bar["high"] - bar["close"]
+            trades.append(
+                {
+                    "side": "short",
+                    "entry_price": bar["close"],
+                    "stop_loss": bar["high"],
+                    "target": bar["close"] - self.r_multiple * risk,
+                }
+            )
+        return trades

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,91 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from rules.engine import RuleEngine
+from simulator.core import Simulator
+from simulator.metrics import compute_metrics
+from strategy.orb import OpeningRangeStrategy
+from strategy.vwap import VWAPStrategy
+
+
+def _df(rows):
+    return pd.DataFrame(rows)
+
+
+def test_orb_generates_trade():
+    data = _df([
+        {"date": "2025-01-01 09:30", "open": 100, "high": 105, "low": 95, "close": 100, "volume": 1000},
+        {"date": "2025-01-01 09:35", "open": 100, "high": 110, "low": 99, "close": 106, "volume": 1500},
+        {"date": "2025-01-01 09:40", "open": 106, "high": 130, "low": 105, "close": 120, "volume": 1500},
+    ])
+    strat = OpeningRangeStrategy()
+    rules = RuleEngine("evaluation", {"profit_target": 1000, "trailing_drawdown": 500})
+    sim = Simulator(strat, rules)
+    result = sim.run(data)
+    assert len(result["trades"]) == 1
+
+
+def test_vwap_generates_trade():
+    data = _df([
+        {"date": "2025-01-01 09:30", "open": 100, "high": 101, "low": 99, "close": 100, "volume": 1000},
+        {"date": "2025-01-01 09:35", "open": 100, "high": 105, "low": 100, "close": 104, "volume": 1500},
+    ])
+    strat = VWAPStrategy()
+    rules = RuleEngine("evaluation", {"profit_target": 1000, "trailing_drawdown": 500})
+    sim = Simulator(strat, rules)
+    result = sim.run(data)
+    assert len(result["trades"]) == 1
+
+
+def test_stop_target_and_breach_detection():
+    data = _df([
+        {"date": "2025-01-01 09:30", "open": 100, "high": 101, "low": 99, "close": 100, "volume": 1000},
+        {"date": "2025-01-01 09:35", "open": 100, "high": 100, "low": 95, "close": 95, "volume": 1000},
+        {"date": "2025-01-01 09:40", "open": 95, "high": 96, "low": 85, "close": 86, "volume": 1000},
+    ])
+
+    class BreachStrategy:
+        def on_bar(self, bar, history):
+            if len(history) == 1:
+                return [{"side": "long", "entry_price": 100, "stop_loss": 99, "target": 101}]
+            if len(history) == 2:
+                return [{"side": "long", "entry_price": 95, "stop_loss": 90, "target": 105}]
+            return []
+
+    strat = BreachStrategy()
+    rules = RuleEngine("evaluation", {"profit_target": 1000, "trailing_drawdown": 1})
+    sim = Simulator(strat, rules)
+    result = sim.run(data)
+    trade = result["trades"][1]
+    assert trade["exit_price"] == 90
+    assert trade["profit"] == -5
+    assert result["logs"]  # trailing drawdown breach
+
+
+def test_metrics_computed_correctly():
+    trades = [
+        {
+            "entry_price": 100,
+            "stop_loss": 90,
+            "exit_price": 110,
+            "profit": 10,
+            "exit_time": "2025-01-01",
+        },
+        {
+            "entry_price": 110,
+            "stop_loss": 105,
+            "exit_price": 100,
+            "profit": -10,
+            "exit_time": "2025-01-02",
+        },
+    ]
+    metrics = compute_metrics(trades, [])
+    assert metrics["win_rate"] == 0.5
+    assert metrics["avg_r"] == -0.5
+    assert metrics["max_drawdown"] == -10
+    assert metrics["daily_pnl"][pd.to_datetime("2025-01-01").date()] == 10
+    assert metrics["daily_pnl"][pd.to_datetime("2025-01-02").date()] == -10


### PR DESCRIPTION
## Summary
- implement bar-level Simulator integrating strategies and Apex RuleEngine
- add metrics module and CLI runner with CSV/JSON output
- provide ORB and VWAP strategies with unit tests

## Testing
- `pytest tests/test_simulator.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a331ff7a5c832ca4869952bbe72492