### PR TITLE
feat: publish openapi spec with typed js sdk

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,0 +1,325 @@
+openapi: 3.1.0
+info:
+  title: Prism Apex Tool API
+  version: v0
+  description: >
+    Public API for Prism Apex Tool (MVP).
+    Operators manually execute tickets in Tradovate; this API provides signals, account status, rules, alerts, reports, notifications, and health/jobs status.
+servers:
+  - url: http://localhost:8080
+paths:
+  /health:
+    get:
+      summary: Health check
+      operationId: getHealth
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema: { type: object, properties: { ok: { type: boolean } }, required: [ok] }
+
+  /tickets:
+    get:
+      summary: List current trade tickets
+      operationId: listTickets
+      responses:
+        '200':
+          description: Tickets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Ticket'
+
+  /signals/preview:
+    post:
+      summary: Preview a candidate signal under Apex rules
+      operationId: previewSignal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SignalPreviewRequest' }
+      responses:
+        '200':
+          description: Preview result
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SignalPreviewResponse' }
+
+  /tickets/commit:
+    post:
+      summary: Commit a validated ticket for operator execution
+      operationId: commitTicket
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/TicketCommitRequest' }
+      responses:
+        '200':
+          description: Committed ticket
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Ticket' }
+
+  /account:
+    get:
+      summary: Read-only account overview (balances, drawdown headroom, open positions count)
+      operationId: getAccount
+      responses:
+        '200':
+          description: Account status
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AccountStatus' }
+
+  /rules/status:
+    get:
+      summary: Current rules/guardrails state (EOD window, daily loss proximity, scaling)
+      operationId: getRulesStatus
+      responses:
+        '200':
+          description: Rules status
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/RulesStatus' }
+
+  /alerts:
+    get:
+      summary: Current alerts (WARN/CRITICAL)
+      operationId: listAlerts
+      responses:
+        '200':
+          description: Alerts
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Alert' }
+
+  /reports:
+    get:
+      summary: Summary metrics (from simulator/backtests or runtime)
+      operationId: getReports
+      responses:
+        '200':
+          description: Report metrics
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ReportSummary' }
+
+  /notify/register:
+    post:
+      summary: Register/update recipients for notifications
+      operationId: registerRecipients
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/NotifyRegisterRequest' }
+      responses:
+        '200':
+          description: Recipients updated
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/NotifyRegisterResponse' }
+
+  /notify/test:
+    post:
+      summary: Send a test notification message
+      operationId: sendTestNotification
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/NotifyTestRequest' }
+      responses:
+        '200':
+          description: Dispatch results
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/NotifyTestResponse' }
+
+  /jobs/status:
+    get:
+      summary: Background jobs & flags status
+      operationId: getJobsStatus
+      responses:
+        '200':
+          description: Jobs status
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/JobsStatus' }
+
+  /openapi.json:
+    get:
+      summary: Serve this OpenAPI document (JSON)
+      operationId: getOpenApiJson
+      responses:
+        '200':
+          description: OpenAPI JSON
+          content:
+            application/json: {}
+
+components:
+  schemas:
+    Ticket:
+      type: object
+      required: [id, symbol, side, entry, stop, target, time]
+      properties:
+        id: { type: string }
+        symbol: { type: string }
+        side: { type: string, enum: [BUY, SELL] }
+        entry: { type: number }
+        stop: { type: number }
+        target: { type: number }
+        size: { type: integer, minimum: 1, default: 1 }
+        time: { type: string, format: date-time }
+
+    SignalPreviewRequest:
+      type: object
+      required: [symbol, side, entry, stop, target, size, mode]
+      properties:
+        symbol: { type: string }
+        side: { type: string, enum: [BUY, SELL] }
+        entry: { type: number }
+        stop: { type: number }
+        target: { type: number }
+        size: { type: integer, minimum: 1 }
+        mode: { type: string, enum: [evaluation, funded] }
+
+    SignalPreviewResponse:
+      type: object
+      required: [block, reasons, normalized]
+      properties:
+        block: { type: boolean, description: "If true, operator must NOT place this trade" }
+        reasons:
+          type: array
+          items: { type: string }
+        normalized:
+          type: object
+          description: "Normalized/capped values (e.g., ≤5R target)"
+          properties:
+            entry: { type: number }
+            stop: { type: number }
+            target: { type: number }
+            size: { type: integer, minimum: 1 }
+
+    TicketCommitRequest:
+      allOf:
+        - $ref: '#/components/schemas/SignalPreviewRequest'
+      description: "Commit after human review; duplicates rejected idempotently."
+
+    AccountStatus:
+      type: object
+      required: [balance, drawdown, openPositions]
+      properties:
+        balance: { type: number }
+        drawdown: { type: number }
+        openPositions: { type: integer }
+        netLiqHigh: { type: number, nullable: true }
+
+    RulesStatus:
+      type: object
+      required: [stopRequired, rrLeq5, ddHeadroom, halfSize, consistencyPolicy, eodState]
+      properties:
+        stopRequired: { type: boolean }
+        rrLeq5: { type: boolean }
+        ddHeadroom: { type: boolean }
+        halfSize: { type: string }
+        consistencyPolicy:
+          type: object
+          properties:
+            warnAt: { type: number }
+            failAt: { type: number }
+        eodState:
+          type: string
+          enum: [OK, BLOCK_NEW, EOD]
+
+    Alert:
+      type: object
+      required: [level, message, ts]
+      properties:
+        level: { type: string, enum: [INFO, WARN, CRITICAL] }
+        message: { type: string }
+        ts: { type: string, format: date-time }
+        tags:
+          type: array
+          items: { type: string }
+
+    ReportSummary:
+      type: object
+      required: [win_rate, avg_r, max_dd, rule_breaches]
+      properties:
+        win_rate: { type: number }
+        avg_r: { type: number }
+        max_dd: { type: number }
+        rule_breaches: { type: integer }
+
+    NotifyRegisterRequest:
+      type: object
+      properties:
+        email:
+          type: array
+          items: { type: string, format: email }
+        telegramChatId: { type: string }
+        slackChannelId: { type: string }
+        smsNumber: { type: string }
+
+    NotifyRegisterResponse:
+      type: object
+      required: [ok, recipients]
+      properties:
+        ok: { type: boolean }
+        recipients:
+          type: object
+          properties:
+            email: { type: array, items: { type: string, format: email } }
+            telegram: { type: array, items: { type: string } }
+            slack: { type: array, items: { type: string } }
+            sms: { type: array, items: { type: string } }
+
+    NotifyTestRequest:
+      type: object
+      required: [message]
+      properties:
+        message: { type: string }
+        level: { type: string, enum: [INFO, WARN, CRITICAL], default: INFO }
+        tags:
+          type: array
+          items: { type: string }
+          default: []
+
+    NotifyTestResponse:
+      type: object
+      required: [ok, results]
+      properties:
+        ok: { type: boolean }
+        results:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+
+    JobsStatus:
+      type: object
+      required: [jobs, flags]
+      properties:
+        jobs:
+          type: array
+          items:
+            type: object
+            properties:
+              name: { type: string }
+              everyMs: { type: integer }
+              lastRun: { type: string, nullable: true }
+              lastOk: { type: string, nullable: true }
+              lastError: { type: string, nullable: true }
+              running: { type: boolean }
+        flags:
+          type: object
+          properties:
+            ocoMissing: { type: boolean }

--- a/apps/api/src/__tests__/openapi.spec.ts
+++ b/apps/api/src/__tests__/openapi.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: any;
+
+beforeEach(async () => {
+  vi.resetModules();
+  Object.assign(process.env, {
+    TRADOVATE_BASE_URL: 'http://localhost',
+    TRADOVATE_USERNAME: 'user',
+    TRADOVATE_PASSWORD: 'pass',
+    TRADOVATE_CLIENT_ID: 'id',
+    TRADOVATE_CLIENT_SECRET: 'secret',
+    DATA_DIR: fs.mkdtempSync(path.join(os.tmpdir(), 'openapi-')),
+  });
+  const mod = await import('../server');
+  buildServer = mod.buildServer;
+});
+
+describe('OpenAPI conformance (MVP smoke)', () => {
+  it('GET /health matches spec shape', async () => {
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/health' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(typeof body.ok).toBe('boolean');
+  });
+
+  it('Tickets list is an array of Ticket shape (subset)', async () => {
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/tickets' });
+    expect(res.statusCode).toBe(200);
+    const arr = res.json();
+    expect(Array.isArray(arr)).toBe(true);
+    if (arr.length) {
+      const t = arr[0];
+      expect(typeof t.symbol).toBe('string');
+      expect(['BUY', 'SELL']).toContain(t.side);
+      expect(typeof t.entry).toBe('number');
+    }
+  });
+
+  it('Preview accepts body and returns block/reasons per spec', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/signals/preview',
+      payload: { symbol: 'ES', side: 'BUY', entry: 5000, stop: 4990, target: 5010, size: 1, mode: 'evaluation' }
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(typeof body.block).toBe('boolean');
+    expect(Array.isArray(body.reasons)).toBe(true);
+  });
+
+  it('OpenAPI endpoint returns a YAML container', async () => {
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/openapi.json' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.openapi).toBe('3.1.0');
+    expect(typeof body.yaml).toBe('string');
+    expect(body.yaml).toMatch(/openapi:\s+3\.1\.0/);
+  });
+});

--- a/apps/api/src/__tests__/reporting.spec.ts
+++ b/apps/api/src/__tests__/reporting.spec.ts
@@ -1,23 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildServer } from '../server';
-import { store } from '../store';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+let buildServer: any;
+let store: typeof import('../store').store;
 
 // Mock env for Tradovate client
-beforeEach(() => {
+beforeEach(async () => {
+  vi.resetModules();
   process.env.TRADOVATE_BASE_URL = 'https://example.test/v1';
   process.env.TRADOVATE_USERNAME = 'u';
   process.env.TRADOVATE_PASSWORD = 'p';
   process.env.TRADOVATE_CLIENT_ID = 'cid';
   process.env.TRADOVATE_CLIENT_SECRET = 'sec';
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'report-'));
+  const mod = await import('../server');
+  buildServer = mod.buildServer;
+  store = (await import('../store')).store;
   vi.useRealTimers();
-
-  // Seed store with synthetic data for 2025-08-17
-  const date = '2030-01-01';
-  // @ts-ignore internal access to mutate for tests
-  const d = (store as any);
-  // Reset state by reloading file? Instead patch via public API:
-  // We'll append ticket entries with specific date stamps
-  // (In a real test, we might isolate store; keeping MVP-simple here)
 });
 
 function mockFetchSequence(responses: { status: number; json: any }[]) {

--- a/apps/api/src/routes/openapi.ts
+++ b/apps/api/src/routes/openapi.ts
@@ -1,0 +1,15 @@
+import type { FastifyInstance } from 'fastify';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export async function openapiRoute(app: FastifyInstance) {
+  app.get('/openapi.json', async (_req, reply) => {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const root = path.resolve(__dirname, '../../../../');
+    const yaml = fs.readFileSync(path.join(root, 'api/openapi.yaml'), 'utf8');
+    // Lazy convert: for tooling we can serve YAML as text; many tools accept YAML directly.
+    // For stricter JSON serving, bring in 'yaml' lib later. MVP: serve YAML string in JSON field.
+    return reply.send({ openapi: '3.1.0', yaml });
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -9,6 +9,7 @@ import { alertsRoutes } from './routes/alerts';
 import { exportRoutes } from './routes/export';
 import { notifyRoutes } from './routes/notify';
 import { jobsRoutes } from './routes/jobs';
+import { openapiRoute } from './routes/openapi';
 
 import { registerJob, startJobs } from './jobs/scheduler';
 import { jobEodFlat } from './jobs/eodFlat';
@@ -32,6 +33,7 @@ export function buildServer() {
   app.register(exportRoutes);
   app.register(notifyRoutes);
   app.register(jobsRoutes);
+  app.register(openapiRoute);
 
   // ---- Jobs ----
   registerJob('EOD_FLAT', 60_000, jobEodFlat);          // check every 60s (phased logic within)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "apps/*",
     "packages/*",
     "infra/*",
-    "tests/*"
+    "tests/*",
+    "sdks/*"
   ],
   "scripts": {
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0 --no-error-on-unmatched-pattern",

--- a/sdks/js/README.md
+++ b/sdks/js/README.md
@@ -1,0 +1,27 @@
+# @prism-apex/sdk
+
+Minimal, typed JS/TS SDK for Prism Apex Tool.
+
+## Install
+```bash
+npm i @prism-apex/sdk
+```
+
+## Usage
+```ts
+import { PrismClient } from '@prism-apex/sdk';
+
+const api = new PrismClient({ baseUrl: 'http://your-server:8080' });
+
+const health = await api.getHealth();
+const tickets = await api.listTickets();
+
+const preview = await api.previewSignal({
+  symbol: 'ES', side: 'BUY', entry: 5000, stop: 4990, target: 5010, size: 1, mode: 'evaluation'
+});
+if (!preview.block) {
+  await api.commitTicket({ symbol: 'ES', side: 'BUY', entry: 5000, stop: 4990, target: 5010, size: 1, mode: 'evaluation' });
+}
+```
+
+This SDK is fetch-based and has no runtime deps. All types mirror the OpenAPI spec (MVP subset).

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@prism-apex/sdk",
+  "version": "0.1.0",
+  "description": "Typed JS SDK for Prism Apex Tool API",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist"
+  },
+  "license": "MIT"
+}

--- a/sdks/js/src/client.ts
+++ b/sdks/js/src/client.ts
@@ -1,0 +1,132 @@
+export type SDKOptions = {
+  baseUrl?: string;         // default http://localhost:8080
+  fetchImpl?: typeof fetch; // override for tests
+  apiKey?: string;          // reserved, not used in MVP
+};
+
+export class PrismClient {
+  private baseUrl: string;
+  private f: typeof fetch;
+
+  constructor(opts: SDKOptions = {}) {
+    this.baseUrl = (opts.baseUrl || 'http://localhost:8080').replace(new RegExp('/+$'), '');
+    this.f = opts.fetchImpl || fetch;
+  }
+
+  private async req<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await this.f(`${this.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        'content-type': 'application/json',
+        ...(init?.headers || {}),
+      }
+    });
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      throw new Error(`HTTP ${res.status} ${res.statusText}: ${txt}`);
+    }
+    if (res.headers.get('content-type')?.includes('application/json')) {
+      return res.json() as Promise<T>;
+    }
+    // @ts-expect-error allow non-json (openapi route MVP returns yaml container)
+    return res.text();
+  }
+
+  getHealth() { return this.req<{ ok: boolean }>('/health'); }
+
+  listTickets() { return this.req<Ticket[]>('/tickets'); }
+
+  previewSignal(body: SignalPreviewRequest) {
+    return this.req<SignalPreviewResponse>('/signals/preview', { method: 'POST', body: JSON.stringify(body) });
+  }
+
+  commitTicket(body: TicketCommitRequest) {
+    return this.req<Ticket>('/tickets/commit', { method: 'POST', body: JSON.stringify(body) });
+  }
+
+  getAccount() { return this.req<AccountStatus>('/account'); }
+
+  getRulesStatus() { return this.req<RulesStatus>('/rules/status'); }
+
+  listAlerts() { return this.req<Alert[]>('/alerts'); }
+
+  getReports() { return this.req<ReportSummary>('/reports'); }
+
+  registerRecipients(body: NotifyRegisterRequest) {
+    return this.req<NotifyRegisterResponse>('/notify/register', { method: 'POST', body: JSON.stringify(body) });
+  }
+
+  sendTestNotification(body: NotifyTestRequest) {
+    return this.req<NotifyTestResponse>('/notify/test', { method: 'POST', body: JSON.stringify(body) });
+  }
+
+  getJobsStatus() { return this.req<JobsStatus>('/jobs/status'); }
+
+  getOpenApi() { return this.req<any>('/openapi.json'); }
+}
+
+/** ---- Types (mirrored from OpenAPI; keep minimal & readable) ---- */
+export type Ticket = {
+  id: string;
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  entry: number;
+  stop: number;
+  target: number;
+  size: number;
+  time: string;
+};
+
+export type SignalPreviewRequest = {
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  entry: number;
+  stop: number;
+  target: number;
+  size: number;
+  mode: 'evaluation' | 'funded';
+};
+
+export type SignalPreviewResponse = {
+  block: boolean;
+  reasons: string[];
+  normalized?: { entry?: number; stop?: number; target?: number; size?: number };
+};
+
+export type TicketCommitRequest = SignalPreviewRequest;
+
+export type AccountStatus = { balance: number; drawdown: number; openPositions: number; netLiqHigh?: number | null };
+
+export type RulesStatus = {
+  stopRequired: boolean;
+  rrLeq5: boolean;
+  ddHeadroom: boolean;
+  halfSize: string;
+  consistencyPolicy: { warnAt: number; failAt: number };
+  eodState: 'OK' | 'BLOCK_NEW' | 'EOD';
+};
+
+export type Alert = { level: 'INFO' | 'WARN' | 'CRITICAL'; message: string; ts: string; tags?: string[] };
+
+export type ReportSummary = { win_rate: number; avg_r: number; max_dd: number; rule_breaches: number };
+
+export type NotifyRegisterRequest = {
+  email?: string[];
+  telegramChatId?: string;
+  slackChannelId?: string;
+  smsNumber?: string;
+};
+
+export type NotifyRegisterResponse = {
+  ok: boolean;
+  recipients: { email?: string[]; telegram?: string[]; slack?: string[]; sms?: string[] };
+};
+
+export type NotifyTestRequest = { message: string; level?: 'INFO' | 'WARN' | 'CRITICAL'; tags?: string[] };
+
+export type NotifyTestResponse = { ok: boolean; results: Array<Record<string, unknown>> };
+
+export type JobsStatus = {
+  jobs: Array<{ name: string; everyMs: number; lastRun?: string; lastOk?: string; lastError?: string; running: boolean }>;
+  flags: { ocoMissing?: boolean };
+};

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1,0 +1,1 @@
+export * from './client.js';

--- a/sdks/js/tsconfig.json
+++ b/sdks/js/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- document Prism Apex API v0 in OpenAPI 3.1 and expose `/openapi.json`
- add minimal fetch-based JS SDK with typed endpoints
- smoke-test key routes against spec using Fastify inject

## Testing
- `npm test -w apps/api`
- `npm run build -w sdks/js`


------
https://chatgpt.com/codex/tasks/task_b_68a44dc37854832c8e09b805464107a3