### PR TITLE
Add go-live readiness package and helper make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,13 @@ release:
 deploy:
 	@if [ -z "$$PROD_SSH_HOST" ] || [ -z "$$PROD_SSH_USER" ] || [ -z "$$PROD_STACK_DIR" ] || [ -z "$$STACK_NAME" ]; then echo "Set PROD_SSH_HOST, PROD_SSH_USER, PROD_STACK_DIR, STACK_NAME, TAG, GHCR_OWNER"; exit 2; fi
 	ssh $$PROD_SSH_USER@$$PROD_SSH_HOST "STACK_NAME=$$STACK_NAME TAG=$$TAG GHCR_OWNER=$$GHCR_OWNER STACK_DIR=$$PROD_STACK_DIR bash $$PROD_STACK_DIR/scripts/deploy.sh"
+
+.PHONY: readiness uat
+
+# Print path to go-live checklist (for convenience)
+readiness:
+	@echo "Open docs/release/go-live-checklist.md"
+
+# Print path to UAT scripts
+uat:
+	@echo "Open docs/release/uat-scenarios.md"

--- a/docs/release/go-live-checklist.md
+++ b/docs/release/go-live-checklist.md
@@ -1,0 +1,69 @@
+# Prism Apex Tool — Go-Live Master Checklist (Oct 1)
+
+**Owners:** Sean (CTO), Craig (CEO), Solutions Architect, IT PM, Lead Operator  
+**Environment:** Production (single Ubuntu host, Docker)  
+**Decision Gate:** All boxes ✅ before enabling live operations on Oct 1.
+
+---
+
+## 1) Infrastructure & Deploy
+- [ ] Server specs validated against plan (CPU/RAM/disk/network).
+- [ ] OS updated and rebooted within last 7 days.
+- [ ] Docker + compose plugin installed (see `infra/scripts/bootstrap.sh`).
+- [ ] `infra/docker-compose.prod.yml` present on server.
+- [ ] `infra/.env.prod.example` copied to `${PROD_STACK_DIR}/.env` with real values.
+- [ ] GitHub Actions `deploy` workflow green on the latest tagged release.
+- [ ] `http://<server>:8080/health` returns `{ ok: true }`.
+- [ ] `http://<server>/` dashboard loads.
+
+## 2) Configuration & Secrets
+- [ ] TRADOVATE read-only credentials stored in `.env` (no write permissions).
+- [ ] TradingView `TRADINGVIEW_WEBHOOK_SECRET` set (if alerts used).
+- [ ] SMTP/Telegram/Slack/Twilio tokens loaded (optional; at least one required).
+- [ ] `DAILY_LOSS_CAP_USD` configured to Apex account level.
+- [ ] Timezone assumptions documented as GMT/UTC in Operator Handbook.
+
+## 3) Notifications (at least one must work)
+- [ ] `/notify/register` called with recipients (Slack channel ID or email).
+- [ ] `/notify/test` returns transports OK (non-200 is a blocker).
+- [ ] Operator sees test alert in chosen channel (screenshot captured).
+
+## 4) Signals & Tickets (MVP manual flow)
+- [ ] TradingView → Webhook → `/ingest` (or equivalent) verified with HMAC.
+- [ ] `/signals/preview` normalizes to ≤5R target and blocks invalid tickets.
+- [ ] `/tickets/commit` creates ticket visible on dashboard.
+- [ ] Operator can manually key ticket into **Tradovate** with matching Stop + Target.
+- [ ] Missing OCO triggers **CRITICAL** alert and dashboard **Pause** flag.
+
+## 5) Guardrails & Rules (Apex)
+- [ ] EOD window alerts fire at **20:49–20:54 (WARN)** and **20:55–20:59 (CRITICAL)** GMT.
+- [ ] Daily loss proximity alerts at **≥70%** (WARN) and **≥85%** (CRITICAL).
+- [ ] Consistency proximity alerts in funded mode at **≥25%/≥30%**.
+- [ ] Stop-loss required — tickets without stops are **blocked** in preview.
+- [ ] Dashboard shows **flat** state at EOD (no open positions).
+
+## 6) Observability & Logs
+- [ ] API logs include request IDs and warning/error lines are visible with `docker compose logs`.
+- [ ] `/jobs/status` shows recent run times and `flags.ocoMissing` = false in steady state.
+- [ ] Disk space > 20% free; log rotation plan in place.
+
+## 7) Security & Access
+- [ ] SSH keys restricted to deployment user.
+- [ ] No secrets committed to repo; all via GitHub Secrets or server `.env`.
+- [ ] Dashboard behind allowed IPs or temporary auth (MVP), documented.
+
+## 8) Operator Handbook & Training
+- [ ] Operators trained on **handbook** (SOD, During Session, EOD, Incidents).
+- [ ] Dry-run session completed with sample tickets and screenshots.
+- [ ] Escalation tree clear (names, Slack handles, phone on file).
+
+## 9) UAT Completion
+- [ ] All **UAT scenarios** in `docs/release/uat-scenarios.md` show **PASS**.
+- [ ] Evidence (screens, JSON exports) archived in `/evidence/YYYY-MM-DD`.
+
+## 10) Executive Sign-Off
+- [ ] `docs/release/sign-off-template.md` completed with signatures/dates.
+
+**Final Decision:**  
+- [ ] ✅ GO LIVE on Oct 1  
+- [ ] ❌ BLOCKED (attach reason)

--- a/docs/release/runbook-rollback.md
+++ b/docs/release/runbook-rollback.md
@@ -1,0 +1,45 @@
+# Prism Apex Tool — Rollback & Incident Runbook
+
+**Priority:** Restore safe operations quickly, protect Apex compliance, prevent irreversible loss.
+
+---
+
+## 1) Immediate Actions
+- [ ] Announce incident in Slack `#ops-incidents` (include time, symptoms).
+- [ ] **Pause** new tickets (dashboard Pause or temporary block in API).
+- [ ] Verify positions in Tradovate — **flatten** if risk is elevated.
+
+## 2) Quick Diagnostics (5–10 min)
+- [ ] `GET /health` — should be OK.
+- [ ] `docker compose ps` — containers running.
+- [ ] `docker compose logs --since=10m` — check errors.
+- [ ] `/jobs/status` — lastOk timestamps present.
+
+## 3) Rollback (Tag N → N-1)
+- [ ] Select previous tag (e.g., `v0.1.2` → `v0.1.1`).
+- [ ] Run:
+```bash
+TAG=v0.1.1 make deploy
+```
+- [ ] Confirm health:
+```bash
+curl -fsS http://<server>:8080/health
+```
+- [ ] Open dashboard `/`
+
+## 4) Data Safety
+- Volumes preserved; no destructive migrations in MVP.
+- Backup `.env` and `.data/state.json` before manual edits.
+
+## 5) Recovery & Resume
+- Clear dashboard **Pause** flag when safe.
+- Announce resolution in Slack with incident summary.
+- Create follow-up ticket for root cause & action items.
+
+## 6) Post-Mortem Template
+- What happened:
+- Impact window:
+- Root cause:
+- Actions taken:
+- Preventative measures:
+- Owners & due dates:

--- a/docs/release/sign-off-template.md
+++ b/docs/release/sign-off-template.md
@@ -1,0 +1,40 @@
+# Prism Apex Tool — Executive Go-Live Sign-Off
+
+**Project:** Prism Apex Tool (Path 1b — Prop-Firm Equities/Futures Trading)  
+**Go-Live Date:** Oct 1 (GMT)
+
+---
+
+## Summary
+- MVP Scope: Manual execution via Tradovate; strategies ORB + VWAP.
+- Risk Controls: Apex guardrails enforced (EOD flat, daily loss proximity, consistency, stop-loss, ≤5R).
+- Monitoring: Email/Telegram/Slack alerts + background jobs.
+- Deployment: Docker on single Ubuntu host; health-gated.
+
+---
+
+## Readiness Checklist Status
+- Go-Live Master Checklist: **All items ✅**  
+- UAT Scenarios: **All PASS** (see `docs/release/uat-scenarios.md`)
+
+---
+
+## Residual Risks (Known & Accepted)
+- Manual order entry risk (operator error) — mitigated by ticket UI + OCO + alerts.
+- Bar-level backtest approximation — conservative execution assumptions.
+- Single-host deployment — acceptable for MVP; DR plan documented.
+
+---
+
+## Approval
+**CTO (Sean):**  
+Name: _______________________  Signature: _______________________  Date: __________
+
+**CEO (Craig):**  
+Name: _______________________  Signature: _______________________  Date: __________
+
+**Solutions Architect:**  
+Name: _______________________  Signature: _______________________  Date: __________
+
+**IT PM:**  
+Name: _______________________  Signature: _______________________  Date: __________

--- a/docs/release/uat-scenarios.md
+++ b/docs/release/uat-scenarios.md
@@ -1,0 +1,126 @@
+# Prism Apex Tool — UAT Scenarios & Scripts
+
+**Goal:** Prove MVP works end-to-end with manual execution and Apex guardrails before Oct 1.  
+**Test Window:** Preferably same time window as live operations. All times GMT.
+
+---
+
+## Legend
+- **Actor:** System / Operator
+- **Input:** What to do
+- **Expected:** Pass criteria
+- **Evidence:** What to capture (screenshot/json)
+
+---
+
+## UAT-01 Health & Deploy
+- **Actor:** System
+- **Input:** `GET /health`
+- **Expected:** `{ ok: true }`
+- **Evidence:** cURL output saved
+
+---
+
+## UAT-02 Notifications (Slack or Email)
+- **Actor:** System
+- **Input:** `POST /notify/test { "message": "UAT-02", "level": "INFO", "tags": ["UAT"] }`
+- **Expected:** At least one transport returns OK; operator sees message
+- **Evidence:** Slack/email screenshot
+
+---
+
+## UAT-03 Signal Preview — ORB
+- **Actor:** System
+- **Input:** `POST /signals/preview` with an ORB long (entry=5000, stop=4990, target=5025, size=1, mode="evaluation")  
+- **Expected:** `normalized.target` ≤ 5R; `block=false`; reasons empty or informational
+- **Evidence:** JSON response saved
+
+---
+
+## UAT-04 Ticket Commit — ORB
+- **Actor:** System → Operator
+- **Input:** `POST /tickets/commit` using normalized values from UAT-03; Operator keys order in **Tradovate** with Stop+Target OCO
+- **Expected:** Ticket appears on dashboard; Tradovate shows working order with linked OCO
+- **Evidence:** Dashboard + Tradovate screenshots
+
+---
+
+## UAT-05 Missing OCO Detected
+- **Actor:** Operator (negative test)
+- **Input:** Enter a dummy order **without** OCO on Tradovate (test/sim)
+- **Expected:** Within 15s, **CRITICAL** alert + dashboard **Pause** flag
+- **Evidence:** Alert screenshot + `/jobs/status` showing `flags.ocoMissing=true`
+
+---
+
+## UAT-06 Daily Loss Proximity (Simulated)
+- **Actor:** System
+- **Input:** Set `DAILY_LOSS_CAP_USD=100` (temp) and seed negative PnL via backtest hook or mock  
+- **Expected:** WARN at ≥70%, CRITICAL at ≥85%
+- **Evidence:** Alert screenshots; `/rules/status` JSON
+
+---
+
+## UAT-07 EOD Alerts
+- **Actor:** System
+- **Input:** Temporarily stub time to fall inside **20:49–20:54** and **20:55–20:59** GMT windows  
+- **Expected:** WARN then CRITICAL emitted once per day
+- **Evidence:** Alert transcripts or logs; `/jobs/status` timestamps
+
+---
+
+## UAT-08 Consistency Proximity (Funded Mode)
+- **Actor:** System
+- **Input:** Set `store.setPeriodProfit(1000)` and `store.setTodayProfit(310)` (test route or script)
+- **Expected:** CRITICAL alert (≥30%)
+- **Evidence:** Alert screenshot; `/rules/status` JSON
+
+---
+
+## UAT-09 VWAP Ticket Lifecycle
+- **Actor:** System → Operator
+- **Input:** `POST /signals/preview` for VWAP; then `POST /tickets/commit`; operator keys into Tradovate with OCO
+- **Expected:** Same as ORB flow; block if missing stop/invalid R
+- **Evidence:** JSON + screenshots
+
+---
+
+## UAT-10 End-of-Day Flat
+- **Actor:** Operator
+- **Input:** Before **21:59 GMT**, close any open trades; verify no positions remaining
+- **Expected:** Dashboard shows **flat**; system sends EOD confirmation alert
+- **Evidence:** Dashboard flat screen + alert screenshot
+
+---
+
+## UAT-11 Readiness Reports
+- **Actor:** System
+- **Input:** `GET /reports`
+- **Expected:** JSON shows realistic metrics (win_rate, avg_r, max_dd, rule_breaches)
+- **Evidence:** JSON saved
+
+---
+
+## UAT-12 OpenAPI & SDK Smoke
+- **Actor:** System
+- **Input:** `GET /openapi.json` then call a couple of SDK methods (`getHealth`, `listTickets`)
+- **Expected:** SDK returns valid objects without runtime errors
+- **Evidence:** Console output + snippet
+
+---
+
+## UAT Summary Table (to be completed)
+| ID     | Result (PASS/FAIL) | Owner  | Evidence Link | Notes |
+|--------|---------------------|--------|---------------|-------|
+| UAT-01 |                     |        |               |       |
+| UAT-02 |                     |        |               |       |
+| UAT-03 |                     |        |               |       |
+| UAT-04 |                     |        |               |       |
+| UAT-05 |                     |        |               |       |
+| UAT-06 |                     |        |               |       |
+| UAT-07 |                     |        |               |       |
+| UAT-08 |                     |        |               |       |
+| UAT-09 |                     |        |               |       |
+| UAT-10 |                     |        |               |       |
+| UAT-11 |                     |        |               |       |
+| UAT-12 |                     |        |               |       |


### PR DESCRIPTION
## Summary
- add go-live master checklist, UAT scripts, exec sign-off template, and rollback runbook
- append `readiness` and `uat` convenience targets to Makefile

## Testing
- `npm test -w packages/shared -- --run`
- `npm test -w packages/rules-apex -- --run`
- `npm test -w packages/signals -- --run`
- `npm test -w packages/clients-tradovate -- --run`
- `npm test -w apps/api -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a46c32708c832cbfb6ddfa6a84c714