### PR TITLE
chore: add release checklist and tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release Pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install deps
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: make test
+      - name: Guardrail tests
+        run: make guardrails:test
+      - name: Run Simulator
+        run: make simulate
+      - name: Lint & Type check
+        run: make lint && make typecheck

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,9 @@ demo:
 
 .PHONY: release deploy
 
-# Create a signed tag and push (CI will build & deploy)
 release:
-	@if [ -z "$$TAG" ]; then echo "Usage: make release TAG=v0.1.0"; exit 2; fi
-	git tag -a $$TAG -m "Release $$TAG"
-	git push origin $$TAG
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=vX.Y.Z"; exit 1; fi
+	bash scripts/release_tag.sh $(VERSION)
 
 # Convenience local wrapper to call remote deploy script (requires same secrets exported)
 deploy:
@@ -144,7 +142,7 @@ strat-sim:
 
 .PHONY: simulate
 simulate:
-        python simulator/run_simulation.py --input data/ES_1m.sample.csv --strategy ALL
+	python simulator/run_simulation.py --input data/ES_1m.sample.csv --strategy ALL
 
 .PHONY: panic
 

--- a/docs/release/checklist.md
+++ b/docs/release/checklist.md
@@ -1,0 +1,20 @@
+# Release Checklist — Prism Apex Tool
+
+## Preflight
+- [ ] All unit tests pass (`make test`)
+- [ ] All guardrail monitors pass (`make guardrails:test`)
+- [ ] Simulator run successful (`make simulate`)
+
+## Operator Signoff
+- [ ] Operator confirms panic button works
+- [ ] Operator confirms notifications (Slack/Email) received
+- [ ] Operator confirms training mode works
+
+## PM Signoff
+- [ ] PM validates checklist complete
+- [ ] Version bump confirmed
+
+## Release
+- [ ] Run `make release VERSION=vX.Y.Z`
+- [ ] GitHub Actions pipeline must pass
+- [ ] Tag pushed and CI confirms release

--- a/docs/release/operator_signoff.md
+++ b/docs/release/operator_signoff.md
@@ -1,0 +1,18 @@
+# Operator Release Signoff — Plain English
+
+## Why This Matters
+We need to be sure Prism Apex Tool is safe to run under Apex rules.
+
+## What You Do
+1. Run `make simulate` → confirms rules are respected.
+2. Run `make guardrails:test` → ensures brakes work.
+3. Test panic button in dashboard → system must stop.
+4. Confirm Slack/Email alerts arrive.
+5. Confirm training mode works (`make training`).
+
+If all checks pass:
+- Tell PM "OK to release."
+- PM will tag the release.
+
+If any checks fail:
+- Stop and report back.

--- a/scripts/release_tag.sh
+++ b/scripts/release_tag.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+if [ -z "$1" ]; then
+  echo "Usage: ./release_tag.sh vX.Y.Z"
+  exit 1
+fi
+VERSION=$1
+git tag $VERSION
+git push origin $VERSION
+echo "Tagged release $VERSION and pushed to origin"


### PR DESCRIPTION
## Summary
- document release checklist and operator signoff
- add release workflow and tagging helper script
- update Makefile with release target

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a5f5c1b7bc832c8beff78c138ac1f7