### PR TITLE
Add post-trade analytics and payout tracking

### DIFF
--- a/analytics/payout_tracker.py
+++ b/analytics/payout_tracker.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+PAYOUT_THRESHOLD = 2500
+STATUS_FILE = Path("reports/payout_status.json")
+
+
+def update_payout_status(daily_pnl: float, breaches=None):
+    """Update cumulative PnL and payout eligibility."""
+    if breaches is None:
+        breaches = []
+
+    status = {
+        "cumulative_pnl": 0.0,
+        "threshold": PAYOUT_THRESHOLD,
+        "eligible": False,
+        "breached": False,
+    }
+    if STATUS_FILE.exists():
+        with open(STATUS_FILE, "r", encoding="utf-8") as f:
+            status.update(json.load(f))
+
+    status["cumulative_pnl"] += daily_pnl
+    if breaches:
+        status["breached"] = True
+    status["eligible"] = (
+        status["cumulative_pnl"] >= PAYOUT_THRESHOLD and not status["breached"]
+    )
+
+    STATUS_FILE.parent.mkdir(exist_ok=True)
+    with open(STATUS_FILE, "w", encoding="utf-8") as f:
+        json.dump(status, f, indent=2)
+    return status
+
+
+def get_payout_status():
+    if STATUS_FILE.exists():
+        with open(STATUS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {
+        "cumulative_pnl": 0.0,
+        "threshold": PAYOUT_THRESHOLD,
+        "eligible": False,
+        "breached": False,
+    }

--- a/analytics/post_trade.py
+++ b/analytics/post_trade.py
@@ -1,0 +1,50 @@
+import json
+import datetime
+from pathlib import Path
+from audit.logger import read_events
+from analytics.payout_tracker import update_payout_status
+from notifications.notify import notify
+
+REPORTS_DIR = Path("reports")
+REPORTS_DIR.mkdir(exist_ok=True)
+
+
+def generate_daily_report(date: datetime.date | None = None, send_notification: bool = False):
+    """Aggregate daily trading activity and generate report."""
+    if date is None:
+        date = datetime.date.today()
+
+    events = read_events(date)
+    gross_pnl = sum(e.get("pnl", 0) for e in events)
+    fees = sum(e.get("fees", 0) for e in events)
+    net_pnl = gross_pnl - fees
+
+    breaches = [e for e in events if e.get("type") in ["GUARDRAIL", "PANIC"]]
+    operator_actions = [
+        e for e in events if e.get("type") in ["TICKET", "PANIC", "TRAINING"]
+    ]
+
+    report = {
+        "date": str(date),
+        "pnl": {"gross": gross_pnl, "net": net_pnl},
+        "breaches": breaches,
+        "operator_actions": operator_actions,
+    }
+
+    daily_path = REPORTS_DIR / f"daily_{date}.json"
+    with open(daily_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+
+    payout_status = update_payout_status(net_pnl, breaches)
+    report["payout_status"] = payout_status
+
+    if send_notification:
+        subject = f"[DAILY REPORT] {date}"
+        body = (
+            f"Net PnL: {net_pnl}\n"
+            f"Payout Eligible: {payout_status['eligible']}\n"
+            f"Breaches: {len(breaches)}"
+        )
+        notify(subject, body)
+
+    return report

--- a/api/analytics.py
+++ b/api/analytics.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+from analytics.post_trade import generate_daily_report
+from analytics.payout_tracker import get_payout_status
+
+router = APIRouter(prefix="/api/analytics", tags=["analytics"])
+
+
+@router.get("/daily")
+def daily():
+    return generate_daily_report()
+
+
+@router.get("/payout")
+def payout():
+    return get_payout_status()

--- a/api/dashboard.py
+++ b/api/dashboard.py
@@ -14,6 +14,7 @@ from api.strategy_switch import router as strategy_router
 from api.jobs_scheduler import start_scheduler_job
 from api.health import router as health_router
 from api.panic import router as panic_router
+from api.analytics import router as analytics_router
 
 app = FastAPI()
 app.include_router(accounts_router)
@@ -22,6 +23,7 @@ app.include_router(copy_router)
 app.include_router(strategy_router)
 app.include_router(health_router)
 app.include_router(panic_router)
+app.include_router(analytics_router)
 start_multi_job(app, every_sec=30)
 start_scheduler_job(every_sec=30)
 

--- a/audit/logger.py
+++ b/audit/logger.py
@@ -44,3 +44,22 @@ def log_event(event_type: str, message: str, details: Optional[Dict] = None) -> 
         f.write(json.dumps(entry) + "\n")
 
     logger.info(f"{event_type}: {message}")
+
+
+def read_events(date):
+    """Read audit events for a given date."""
+    path = LOG_DIR / f"audit_{date}.jsonl"
+    events = []
+    if path.exists():
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                event = {"type": entry.get("event_type")}
+                details = entry.get("details", {})
+                if isinstance(details, dict):
+                    event.update(details)
+                events.append(event)
+    return events

--- a/docs/analytics/payout_tracker.md
+++ b/docs/analytics/payout_tracker.md
@@ -1,0 +1,12 @@
+# Payout Tracker
+
+## Purpose
+Tracks progress toward Apex payout thresholds.
+
+## Rules
+- Threshold: $2,500 profit (no rule breaches).
+- Status saved in `reports/payout_status.json`.
+- Dashboard shows current progress bar.
+
+## Usage
+Run `/api/analytics/payout` or check dashboard.

--- a/docs/analytics/post_trade.md
+++ b/docs/analytics/post_trade.md
@@ -1,0 +1,13 @@
+# Post-Trade Analytics
+
+## Purpose
+Every day after trading, the system generates a report:
+- Daily PnL (gross and net)
+- Guardrail breaches
+- Operator actions
+
+## Location
+Reports stored in `reports/daily_YYYY-MM-DD.json`.
+
+## Usage
+View on dashboard under "Daily Report".

--- a/frontend/src/components/PostTradeReport.jsx
+++ b/frontend/src/components/PostTradeReport.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+
+export default function PostTradeReport() {
+  const [report, setReport] = useState(null);
+  const [payout, setPayout] = useState(null);
+
+  useEffect(() => {
+    fetch("/api/analytics/daily")
+      .then((r) => r.json())
+      .then(setReport);
+    fetch("/api/analytics/payout")
+      .then((r) => r.json())
+      .then(setPayout);
+  }, []);
+
+  if (!report || !payout) return <p>Loading...</p>;
+
+  const progress = Math.min(
+    (payout.cumulative_pnl / payout.threshold) * 100,
+    100
+  );
+
+  return (
+    <div className="p-4 bg-white shadow rounded-xl">
+      <h2 className="text-xl font-bold mb-2">Daily Post-Trade Report</h2>
+      <p>Gross PnL: {report.pnl.gross}</p>
+      <p>Net PnL: {report.pnl.net}</p>
+      <h3 className="font-semibold">Breaches</h3>
+      <ul>
+        {report.breaches.map((b, i) => (
+          <li key={i} className="text-red-600">
+            {b.type}: {b.details}
+          </li>
+        ))}
+      </ul>
+      <h3 className="font-semibold">Operator Actions</h3>
+      <table className="w-full text-left">
+        <tbody>
+          {report.operator_actions.map((a, i) => (
+            <tr key={i}>
+              <td className="pr-2">{a.type}</td>
+              <td>{JSON.stringify(a)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <h3 className="font-semibold mt-4">Payout Progress</h3>
+      <div className="w-full bg-gray-200 rounded">
+        <div
+          className="bg-green-500 text-xs leading-none py-1 text-center text-white rounded"
+          style={{ width: `${progress}%` }}
+        >
+          {progress.toFixed(1)}%
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- aggregate audit logs into daily post-trade reports and notify via Slack/email
- track cumulative PnL toward Apex payout threshold with eligibility flag
- expose analytics API endpoints and frontend component for daily reports and payout progress

## Testing
- `pytest`
- `npm test` *(fails: No test files found / missing scripts)*


------
https://chatgpt.com/codex/tasks/task_b_68a610aaa318832c85a03a9ab1c84956