### PR TITLE
feat: add production deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,101 @@
+name: deploy
+
+on:
+  push:
+    tags:
+      - 'v*'      # release on version tags
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test --workspaces --if-present
+
+      - name: Build dashboard
+        run: npm run build -w apps/dashboard
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Extract tag/sha
+        id: meta
+        run: |
+          echo "TAG=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+          echo "SHA=${GITHUB_SHA::12}" >> $GITHUB_OUTPUT
+
+      - name: Build & push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/prism-apex-api:${{ steps.meta.outputs.TAG }}
+            ghcr.io/${{ github.repository_owner }}/prism-apex-api:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build & push Dashboard image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/dashboard/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/prism-apex-dashboard:${{ steps.meta.outputs.TAG }}
+            ghcr.io/${{ github.repository_owner }}/prism-apex-dashboard:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  deploy:
+    runs-on: ubuntu-22.04
+    needs: build-and-push
+    steps:
+      - name: Checkout infra
+        uses: actions/checkout@v4
+
+      - name: Write SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.PROD_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+
+      - name: Bootstrap server (one-time safe)
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.PROD_SSH_USER }}@${{ secrets.PROD_SSH_HOST }} 'bash -s' < infra/scripts/bootstrap.sh
+
+      - name: Push infra files to server
+        run: |
+          rsync -avz -e "ssh -o StrictHostKeyChecking=no" infra/ ${{ secrets.PROD_SSH_USER }}@${{ secrets.PROD_SSH_HOST }}:${{ secrets.PROD_STACK_DIR }}/
+
+      - name: Deploy stack (health-gated)
+        env:
+          STACK_NAME: ${{ secrets.STACK_NAME }}
+          TAG: ${{ github.ref_name }}
+          GHCR_OWNER: ${{ github.repository_owner }}
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.PROD_SSH_USER }}@${{ secrets.PROD_SSH_HOST }} \
+            "STACK_NAME=$STACK_NAME TAG=$TAG GHCR_OWNER=$GHCR_OWNER bash ${{ secrets.PROD_STACK_DIR }}/scripts/deploy.sh"

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,16 @@ docker compose down -v
 
 logs:
 docker compose logs -f
+
+.PHONY: release deploy
+
+# Create a signed tag and push (CI will build & deploy)
+release:
+	@if [ -z "$$TAG" ]; then echo "Usage: make release TAG=v0.1.0"; exit 2; fi
+	git tag -a $$TAG -m "Release $$TAG"
+	git push origin $$TAG
+
+# Convenience local wrapper to call remote deploy script (requires same secrets exported)
+deploy:
+	@if [ -z "$$PROD_SSH_HOST" ] || [ -z "$$PROD_SSH_USER" ] || [ -z "$$PROD_STACK_DIR" ] || [ -z "$$STACK_NAME" ]; then echo "Set PROD_SSH_HOST, PROD_SSH_USER, PROD_STACK_DIR, STACK_NAME, TAG, GHCR_OWNER"; exit 2; fi
+	ssh $$PROD_SSH_USER@$$PROD_SSH_HOST "STACK_NAME=$$STACK_NAME TAG=$$TAG GHCR_OWNER=$$GHCR_OWNER STACK_DIR=$$PROD_STACK_DIR bash $$PROD_STACK_DIR/scripts/deploy.sh"

--- a/infra/.env.prod.example
+++ b/infra/.env.prod.example
@@ -1,0 +1,35 @@
+# Prism Apex Tool production env
+
+# ---- API ----
+HOST=0.0.0.0
+PORT=8080
+DATA_DIR=/var/lib/prism-apex-tool
+NODE_ENV=production
+
+# ---- Tradovate Client (read-only) ----
+TRADOVATE_BASE_URL=https://live.tradovateapi.com/v1
+TRADOVATE_USERNAME=
+TRADOVATE_PASSWORD=
+TRADOVATE_CLIENT_ID=
+TRADOVATE_CLIENT_SECRET=
+
+# ---- Webhook secrets ----
+TRADINGVIEW_WEBHOOK_SECRET=
+# TRADINGVIEW_HMAC_SECRET=
+
+# ---- Email (optional) ----
+SMTP_HOST=
+SMTP_PORT=
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=prism-apex@yourdomain
+
+# ---- Telegram / Slack / SMS (optional) ----
+TELEGRAM_BOT_TOKEN=
+SLACK_BOT_TOKEN=
+TWILIO_SID=
+TWILIO_TOKEN=
+TWILIO_FROM=
+
+# ---- Risk thresholds ----
+DAILY_LOSS_CAP_USD=1000

--- a/infra/README-DEPLOY.md
+++ b/infra/README-DEPLOY.md
@@ -1,0 +1,41 @@
+# Prism Apex Tool — Deployment (Production)
+
+## Overview
+This stack deploys two containers:
+- **API** on port **8080**
+- **Dashboard** on port **80** (proxies `/api/*` to API via Nginx in the image)
+
+## One-time Server Setup
+1. Provision Ubuntu 22.04 server.
+2. Add GitHub Actions secrets (below).
+3. First CI run will **bootstrap** Docker automatically.
+
+## Required GitHub Secrets
+- `GHCR_USERNAME`, `GHCR_TOKEN` — push images to GHCR  
+- `PROD_SSH_HOST`, `PROD_SSH_USER`, `PROD_SSH_KEY` — deploy over SSH  
+- `PROD_STACK_DIR` — e.g., `/home/ubuntu/prism-stack`  
+- `STACK_NAME` — e.g., `prism`  
+
+## First Deploy
+1. Copy `infra/.env.prod.example` → create **server** file `${PROD_STACK_DIR}/.env`.
+2. Tag a release locally:
+   ```bash
+   make release TAG=v0.1.0
+   ```
+3. CI builds & pushes images, then deploys to the server.
+
+## Verify:
+- <http://<server-ip>/> (dashboard)
+- <http://<server-ip>:8080/health> (API)
+
+## Rollback
+Re-deploy previous tag:
+
+```
+TAG=v0.0.9 make deploy
+```
+
+## Notes
+- Volumes are preserved across updates (prism_data).
+- Health-gated rollout avoids serving broken builds.
+- Add a reverse proxy + TLS later (Caddy/Traefik) if you need HTTPS.

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,0 +1,49 @@
+version: "3.9"
+
+services:
+  api:
+    image: ghcr.io/${GHCR_OWNER:-yourorg}/prism-apex-api:${TAG:-latest}
+    container_name: ${STACK_NAME:-prism}-api
+    env_file: .env
+    environment:
+      NODE_ENV: production
+      PORT: 8080
+      DATA_DIR: /var/lib/prism-apex-tool
+    volumes:
+      - prism_data:/var/lib/prism-apex-tool
+    networks:
+      - prism
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+
+  dashboard:
+    image: ghcr.io/${GHCR_OWNER:-yourorg}/prism-apex-dashboard:${TAG:-latest}
+    container_name: ${STACK_NAME:-prism}-dashboard
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+    networks:
+      - prism
+    ports:
+      - "80:80"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1/"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  prism_data:
+
+networks:
+  prism:
+    driver: bridge

--- a/infra/k8s/api-deployment.yaml
+++ b/infra/k8s/api-deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prism-api
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: prism-api } }
+  template:
+    metadata: { labels: { app: prism-api } }
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/YOURORG/prism-apex-api:latest
+          envFrom: [{ configMapRef: { name: prism-env } }]
+          ports: [{ containerPort: 8080 }]
+          readinessProbe: { httpGet: { path: /health, port: 8080 }, initialDelaySeconds: 5, periodSeconds: 5 }
+          livenessProbe: { httpGet: { path: /health, port: 8080 }, initialDelaySeconds: 10, periodSeconds: 10 }

--- a/infra/k8s/dashboard-deployment.yaml
+++ b/infra/k8s/dashboard-deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prism-dashboard
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: prism-dashboard } }
+  template:
+    metadata: { labels: { app: prism-dashboard } }
+    spec:
+      containers:
+        - name: dashboard
+          image: ghcr.io/YOURORG/prism-apex-dashboard:latest
+          ports: [{ containerPort: 80 }]
+          readinessProbe: { httpGet: { path: /, port: 80 }, initialDelaySeconds: 5, periodSeconds: 5 }
+          livenessProbe: { httpGet: { path: /, port: 80 }, initialDelaySeconds: 10, periodSeconds: 10 }

--- a/infra/k8s/ingress.yaml
+++ b/infra/k8s/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prism-ingress
+spec:
+  rules:
+    - host: prism.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend: { service: { name: prism-dashboard-svc, port: { number: 80 } } }
+          - path: /api
+            pathType: Prefix
+            backend: { service: { name: prism-api-svc, port: { number: 8080 } } }

--- a/infra/k8s/services.yaml
+++ b/infra/k8s/services.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prism-api-svc
+spec:
+  selector: { app: prism-api }
+  ports: [{ port: 8080, targetPort: 8080 }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prism-dashboard-svc
+spec:
+  selector: { app: prism-dashboard }
+  ports: [{ port: 80, targetPort: 80 }]

--- a/infra/scripts/bootstrap.sh
+++ b/infra/scripts/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Idempotent bootstrap for Ubuntu server
+# - Installs Docker & compose plugin
+# - Creates stack directory with proper perms
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[BOOTSTRAP] Installing Docker..."
+  sudo apt-get update -y
+  sudo apt-get install -y ca-certificates curl gnupg
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+  sudo apt-get update -y
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  sudo usermod -aG docker $USER || true
+fi
+
+STACK_DIR=${STACK_DIR:-${HOME}/prism-stack}
+mkdir -p "$STACK_DIR"
+mkdir -p "$STACK_DIR/scripts"
+
+echo "[BOOTSTRAP] Docker version: $(docker --version)"
+echo "[BOOTSTRAP] Stack dir: $STACK_DIR"

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Expected env: STACK_NAME, TAG, GHCR_OWNER
+STACK_NAME=${STACK_NAME:-prism}
+TAG=${TAG:-latest}
+GHCR_OWNER=${GHCR_OWNER:-yourorg}
+STACK_DIR=${STACK_DIR:-$HOME/prism-stack}
+export TAG GHCR_OWNER
+
+cd "$STACK_DIR"
+
+# Ensure .env exists (operator should upload it once based on .env.prod.example)
+if [ ! -f ".env" ]; then
+  echo "[DEPLOY] ERROR: $STACK_DIR/.env not found. Upload your production env first."
+  exit 1
+fi
+
+echo "[DEPLOY] Pulling images ghcr.io/${GHCR_OWNER}/prism-apex-*: ${TAG}"
+docker compose -f docker-compose.prod.yml pull
+
+echo "[DEPLOY] Starting updated stack..."
+docker compose -f docker-compose.prod.yml up -d
+
+# Health gate: poll both services
+deadline=$((SECONDS + 120))
+ok_api=0
+ok_dash=0
+while [ $SECONDS -lt $deadline ]; do
+  if curl -fsS http://127.0.0.1:8080/health >/dev/null; then ok_api=1; fi
+  if curl -fsS http://127.0.0.1/ >/dev/null; then ok_dash=1; fi
+  if [ $ok_api -eq 1 ] && [ $ok_dash -eq 1 ]; then break; fi
+  sleep 3
+
+done
+
+if [ $ok_api -ne 1 ] || [ $ok_dash -ne 1 ]; then
+  echo "[DEPLOY] ERROR: health checks failed. See 'docker compose logs'."
+  exit 2
+fi
+
+echo "[DEPLOY] Success. Stack ${STACK_NAME} is healthy on tag ${TAG}."


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build, publish and deploy tagged releases
- add production docker-compose stack, scripts, env example, and docs
- add helper Makefile targets and optional Kubernetes manifests

## Testing
- `docker-compose -f infra/docker-compose.prod.yml config`
- `npm test --workspaces --if-present` *(fails: No test files found; vitest exit 1)*

------
https://chatgpt.com/codex/tasks/task_b_68a36becae5c832ca43ab87e2219296a