### PR TITLE
chore(dev): add hardened dev scripts, API env template, and step-by-step README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ build
 .env
 .env.*
 !.env.example
+!.env.local.example
 
 # Misc
 .DS_Store

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,0 +1,85 @@
+# Local Development (API + Dashboard)
+
+This guide gets both services running locally in two terminals with proxy wiring and health checks.
+
+## Prereqs
+- Node 20+ and `pnpm` (Corepack):
+  ```bash
+  corepack enable
+  corepack prepare pnpm@latest --activate
+  ```
+
+From repo root, install deps once:
+
+pnpm install --no-frozen-lockfile
+
+1) Prepare API env
+
+Create a local env file (or use defaults):
+
+cp apps/api/.env.local.example apps/api/.env.local
+# edit values if you have real credentials; otherwise leave as-is for dev
+
+2) Start the API
+
+In Terminal A (repo root):
+
+./dev_api.sh
+
+
+You should see:
+
+[dev:api] PORT=8000 HOST=0.0.0.0 DATA_DIR=/var/lib/prism-apex-tool
+[dev:api] Starting Fastify (tsx watch)…
+{"msg":"API listening on 0.0.0.0:8000"}
+
+
+Health check:
+
+curl -s http://localhost:8000/health
+# -> {"ok":true}
+
+3) Start the Dashboard
+
+In Terminal B (repo root):
+
+./dev_dashboard.sh
+
+
+Then open:
+
+http://localhost:3000
+
+Vite proxy is already configured so the dashboard calls /api/* which Vite rewrites to http://localhost:8000/compat/*.
+
+4) Sanity checks (from any terminal)
+# Vite → API through proxy
+curl -s http://localhost:3000/api/health
+# -> {"ok":true}
+
+# Alerts queue (empty until populated)
+curl -s "http://localhost:3000/api/alerts/queue?limit=50"
+# -> []
+
+Troubleshooting
+
+Port 3000 or 8000 already in use
+
+Change the port in apps/dashboard/vite.config.ts (server.port) or in apps/api/.env.local (PORT), then restart the corresponding script.
+
+CORS/Proxy issues
+
+In dev, all calls should go through Vite on http://localhost:3000 and the proxy to http://localhost:8000. If you’re calling the API directly from the browser (not via /api/*), you may hit CORS. Use the /api/* paths in the app.
+
+ESBuild “loader must be a string”
+
+Make sure apps/dashboard/vite.config.ts includes the JSX loader lines from PR5/PR6 and you’ve restarted pnpm run dev after edits.
+
+Clear Vite cache if needed:
+
+rm -rf apps/dashboard/node_modules/.vite
+
+
+Environment variables not set
+
+The API may log a “Missing env vars…” for Tradovate if codepaths that require them are exercised. For pure UI testing, the /compat/* routes do not require real credentials.

--- a/apps/api/.env.local.example
+++ b/apps/api/.env.local.example
@@ -1,0 +1,16 @@
+# === Prism Apex API local env (example) ===
+# Copy to .env.local and tweak values as needed.
+
+# Network
+PORT=8000
+HOST=0.0.0.0
+
+# Local data storage (store.ts writes JSON here)
+DATA_DIR=/var/lib/prism-apex-tool
+
+# Tradovate sandbox/dev placeholders (API constructs a client if these are set)
+TRADOVATE_BASE_URL=https://demo.tradovateapi.com
+TRADOVATE_USERNAME=demo-user
+TRADOVATE_PASSWORD=demo-pass
+TRADOVATE_CLIENT_ID=demo-client
+TRADOVATE_CLIENT_SECRET=demo-secret

--- a/dev_api.sh
+++ b/dev_api.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Always run from repo root (supports invocation from subdirs)
+cd "$(dirname "$0")"
+
+# Nice logging
+log() { printf "\033[1;34m[dev:api]\033[0m %s\n" "$*"; }
+err() { printf "\033[1;31m[dev:api]\033[0m %s\n" "$*" >&2; }
+
+# Defaults
+export PORT="${PORT:-8000}"
+export HOST="${HOST:-0.0.0.0}"
+export DATA_DIR="${DATA_DIR:-/var/lib/prism-apex-tool}"
+
+# Load local env (if present)
+ENV_FILE="apps/api/.env.local"
+if [[ -f "$ENV_FILE" ]]; then
+  log "Loading env from $ENV_FILE"
+  # shellcheck disable=SC1090
+  set -a; . "$ENV_FILE"; set +a
+else
+  log "No $ENV_FILE found (that's OK). Using inline defaults if any."
+fi
+
+# Ensure data dir exists (store.ts writes data.json here)
+if [[ ! -d "$DATA_DIR" ]]; then
+  log "Creating DATA_DIR at $DATA_DIR"
+  mkdir -p "$DATA_DIR"
+fi
+
+# Sanity: show essentials
+log "PORT=$PORT HOST=$HOST DATA_DIR=$DATA_DIR"
+
+# Tooling checks (soft)
+command -v pnpm >/dev/null 2>&1 || err "pnpm not found. Install with: corepack enable && corepack prepare pnpm@latest --activate"
+command -v node  >/dev/null 2>&1 || err "node not found. Install Node 20+."
+# tsx is invoked via pnpm dlx, so no global install required.
+
+# Run API in watch mode
+log "Starting Fastify (tsx watch)…"
+exec pnpm -w dlx tsx watch apps/api/src/index.ts

--- a/dev_dashboard.sh
+++ b/dev_dashboard.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Always run from repo root (supports invocation from subdirs)
+cd "$(dirname "$0")"
+
+log() { printf "\033[1;32m[dev:web]\033[0m %s\n" "$*"; }
+err() { printf "\033[1;31m[dev:web]\033[0m %s\n" "$*" >&2; }
+
+# Move into dashboard app
+cd apps/dashboard
+
+# Confirm port used in vite.config.* (should be 3000 as per PR5/PR6)
+log "Starting Vite dev server on http://localhost:3000"
+log "Proxy is configured so /api/* → http://localhost:8000/compat/*"
+
+# Run Vite dev
+exec pnpm run dev


### PR DESCRIPTION
## Summary
- add dev_api.sh script to load env, ensure DATA_DIR, and run API in watch mode
- add dev_dashboard.sh script to run Vite dev server with proxy
- add apps/api/.env.local.example and README-dev.md for quick setup

## Testing
- `pnpm lint` *(fails: simple-import-sort/imports, prettier/prettier, import/no-unresolved, @typescript-eslint/no-explicit-any)*
- `pnpm test` *(fails: reference errors in test files and Playwright test usage)*

------
https://chatgpt.com/codex/tasks/task_b_68a64c1e48cc832c87e277708871a19d