### PR TITLE
docs: add Apex Trader Funding skeleton docs

### DIFF
--- a/apex/README.md
+++ b/apex/README.md
@@ -1,0 +1,12 @@
+# Apex Trader Funding Integration
+
+**Purpose:** Centralized documentation for evaluation, funded accounts, payouts, and platforms.
+
+TODO: Add high-level intro.
+
+## Links
+
+- [Evaluation Rules](./evaluation-rules.md)
+- [Funded Rules](./funded-rules.md)
+- [Payout Process](./payouts.md)
+- [Platform Options](./platforms/README.md)

--- a/apex/evaluation-rules.md
+++ b/apex/evaluation-rules.md
@@ -1,0 +1,30 @@
+# Apex Evaluation Rules
+
+**Purpose:** Document rules for the challenge/evaluation accounts.
+
+## Profit Target & Trailing Drawdown
+- TODO: Insert detailed formula & examples.
+- Compliance Note: Trailing drawdown must be monitored at all times.
+
+## Minimum Trading Days
+- Requirement: 7 trading days minimum.
+- Compliance Note: Days without trades do not count.
+
+## End-of-Day Flat Rule
+- Must be flat by 4:59 ET daily.
+- Compliance Note: Violations may reset the account.
+
+## Allowed Trading Times & News Trading
+- TODO: Clarify news trading allowance and timing windows.
+- Compliance Note: Observe exchange halts and Apex notices.
+
+## No Scaling Limits
+- Full contract use allowed during evaluation.
+- Compliance Note: See [Funded Rules](./funded-rules.md#half-contract-rule) for funded scaling restrictions.
+
+## Resets & Account Failure Conditions
+- TODO: Detail reset fees and process.
+- Compliance Note: Account breaches result in failure and may require reset.
+
+## Cross-References
+- See [Funded Rules](./funded-rules.md) for post-evaluation policies.

--- a/apex/funded-rules.md
+++ b/apex/funded-rules.md
@@ -1,0 +1,42 @@
+# Apex Funded Rules (Performance Accounts)
+
+**Purpose:** Define rules for funded trading accounts.
+
+## Consistency Rule
+- Profit per day should not exceed 30% of total profits.
+- Compliance Note: Breaches may delay payouts.
+
+## Max Loss / Risk Policy
+- Risk per trade ≤30% of profits until threshold increases to 50%.
+- Compliance Note: Exceeding risk limits may forfeit account.
+
+## Mandatory Stop-Loss (Risk/Reward ≤5:1)
+- TODO: Document enforcement examples.
+- Compliance Note: Orders must include protective stops.
+
+## Half-Contract Rule
+- Scaling limited to half of evaluation max until drawdown cleared.
+- Compliance Note: See [Evaluation Rules](./evaluation-rules.md#no-scaling-limits) for contrast.
+
+## Drawdown Behavior
+- Trailing until locked at initial balance + $100.
+- Compliance Note: Monitor balance to avoid trailing breach.
+
+## No All-In / Windfall Strategies
+- TODO: Define windfall and all-in criteria.
+- Compliance Note: Excessive leverage triggers review.
+
+## Multi-Account Rules
+- Max 20 accounts; no hedging or gaming across accounts.
+- Compliance Note: Linked accounts must trade independently.
+
+## Allowed Strategies
+- Scaling, DCA, and news trading permitted within risk limits.
+- Compliance Note: Maintain audit trails for all automated systems.
+
+## TODO
+- Add probation & compliance violation examples.
+
+## Cross-References
+- See [Evaluation Rules](./evaluation-rules.md) for challenge phase.
+- See [Payout Process](./payouts.md) for withdrawal policies.

--- a/apex/payouts.md
+++ b/apex/payouts.md
@@ -1,0 +1,27 @@
+# Apex Payout Process
+
+**Purpose:** Describe payout rules and cadence.
+
+## First 3 Payouts
+- Safety net in place; capped withdrawal amounts.
+- Compliance Note: Funds beyond cap remain in account.
+
+## Standard Payout Frequency
+- Payout requests follow an 8-day cycle.
+- Compliance Note: Submitting early restarts the cycle.
+
+## Profit Split
+- 100% of first $25k; then 90/10 split until 5th payout.
+- After 5th payout, trader retains 100% of profits.
+- Compliance Note: Verify payout counts before changing split.
+
+## Withdrawal Methods
+- ACH for domestic; alternative methods for international (e.g., Plaid).
+- Compliance Note: Ensure tax forms are on file.
+
+## Transition to Live Accounts
+- TODO: Outline process for moving to live brokerage accounts.
+- Compliance Note: Additional KYC may be required.
+
+## Cross-References
+- See [Funded Rules](./funded-rules.md#consistency-rule) for consistency requirements affecting payouts.

--- a/apex/platforms/README.md
+++ b/apex/platforms/README.md
@@ -1,0 +1,10 @@
+# Apex Platform Options
+
+Overview of supported platforms: Rithmic/NinjaTrader, Tradovate/TradingView, WealthCharts.
+
+TODO: Add operator guidance chart.
+
+## Links
+- [Rithmic + NinjaTrader](./rithmic.md)
+- [Tradovate + TradingView](./tradovate.md)
+- [WealthCharts](./wealthcharts.md)

--- a/apex/platforms/rithmic.md
+++ b/apex/platforms/rithmic.md
@@ -1,0 +1,31 @@
+# Rithmic + NinjaTrader
+
+**Purpose:** Document setup and caveats for Rithmic accounts.
+
+## Setup Steps
+- TODO: Provide step-by-step account linking and platform install instructions.
+
+## Windows Requirement
+- Platform requires Windows environment.
+- Compliance Note: Unsupported OS use may breach terms.
+
+## Technical Difficulty
+- Rated 7/10.
+- Compliance Note: Operators should verify user competency before recommendation.
+
+## Pros
+- Low latency execution.
+- Flexible automation support.
+- Compliance Note: Automation must log orders for audit.
+
+## Cons
+- Windows-only; complex initial configuration; no mobile support.
+- Compliance Note: Document exceptions for Mac users.
+
+## Watchouts
+- Server selection impacts latency.
+- Concurrent logins restricted.
+- Data status must be real-time.
+- Compliance Note: Monitor for unauthorized API connections.
+
+TODO: Add screenshots of NinjaTrader config.

--- a/apex/platforms/tradovate.md
+++ b/apex/platforms/tradovate.md
@@ -1,0 +1,27 @@
+# Tradovate + TradingView
+
+**Purpose:** Document setup and caveats for Tradovate accounts.
+
+## Setup Steps
+- TODO: Outline account activation and TradingView integration.
+
+## Technical Difficulty
+- Rated 3/10.
+- Compliance Note: Suitable for beginners but still requires supervision.
+
+## Pros
+- Web, Mac, and mobile access.
+- Native TradingView integration.
+- Compliance Note: Cloud-based trading must ensure secure credentials.
+
+## Cons
+- Fewer advanced tools.
+- Reliance on cloud connectivity.
+- Compliance Note: Verify stability before high-frequency use.
+
+## Watchouts
+- Symbol codes differ from other platforms.
+- Payout day counts may vary.
+- Compliance Note: Confirm platform timezones for EOD rules.
+
+TODO: Add TradingView broker panel screenshot.

--- a/apex/platforms/wealthcharts.md
+++ b/apex/platforms/wealthcharts.md
@@ -1,0 +1,27 @@
+# WealthCharts
+
+**Purpose:** Document setup and caveats for WealthCharts accounts.
+
+## Setup Steps
+- TODO: Provide account linking and layout selection steps.
+
+## Technical Difficulty
+- Rated 4/10.
+- Compliance Note: Provide training on platform-specific quirks.
+
+## Pros
+- Pre-made layouts and guided workflows.
+- Built-in liquidation indicator.
+- Compliance Note: Ensure indicator visibility for all traders.
+
+## Cons
+- Closed ecosystem with limited integrations.
+- Potential Windows-only risk depending on components.
+- Compliance Note: Review update policies for security.
+
+## Watchouts
+- Platform updates may be mandatory.
+- Automation support is limited.
+- Compliance Note: Document any external tool connections.
+
+TODO: Add Apex-prebuilt layout diagram.


### PR DESCRIPTION
## Summary
- add Apex Trader Funding documentation skeleton for evaluation, funded, payouts, and platforms

## Testing
- `npm test` *(fails: No test files found, exits 1)*
- `npm run lint` *(fails: lint script error)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a43e46d314832cbcd5a24709001c23