### PR TITLE
docs: add operator training deck and quick cards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,12 @@ readiness:
 # Print path to UAT scripts
 uat:
 	@echo "Open docs/release/uat-scenarios.md"
+
+.PHONY: deck cards
+
+deck:
+	@echo "Open docs/operator/training-deck.md"
+
+cards:
+	@echo "Quick cards:"
+	@ls -1 docs/operator/quick-cards/*.md

--- a/docs/operator/quick-cards/cheat-sheet.md
+++ b/docs/operator/quick-cards/cheat-sheet.md
@@ -1,0 +1,21 @@
+# Cheat Sheet — Terms & Times
+
+## Terms (Plain English)
+- **ORB (Open Session Breakout):** Trade the break of the first ~15m range after open.
+- **VWAP:** Volume-weighted average price; “fair” intraday benchmark.
+- **OCO:** One-Cancels-the-Other (Stop + Target paired).
+- **Flat:** No open positions.
+- **≤5R:** Max target is 5× risk distance from entry to stop.
+- **Consistency:** In funded mode, one day’s profit should not exceed ~30% of period profit.
+
+## Times (GMT)
+- **Session focus (CME RTH):** 14:30–21:59 GMT  
+- **EOD alerts:** T–10 (20:49–20:54), T–5 (20:55–20:59), **Flat by 21:59**
+
+## Quick Math
+- **R (Risk):** |Entry − Stop|  
+- **5R target:** Entry ± 5×R (system clamps automatically)
+
+## Do / Don’t
+- **Do:** Follow tickets exactly; confirm OCO; watch alerts.  
+- **Don’t:** Trade after 21:59 GMT; ignore CRITICAL alerts.

--- a/docs/operator/quick-cards/eod-flat.md
+++ b/docs/operator/quick-cards/eod-flat.md
@@ -1,0 +1,20 @@
+# Quick Card — End-of-Day Flat (21:59 GMT)
+
+**Goal:** Be **flat** (no positions) by **21:59 GMT**.
+
+## Timeline (GMT)
+- **20:49–20:54:** System sends **WARN** “EOD T–10”.  
+- **20:55–20:59:** System sends **CRITICAL** “EOD T–5”.  
+- **21:59:** Must be **FLAT**.
+
+## Steps
+1) Check **open positions** in Tradovate — close if any.  
+2) Verify **dashboard** shows no open positions.  
+3) Capture daily summary (export or screenshot).  
+4) Post **EOD flat** confirmation in Slack.
+
+## Do / Don’t
+**Do:** Close early if in doubt.  
+**Don’t:** Carry any position past **21:59 GMT**.
+
+[Placeholder: screenshot flat confirmation]

--- a/docs/operator/quick-cards/execute-ticket.md
+++ b/docs/operator/quick-cards/execute-ticket.md
@@ -1,0 +1,24 @@
+# Quick Card — Execute a Ticket (Tradovate Manual Entry)
+
+**Goal:** Enter the system’s ticket with OCO **Stop + Target**.
+
+## Steps
+1) In dashboard **Tickets**, pick the next ticket.  
+   - Fields: symbol, side, **entry**, **stop**, **target**, size.
+2) Open **Tradovate** order ticket for the same symbol/account.
+3) Select **OCO / Bracket** order type (Stop + Target).  
+4) Fill **Entry**, **Stop**, **Target**, **Size** exactly as shown.
+5) Review → **Submit**.
+6) Confirm in Tradovate **Working Orders** that OCO is present.
+7) Record the ticket ID in the daily log.
+
+## Checks
+- Stop present? **Yes** (mandatory)  
+- Target ≤ **5R**? (System ensures; verify number)  
+- No **Pause** flag on dashboard? (If **Pause**, do not submit)
+
+## Do / Don’t
+**Do:** Double-check symbol & account before submit.  
+**Don’t:** Modify ticket values unless instructed by PM/SA.
+
+[Placeholder: screenshot Tradovate OCO ticket]

--- a/docs/operator/quick-cards/incidents-&-escalation.md
+++ b/docs/operator/quick-cards/incidents-&-escalation.md
@@ -1,0 +1,18 @@
+# Quick Card — Incidents & Escalation
+
+**Goal:** Stay safe, fast, and compliant.
+
+## Common Incidents
+- **Platform/API down** → Pause trading; notify PM/SA.  
+- **Cannot enter ticket** → Log issue; skip ticket; escalate.  
+- **OCO missing** → **CRITICAL** alert; hard **Pause**; fix order.  
+- **Daily loss/consistency breach** → Flatten; escalate.
+
+## Escalation Path
+1) Post 1-liner in **#ops-incidents** (time, symbol, issue).  
+2) DM **Solutions Architect**, then **IT PM**, then **CTO** (as needed).
+
+## Break-Glass
+- If a position is at risk → **CLOSE FIRST**, then escalate.
+
+[Placeholder: Slack incident snippet]

--- a/docs/operator/quick-cards/monitor-&-alerts.md
+++ b/docs/operator/quick-cards/monitor-&-alerts.md
@@ -1,0 +1,25 @@
+# Quick Card — Monitor & Alerts
+
+**Goal:** React quickly to warnings and blocks.
+
+## Alert Types
+- **WARN (amber):**  
+  - Daily loss ≥70% cap  
+  - Consistency (funded) ≥25%  
+  - EOD T–10 window
+- **CRITICAL (red):**  
+  - Daily loss ≥85% cap  
+  - Missing OCO  
+  - Consistency (funded) ≥30%  
+  - EOD T–5 window
+
+## What To Do
+- **WARN:** Slow down; prepare to flatten or skip new tickets.  
+- **CRITICAL:** **Stop** new entries. Verify positions. Escalate if needed.
+
+## Tools
+- Dashboard **alerts panel** (refresh ~5–60s).  
+- Slack/Email notifications from system.  
+- `/jobs/status` for recent job run times and flags.
+
+[Placeholder: screenshot alert banner]

--- a/docs/operator/quick-cards/sod-checklist.md
+++ b/docs/operator/quick-cards/sod-checklist.md
@@ -1,0 +1,17 @@
+# Quick Card — Start of Day (SOD)
+
+**Goal:** Be fully ready when the session opens.
+
+## Checklist
+- [ ] Open **Prism Apex Dashboard** → `/health` shows **OK**.
+- [ ] Check **/jobs/status** → no stale errors; `ocoMissing=false`.
+- [ ] Confirm **notifications** work (Slack/Email visible).
+- [ ] Verify **session times** (CME RTH): **14:30–21:59 GMT** (MVP focus).
+- [ ] Confirm **account** and **symbol universe** for the day (ES, NQ; or as configured).
+- [ ] Read any **operator notes** in Slack.
+
+## Do / Don’t
+**Do:** Keep Slack open.  
+**Don’t:** Enter trades before session open.
+
+[Placeholder: screenshot dashboard health]

--- a/docs/operator/training-deck.md
+++ b/docs/operator/training-deck.md
@@ -1,0 +1,66 @@
+# Prism Apex Tool — Operator Training Deck (MVP)
+
+## 1) Context & Roles
+- **What you do:** Manually key trades into **Tradovate** from system-generated **tickets**.
+- **What you don’t do:** You **do not** pick instruments, sides, or sizes.
+- **Why:** Apex rules require strict guardrails; our system computes signals and monitors risk.
+
+## 2) Daily Flow (High-Level)
+1. **SOD:** Health check → recipients → session time.
+2. **Execute:** Read ticket → enter order in Tradovate **with OCO stop + target**.
+3. **Monitor:** Watch alerts (Slack/Email) and dashboard status.
+4. **EOD:** **Flat by 21:59 GMT** → confirm zero positions.
+5. **Incidents:** Use the escalation playbook.
+
+```mermaid
+flowchart TD
+    A[SOD Checks] --> B[Read Ticket]
+    B --> C[Enter in Tradovate (OCO)]
+    C --> D[Monitor Alerts & Rules]
+    D --> E[EOD Flat by 21:59 GMT]
+    D --> F{Alert?}
+    F -->|WARN/CRIT| G[Pause & Escalate]
+```
+
+## 3) Tickets (Plain English)
+A ticket contains: symbol, side (BUY/SELL), entry, stop, target, size.
+
+Stop is mandatory. Target is capped at ≤5R by our system.
+
+If the dashboard shows Pause or OCO Missing, do not enter new trades.
+
+## 4) Alerts (What They Mean)
+WARN (amber): Approaching a limit (e.g., 70% daily loss). Be cautious.
+
+CRITICAL (red): Breach imminent or detected (e.g., 85% daily loss; missing OCO). Stop and escalate.
+
+EOD T–10 / T–5: Close out to be flat by 21:59 GMT.
+
+## 5) EOD Flat (Non-Negotiable)
+By 21:59 GMT, zero open positions.
+
+The system nudges you but you own the final check.
+
+## 6) Do / Don’t
+**Do**
+Double-check stop and target are attached (OCO).
+
+Confirm account and symbol match the ticket.
+
+Take screenshots of anomalies.
+
+**Don’t**
+Don’t freestyle entries or sizes.
+
+Don’t trade past 21:59 GMT.
+
+Don’t ignore CRITICAL alerts.
+
+## 7) Escalation
+Post in #ops-incidents with a one-liner (time, symbol, issue).
+
+Ping Solutions Architect → IT PM → CTO (if needed).
+
+If positions are at risk, close then escalate.
+
+[Placeholder: screenshot of dashboard with tickets and alerts]


### PR DESCRIPTION
## Summary
- add print-friendly operator training deck covering context, daily flow, tickets, alerts, EOD flat rule, and escalation
- add quick cards for SOD checklist, manual ticket execution, monitoring alerts, EOD flat, incident escalation, and a cheat sheet
- append Makefile helpers to list deck and quick card paths

## Testing
- `npm test` *(fails: Missing script or no test files in some workspaces)*

------
https://chatgpt.com/codex/tasks/task_b_68a47b06040c832ca7cb22fc30f8fc1e