### PR TITLE
Add dry-run simulation engine and frontend runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,13 @@ seed:
 	@DATA_DIR=.data node --loader ts-node/esm apps/api/scripts/seed.ts
 
 backtest:
-        @echo "Running sample backtest (ORB, ES 1m)..."
-        @mkdir -p out
-        @./node_modules/.bin/tsx apps/cli/src/backtest.ts --strategy=ORB --data=data/ES_1m.sample.csv --mode=evaluation --open=14:30 --close=21:59 --tickValue=50 --seed=42 --out=out/es_orb_sample
+	@echo "Running sample backtest (ORB, ES 1m)..."
+	@mkdir -p out
+	@./node_modules/.bin/tsx apps/cli/src/backtest.ts --strategy=ORB --data=data/ES_1m.sample.csv --mode=evaluation --open=14:30 --close=21:59 --tickValue=50 --seed=42 --out=out/es_orb_sample
 
 .PHONY: backtest-tick
 backtest-tick:
-        @node apps/cli/dist/backtest.js --strategy=ORB --modeReplay=tick --tickData=data/ES_ticks.sample.csv --mode=evaluation --open=14:30 --close=21:59 --tickValue=50 --seed=42 --out=out/es_orb_tick
+	@node apps/cli/dist/backtest.js --strategy=ORB --modeReplay=tick --tickData=data/ES_ticks.sample.csv --mode=evaluation --open=14:30 --close=21:59 --tickValue=50 --seed=42 --out=out/es_orb_tick
 
 demo:
 	@bash apps/cli/scripts/demo.sh
@@ -121,8 +121,8 @@ dashboard:
 .PHONY: audit-test
 
 audit-test:
-        python -c "from audit.logger import log_event; log_event('SYSTEM_EVENT','Audit system test')"
-        @echo "Check logs/audit/ for new entries"
+	python -c "from audit.logger import log_event; log_event('SYSTEM_EVENT','Audit system test')"
+	@echo "Check logs/audit/ for new entries"
 
 .PHONY: multi-check copy-sim
 
@@ -141,3 +141,7 @@ strat-now:
 
 strat-sim:
 	@python scripts/simulate_strategy_day.py
+
+.PHONY: simulate
+simulate:
+	python simulator/run_simulation.py --input data/ES_1m.sample.csv --strategy ALL

--- a/docs/simulator/guide.md
+++ b/docs/simulator/guide.md
@@ -1,0 +1,31 @@
+# Dry-Run Simulator — Operator Guide
+
+## What This Does
+- Replays a trading session (from CSV data).
+- Runs both ORB and VWAP strategies as if live.
+- Applies Apex guardrails.
+- Sends notifications + logs events.
+- Shows what would have happened without risking real accounts.
+
+## Plain English
+This is a **practice run** for the whole system.
+- Feed in a day of data.
+- System tells you what trades it would generate.
+- If rules like “daily loss cap” are broken, you’ll see it flagged.
+- At the end, you get a report in plain English + numbers.
+
+## Steps
+1. Upload CSV file via dashboard.
+2. Select ORB, VWAP, or ALL.
+3. Run simulation.
+4. View results in dashboard + reports folder.
+
+```mermaid
+flowchart TD
+    A[CSV Data] --> B[Simulator Engine]
+    B --> C[Strategy Logic ORB/VWAP]
+    C --> D[Guardrails]
+    D --> E[Notifications + Audit]
+    E --> F[Operator Dashboard]
+    D --> G[Reports JSON/Markdown]
+```

--- a/frontend/src/components/SimulationRunner.jsx
+++ b/frontend/src/components/SimulationRunner.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react";
+
+export default function SimulationRunner() {
+  const [result, setResult] = useState(null);
+
+  const runSim = async (e) => {
+    e.preventDefault();
+    const form = new FormData(e.target);
+    const res = await fetch("/api/simulate", { method: "POST", body: form });
+    setResult(await res.json());
+  };
+
+  return (
+    <div className="border rounded p-3">
+      <h3 className="font-semibold">Dry-Run Simulator</h3>
+      <form onSubmit={runSim} className="space-y-2">
+        <input type="file" name="csv" accept=".csv" />
+        <select name="strategy">
+          <option value="ALL">ALL</option>
+          <option value="ORB">ORB</option>
+          <option value="VWAP">VWAP</option>
+        </select>
+        <button type="submit" className="px-3 py-1 border rounded">Run</button>
+      </form>
+      {result && (
+        <div className="mt-4">
+          <h4 className="font-semibold">Results</h4>
+          <p>Tickets: {result.tickets.length}</p>
+          <p>Breaches: {result.events.length}</p>
+          <ul>
+            {result.events.map((e, i) => (
+              <li key={i}>{e.message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/simulator/run_simulation.py
+++ b/simulator/run_simulation.py
@@ -1,0 +1,103 @@
+"""End-to-End Dry-Run Simulator for Prism Apex Tool."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import List, Tuple
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from audit.logger import log_event
+from notifications.notify import notify
+from rules.engine import RuleEngine
+from simulator.core import Simulator
+from simulator.metrics import compute_metrics
+from strategy.orb import OpeningRangeStrategy
+from strategy.vwap import VWAPStrategy
+
+STRATEGY_MAP: dict[str, type] = {
+    "ORB": OpeningRangeStrategy,
+    "VWAP": VWAPStrategy,
+}
+
+
+def _load_data(path: str | Path, start: str, end: str) -> pd.DataFrame:
+    """Load bar data and slice by date range."""
+    df = pd.read_csv(path, parse_dates=[0])
+    ts_col = df.columns[0]
+    df = df.rename(columns={ts_col: "timestamp"})
+    start_ts = pd.to_datetime(start, utc=True)
+    end_ts = pd.to_datetime(end, utc=True)
+    df = df[(df["timestamp"] >= start_ts) & (df["timestamp"] <= end_ts)]
+    return df.rename(columns={"timestamp": "date"})
+
+
+def simulate(input_file: str, strategy: str, start: str, end: str, outdir: str = "reports/simulation") -> Tuple[List[dict], List[dict]]:
+    """Run the dry-run simulation and emit reports."""
+    df = _load_data(input_file, start, end)
+
+    selected = STRATEGY_MAP.keys() if strategy == "ALL" else [strategy]
+    tickets: List[dict] = []
+    events: List[dict] = []
+
+    for strat_name in selected:
+        strat_cls = STRATEGY_MAP[strat_name]
+        strat = strat_cls()
+        rules = RuleEngine(mode="evaluation", config={"profit_target": 1_000.0, "trailing_drawdown": 1_000.0})
+        sim = Simulator(strat, rules)
+        result = sim.run(df)
+        tickets.extend(result["trades"])
+        events.extend(result["logs"])
+
+    # Emit notifications and audit logs for events
+    for ev in events:
+        subject = "⚠️ Guardrail Breach" if ev.get("rule") != "profit_target" else "ℹ️ Rule Event"
+        notify(subject, ev.get("message", ""))
+        log_event("GUARDRAIL_EVENT", ev.get("rule", ""), ev)
+
+    metrics = compute_metrics(tickets, events)
+    total_pnl = float(sum(t.get("profit", 0.0) for t in tickets))
+    eod_breach = any(ev.get("rule") == "eod_flat" for ev in events)
+
+    session_id = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    out_path = Path(outdir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    json_path = out_path / f"session_{session_id}.json"
+    with json_path.open("w", encoding="utf-8") as f:
+        json.dump({"tickets": tickets, "events": events, "metrics": {"total_pnl": total_pnl, **metrics}}, f, indent=2, default=str)
+
+    md_path = out_path / f"session_{session_id}.md"
+    with md_path.open("w", encoding="utf-8") as f:
+        f.write(f"# Simulation {session_id}\n\n")
+        f.write(f"Strategy: {strategy}\n")
+        f.write(f"Period: {start} → {end}\n\n")
+        f.write(f"Total PnL: {total_pnl:.2f}\n")
+        f.write(f"Max Drawdown: {metrics['max_drawdown']:.2f}\n")
+        f.write(f"Rule Breaches: {metrics['rule_breaches']}\n")
+        f.write(f"EOD Flat: {'No breaches' if not eod_breach else 'Positions open past EOD'}\n\n")
+        f.write("## Guardrail Events\n")
+        for ev in events:
+            f.write(f"- {ev.get('message', '')}\n")
+
+    return tickets, events
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run dry-run simulation")
+    parser.add_argument("--strategy", default="ALL", choices=["ORB", "VWAP", "ALL"])
+    parser.add_argument("--start", default="2025-01-01")
+    parser.add_argument("--end", default="2025-01-31")
+    parser.add_argument("--input", required=True, help="Path to bar-level CSV")
+    args = parser.parse_args()
+    simulate(args.input, args.strategy, args.start, args.end)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- add bar-level dry-run simulator with guardrail notifications and markdown/JSON reports
- expose simulator runner component in frontend
- document how operators can run simulations and add make target

## Testing
- `pytest`
- `npm test -w apps/api --silent`
- `make simulate`


------
https://chatgpt.com/codex/tasks/task_b_68a5ceb33d94832c99ed0651864b9125