### PR TITLE
feat(dashboard): configure dev proxy and tailwind v4

### DIFF
--- a/apps/dashboard/postcss.config.cjs
+++ b/apps/dashboard/postcss.config.cjs
@@ -1,6 +1,5 @@
+const tailwind = require('@tailwindcss/postcss');
+
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [tailwind()],
 };

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -1,8 +1,25 @@
-/* eslint-disable import/no-default-export */
-/* eslint-disable simple-import-sort/imports */
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: path => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+  esbuild: {
+    loader: 'jsx',
+    include: /src\/.*\.js$/,
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      loader: { '.js': 'jsx' },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- configure dashboard dev server with port 3000, API proxy, and JSX loader
- use `@tailwindcss/postcss` plugin in PostCSS config

## Testing
- `pnpm test` *(fails: ReferenceError: describe is not defined, Playwright test errors)*

------
https://chatgpt.com/codex/tasks/task_b_68a6407186a4832cb67c67fda7321ba5