### PR TITLE
Add health/panic endpoints and deployment hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Multi-stage build
+FROM python:3.11-slim as builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+FROM python:3.11-slim
+WORKDIR /app
+RUN useradd -m prism
+USER prism
+COPY --from=builder /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY . .
+HEALTHCHECK CMD curl --fail http://localhost:8000/api/health || exit 1
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Makefile
+++ b/Makefile
@@ -144,4 +144,9 @@ strat-sim:
 
 .PHONY: simulate
 simulate:
-	python simulator/run_simulation.py --input data/ES_1m.sample.csv --strategy ALL
+        python simulator/run_simulation.py --input data/ES_1m.sample.csv --strategy ALL
+
+.PHONY: panic
+
+panic:
+	curl -X POST http://localhost:8000/api/panic?operator=cli

--- a/api/dashboard.py
+++ b/api/dashboard.py
@@ -12,12 +12,16 @@ from api.copytrader import router as copy_router
 from api.jobs_multi import start_multi_job
 from api.strategy_switch import router as strategy_router
 from api.jobs_scheduler import start_scheduler_job
+from api.health import router as health_router
+from api.panic import router as panic_router
 
 app = FastAPI()
 app.include_router(accounts_router)
 app.include_router(rules_cross_router)
 app.include_router(copy_router)
 app.include_router(strategy_router)
+app.include_router(health_router)
+app.include_router(panic_router)
 start_multi_job(app, every_sec=30)
 start_scheduler_job(every_sec=30)
 

--- a/api/health.py
+++ b/api/health.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+import psutil, datetime
+from .strategy_switch import state
+
+router = APIRouter(prefix="/api", tags=["health"])
+
+@router.get("/health")
+def health():
+    return {
+        "status": "OK",
+        "time": datetime.datetime.utcnow().isoformat(),
+        "active_strategy": state.get("active","OFF"),
+        "cpu": psutil.cpu_percent(),
+        "mem": psutil.virtual_memory().percent
+    }

--- a/api/panic.py
+++ b/api/panic.py
@@ -1,0 +1,17 @@
+"""
+Panic Brake API — immediately disables all strategies.
+"""
+
+from fastapi import APIRouter
+from .strategy_switch import switch_strategy
+from notifications.notify import notify
+from audit.logger import log_event
+
+router = APIRouter(prefix="/api", tags=["panic"])
+
+@router.post("/panic")
+def panic(operator: str = "system"):
+    switch_strategy("OFF", operator=operator, reason="panic")
+    notify("🔴 PANIC MODE", f"Triggered by {operator}. All strategies OFF.")
+    log_event("PANIC", "triggered", {"operator": operator})
+    return {"status":"panic_triggered"}

--- a/docs/deployment/hardening.md
+++ b/docs/deployment/hardening.md
@@ -1,0 +1,17 @@
+# Production Hardening — Prism Apex Tool
+
+## Overview
+This guide ensures the tool runs safely in production.
+
+## Key Safeguards
+- Panic Brake → one-click OFF.
+- Auto-restart → crashes restart within 10s.
+- Healthcheck → /api/health shows system OK.
+- Secrets → stored only in .env.production.
+- Monitoring → Prometheus + Grafana.
+
+## Steps
+1. Deploy with Docker/Helm.
+2. Run `make panic` to confirm panic button works.
+3. Check Grafana for CPU/mem + guardrail alerts.
+4. Ensure liveness probe auto-restarts container if stuck.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,21 @@
+resources:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: 8000
+  initialDelaySeconds: 15
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: 8000
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/main.py
+++ b/main.py
@@ -1,0 +1,1 @@
+from api.dashboard import app


### PR DESCRIPTION
## Summary
- add lightweight health endpoint reporting system status
- introduce panic brake API and CLI trigger
- provide production-ready Dockerfile, Helm values, and deployment docs

## Testing
- `pytest`
- `python -m py_compile api/health.py api/panic.py api/dashboard.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_68a5d8be5364832c89f3ecd2c1042462