### PR TITLE
feat: add payout tracking and reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,3 +94,9 @@ cards:
 calibrate:
 	python -m calibration.run_sweeps
 	@echo "Results in reports/calibration/results.csv and results.json"
+
+.PHONY: payouts
+
+payouts:
+	python payouts/tracker.py
+	@echo "See reports/payouts/summary.json and docs/payouts/calendar.md"

--- a/docs/payouts/calendar.md
+++ b/docs/payouts/calendar.md
@@ -1,0 +1,29 @@
+# Prism Apex Tool — Payout Calendar
+
+## Rules Recap
+- **First payout**: After 10 trading days AND $1,000 net profit.
+- **Cycle**: Every 14 days after first payout.
+- **Amounts**:
+  - 100% of first $25,000.
+  - 90% of profits above $25,000.
+
+## Current Account Example
+- Trading days completed: 12
+- Total profit: $2,050
+- Eligible? **Yes**
+- Next payout date: 2025-09-01
+- Estimated payout: $2,050
+
+_All dates are in UTC/GMT._
+
+## Mermaid Flow
+```mermaid
+flowchart TD
+    A[10+ Days + $1k Profit?] -->|No| B[Not Eligible]
+    A -->|Yes| C[Eligible for Payout]
+    C --> D[First $25k → 100%]
+    D --> E[Above $25k → 90%]
+    C --> F[Next Payout in 14 Days]
+```
+
+[Placeholder: operator calendar screenshot]

--- a/payouts/tracker.py
+++ b/payouts/tracker.py
@@ -1,0 +1,70 @@
+"""
+Prism Apex Tool — Payout Tracker
+
+Monitors account performance and calculates payout eligibility per Apex rules.
+"""
+
+import json
+import csv
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPORT_DIR = Path("reports/payouts/")
+REPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def calculate_payouts(trading_days, profit_history, last_payout_date=None):
+    """
+    Args:
+        trading_days: int — number of trading days completed
+        profit_history: list of daily P/L (floats)
+        last_payout_date: datetime.date or None
+    Returns:
+        dict with next payout date, eligible amount, and reserves
+    """
+    total_profit = sum(profit_history)
+    eligible = False
+    next_date = None
+
+    if trading_days >= 10 and total_profit >= 1000:
+        eligible = True
+        base_date = last_payout_date or datetime.now(timezone.utc).date()
+        next_date = base_date + timedelta(days=14)
+
+    first_25k = min(total_profit, 25000)
+    remainder = max(total_profit - 25000, 0)
+    available_balance = first_25k + remainder * 0.9
+    withheld_reserve = total_profit - available_balance
+
+    return {
+        "eligible": eligible,
+        "trading_days": trading_days,
+        "total_profit": total_profit,
+        "next_payout_date": str(next_date) if next_date else None,
+        "available_balance": available_balance,
+        "withheld_reserve": withheld_reserve,
+    }
+
+
+def run_tracker():
+    # Placeholder — load from real DB in production
+    trading_days = 12
+    profit_history = [200, -50, 300, 150, -100, 500, 250, 100, 400, 150, -75, 225]
+
+    result = calculate_payouts(trading_days, profit_history)
+
+    # Save JSON
+    with open(REPORT_DIR / "summary.json", "w") as f:
+        json.dump(result, f, indent=2)
+
+    # Save CSV
+    with open(REPORT_DIR / "summary.csv", "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=result.keys())
+        writer.writeheader()
+        writer.writerow(result)
+
+    print("Payout report generated.")
+
+
+if __name__ == "__main__":
+    run_tracker()


### PR DESCRIPTION
## Summary
- add payout tracker to compute Apex eligibility, reserve amounts, and export reports
- document payout calendar with rules and flowchart
- add `payouts` Makefile target for generating reports

## Testing
- `make payouts`


------
https://chatgpt.com/codex/tasks/task_b_68a4a70b3578832cbcbb24af244f6e5a