### PR TITLE
Add strategy switcher and scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,3 +133,11 @@ copy-sim:
 	@curl -s -X POST http://localhost:8000/api/copytrader/preview \
  -H 'content-type: application/json' \
  -d '{"traderGroupId":"tg-sean-01","baseAccountId":"Apex-ES-50k-1","symbol":"ES","side":"BUY","entry":5000,"stop":4990,"target":5010,"baseSize":1,"mode":"evaluation"}' | jq .
+
+.PHONY: strat-now strat-sim
+
+strat-now:
+	@curl -s http://localhost:8000/api/strategy/active | jq .
+
+strat-sim:
+	@python scripts/simulate_strategy_day.py

--- a/api/dashboard.py
+++ b/api/dashboard.py
@@ -10,12 +10,16 @@ from api.accounts import router as accounts_router
 from api.rules_cross import router as rules_cross_router
 from api.copytrader import router as copy_router
 from api.jobs_multi import start_multi_job
+from api.strategy_switch import router as strategy_router
+from api.jobs_scheduler import start_scheduler_job
 
 app = FastAPI()
 app.include_router(accounts_router)
 app.include_router(rules_cross_router)
 app.include_router(copy_router)
+app.include_router(strategy_router)
 start_multi_job(app, every_sec=30)
+start_scheduler_job(every_sec=30)
 
 REPORTS = Path("reports/")
 

--- a/api/jobs_scheduler.py
+++ b/api/jobs_scheduler.py
@@ -1,0 +1,40 @@
+"""
+Background scheduler to auto-switch strategies based on windows and restrictions.
+"""
+
+import threading, time as pytime
+from datetime import datetime
+from .strategy_switch import switch_strategy, load_schedule
+from audit.logger import log_event
+
+def in_window(now, start, end):
+    return start <= now <= end
+
+def start_scheduler_job(every_sec: int = 30):
+    def loop():
+        while True:
+            try:
+                sched = load_schedule()
+                now = datetime.utcnow().strftime("%H:%M")
+                active = None
+                # Check restrictions first
+                for r in sched.get("restrictions", []):
+                    if r["startGMT"] <= now <= r["endGMT"]:
+                        if switch_strategy("OFF", operator="scheduler", reason=r["reason"]):
+                            log_event("STRATEGY_SWITCH", "restriction", {"reason": r["reason"]})
+                        active = "OFF"
+                        break
+                if not active:
+                    for w in sched.get("windows", []):
+                        if w["startGMT"] <= now <= w["endGMT"]:
+                            if switch_strategy(w["strategy"], operator="scheduler", reason="window"):
+                                log_event("STRATEGY_SWITCH", "window", {"strategy": w["strategy"]})
+                            active = w["strategy"]
+                            break
+                if not active:
+                    switch_strategy("OFF", operator="scheduler", reason="no_window")
+            except Exception as e:
+                log_event("SYSTEM_EVENT", "scheduler_error", {"err": str(e)})
+            pytime.sleep(every_sec)
+    t = threading.Thread(target=loop, daemon=True)
+    t.start()

--- a/api/strategy_switch.py
+++ b/api/strategy_switch.py
@@ -1,0 +1,33 @@
+"""
+Strategy Switcher API — Prism Apex Tool
+"""
+
+from fastapi import APIRouter
+from pathlib import Path
+import json
+from datetime import datetime, time
+from notifications.notify import notify
+from audit.logger import log_event
+
+router = APIRouter(prefix="/api/strategy", tags=["strategy"])
+DATA = Path("data/strategy_schedule.sample.json")
+
+def load_schedule():
+    with open(DATA) as f:
+        return json.load(f)
+
+state = {"active": "OFF", "lastSwitch": None, "reason": None}
+
+@router.get("/active")
+def active_strategy():
+    return state
+
+@router.post("/switch")
+def switch_strategy(strategy: str, operator: str = "system", reason: str = "manual"):
+    prev = state["active"]
+    state["active"] = strategy
+    state["lastSwitch"] = datetime.utcnow().isoformat()
+    state["reason"] = reason
+    notify("\ud83d\udd04 Strategy Switch", f"{prev} → {strategy} by {operator}")
+    log_event("STRATEGY_SWITCH", "manual_switch", {"from": prev, "to": strategy, "operator": operator, "reason": reason})
+    return state

--- a/data/strategy_schedule.sample.json
+++ b/data/strategy_schedule.sample.json
@@ -1,0 +1,27 @@
+{
+  "default": "OFF",
+  "windows": [
+    {
+      "strategy": "ORB",
+      "startGMT": "14:30",
+      "endGMT": "15:00"
+    },
+    {
+      "strategy": "VWAP",
+      "startGMT": "15:00",
+      "endGMT": "20:50"
+    }
+  ],
+  "restrictions": [
+    {
+      "reason": "EOD flat",
+      "startGMT": "20:50",
+      "endGMT": "21:15"
+    },
+    {
+      "reason": "CPI report",
+      "startGMT": "13:25",
+      "endGMT": "13:45"
+    }
+  ]
+}

--- a/docs/strategy-switcher/guide.md
+++ b/docs/strategy-switcher/guide.md
@@ -1,0 +1,27 @@
+# Strategy Switcher — Operator Guide
+
+## What This Does
+- Controls whether **ORB** or **VWAP** strategy is active.
+- Scheduler automatically turns strategies ON/OFF based on time windows.
+- Blocks strategies during restricted periods (e.g., news, EOD).
+
+## Plain English
+- ORB runs at market open (14:30–15:00 GMT).
+- VWAP runs until near close (15:00–20:50 GMT).
+- EOD Flat: everything turns OFF at 20:50 GMT, operator must be flat.
+- Restrictions: system disables trading around major events like CPI.
+
+## How to Use
+1. See **current active strategy** in dashboard.
+2. Use dropdown/buttons to override manually (logged).
+3. Add restricted windows to config JSON if needed.
+4. Scheduler ensures Apex rules are met (no trading after EOD).
+
+```mermaid
+flowchart TD
+    A[Config JSON Windows] --> B[Scheduler Job]
+    C[Restrictions] --> B
+    B --> D[Switch Active Strategy]
+    D --> E[Dashboard Badge]
+    D --> F[Audit Log + Notification]
+```

--- a/frontend/src/components/StrategySwitcher.jsx
+++ b/frontend/src/components/StrategySwitcher.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from "react";
+
+export default function StrategySwitcher() {
+  const [active, setActive] = useState({active: "OFF"});
+  const [windows, setWindows] = useState([]);
+  const [restrictions, setRestrictions] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/strategy/active").then(r=>r.json()).then(setActive);
+    fetch("/data/strategy_schedule.sample.json").then(r=>r.json()).then(d=>{
+      setWindows(d.windows||[]);
+      setRestrictions(d.restrictions||[]);
+    });
+    const poll = setInterval(()=>fetch("/api/strategy/active").then(r=>r.json()).then(setActive), 5000);
+    return ()=>clearInterval(poll);
+  }, []);
+
+  const manualSwitch = async (strategy) => {
+    const res = await fetch(`/api/strategy/switch?strategy=${strategy}&operator=operator1&reason=manual`, {method:"POST"});
+    setActive(await res.json());
+  };
+
+  return (
+    <div className="border rounded p-3">
+      <h3 className="text-lg font-semibold">Strategy Switcher</h3>
+      <p>Active: <span className="font-bold">{active.active}</span></p>
+      <div className="mt-2 space-x-2">
+        {["OFF","ORB","VWAP"].map(s => (
+          <button key={s} onClick={()=>manualSwitch(s)} className="px-3 py-1 border rounded">{s}</button>
+        ))}
+      </div>
+      <h4 className="mt-4 font-semibold">Schedule</h4>
+      <ul className="text-sm">
+        {windows.map((w,i)=><li key={i}>{w.strategy}: {w.startGMT}–{w.endGMT} GMT</li>)}
+      </ul>
+      <h4 className="mt-4 font-semibold">Restrictions</h4>
+      <ul className="text-sm text-red-600">
+        {restrictions.map((r,i)=><li key={i}>{r.reason}: {r.startGMT}–{r.endGMT} GMT</li>)}
+      </ul>
+    </div>
+  );
+}

--- a/scripts/simulate_strategy_day.py
+++ b/scripts/simulate_strategy_day.py
@@ -1,0 +1,27 @@
+"""Simulate a schedule day by printing active strategy every 30 minutes."""
+
+from datetime import datetime, timedelta
+from api.strategy_switch import load_schedule
+
+def simulate_day():
+    sched = load_schedule()
+    t = datetime.strptime("00:00", "%H:%M")
+    end = datetime.strptime("23:59", "%H:%M")
+    step = timedelta(minutes=30)
+    while t <= end:
+        time_str = t.strftime("%H:%M")
+        strategy = "OFF"
+        for r in sched.get("restrictions", []):
+            if r["startGMT"] <= time_str <= r["endGMT"]:
+                strategy = f"OFF ({r['reason']})"
+                break
+        if strategy == "OFF":
+            for w in sched.get("windows", []):
+                if w["startGMT"] <= time_str <= w["endGMT"]:
+                    strategy = w["strategy"]
+                    break
+        print(f"{time_str}: {strategy}")
+        t += step
+
+if __name__ == "__main__":
+    simulate_day()


### PR DESCRIPTION
## Summary
- add strategy scheduler and REST endpoints to toggle ORB/VWAP strategies
- provide simple React UI, docs, and sample schedule config
- include Makefile helpers for querying and simulating strategy state

## Testing
- `npm test -w packages/shared --silent`
- `npm test -w packages/rules-apex --silent`
- `npm test -w packages/signals --silent`
- `npm test -w packages/clients-tradovate --silent -- --run` *(fails: tests hang)*
- `npm test -w apps/api --silent`


------
https://chatgpt.com/codex/tasks/task_b_68a5c7f48bac832ca227c5a4b6a9ded1