### PR TITLE
docker: add full-stack compose for API and dashboard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,27 @@
+node / JS noise
+
 node_modules
-dist
-build
-coverage
+npm-debug.log
+pnpm-debug.log
+yarn-error.log
 .vscode
-.idea
+.DS_Store
+
+build outputs
+
+dist
+coverage
+
+local data
+
+data
+
+docker-compose artifacts
+
+*.pid
+*.log
+
+git
+
 .git
-**/.DS_Store
-**/*.log
-**/tmp
-**/.cache
-**/.vite
-**/playwright-report
-**/test-results
+.gitignore

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,8 @@
+# Override defaults for docker-compose if you have real credentials
+
+# API
+TRADOVATE_BASE_URL=https://demo.tradovateapi.com/v1
+TRADOVATE_USERNAME=your_user
+TRADOVATE_PASSWORD=your_pass
+TRADOVATE_CLIENT_ID=your_client_id
+TRADOVATE_CLIENT_SECRET=your_client_secret

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -1,0 +1,42 @@
+# Docker & Compose (Prod-like)
+
+## Prereqs
+- Docker Desktop or Docker Engine
+- (Optional) copy `.env.docker.example` to `.env` and fill in values
+
+## One command up
+```bash
+docker compose up --build
+```
+
+Dashboard: http://localhost:3000
+
+API: http://localhost:8000/health
+
+Data persistence:
+
+API writes to /var/lib/prism-apex-tool inside the container
+
+Mounted to ./data on your host
+
+Common tasks
+
+Rebuild after code changes:
+
+```bash
+docker compose build --no-cache
+docker compose up
+```
+
+Stop & clean:
+
+```bash
+docker compose down
+```
+
+View logs:
+
+```bash
+docker compose logs -f api
+docker compose logs -f dashboard
+```

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,41 +1,46 @@
-# ---- Build (install dev deps to run tsup) ----
+# ---- Build stage ----
 FROM node:20-alpine AS build
+
 WORKDIR /app
+# Enable corepack to use pnpm reliably
+RUN corepack enable
 
-# Workspaces-friendly installs: copy root files first
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml* ./
-# Copy API package manifest to ensure correct hoisting
-COPY apps/api/package.json apps/api/
-# Install only needed dependencies for building
-RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN pnpm install --filter @prism-apex-tool/api... --unsafe-perm
+# Copy only manifests first for better layer caching
+COPY package.json pnpm-lock.yaml ./
+# Include workspace manifests for linking
+COPY apps/api/package.json apps/api/package.json
+COPY packages packages
+COPY apps apps
+COPY sdks sdks
+COPY tests tests
+COPY tsconfig.base.json tsconfig.base.json
 
-# Copy source
-COPY tsconfig.base.json ./
-COPY apps/api ./apps/api
-COPY packages ./packages
+# Install deps for entire workspace (no postinstall scripts)
+RUN pnpm install --frozen-lockfile=false
 
-# Build API
-WORKDIR /app/apps/api
-RUN pnpm run build
+# Build the workspace (types + bundles)
+RUN pnpm -w run build
 
-# ---- Runtime (lean) ----
+# ---- Runtime stage ----
 FROM node:20-alpine AS runtime
-WORKDIR /srv/api
 
+WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=8000
-EXPOSE 8000
-
-# A writable data dir for local state
 ENV DATA_DIR=/var/lib/prism-apex-tool
-RUN mkdir -p ${DATA_DIR}
 
-# Copy built artifacts and prod deps
-COPY --from=build /app/apps/api/dist ./dist
-COPY --from=build /app/apps/api/package.json ./package.json
-# Install production-only deps for runtime
-RUN corepack enable && corepack prepare pnpm@latest --activate \
- && pnpm install --prod --ignore-scripts
+# Minimal runtime deps
+RUN apk add --no-cache curl
 
-CMD ["node", "--enable-source-maps", "dist/index.js"]
+# Copy built dist for API only
+COPY --from=build /app/apps/api/dist ./apps/api/dist
+# Copy package.json to allow "node dist/index.js" and any runtime resolves
+COPY --from=build /app/apps/api/package.json ./apps/api/package.json
+
+# Non-root user (optional hardening)
+RUN addgroup -S app && adduser -S app -G app
+USER app
+
+EXPOSE 8000
+WORKDIR /app/apps/api
+CMD ["node", "dist/index.js"]

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,30 +1,32 @@
-# ---- Build static site ----
+# ---- Build stage ----
 FROM node:20-alpine AS build
+
 WORKDIR /app
+RUN corepack enable
 
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml* ./
-COPY apps/dashboard/package.json apps/dashboard/
-RUN corepack enable && corepack prepare pnpm@latest --activate
-RUN pnpm install --filter prism-apex-dashboard... --unsafe-perm
+# Copy manifests for cache
+COPY package.json pnpm-lock.yaml ./
+COPY apps/dashboard/package.json apps/dashboard/package.json
+COPY apps apps
+COPY packages packages
+COPY sdks sdks
+COPY tests tests
+COPY tsconfig.base.json tsconfig.base.json
 
-# Copy sources needed for dashboard build
-COPY apps/dashboard ./apps/dashboard
-# If UI imports shared packages in the monorepo, include them here too
-COPY packages ./packages
-COPY tsconfig.base.json ./
+# Install deps
+RUN pnpm install --frozen-lockfile=false
 
+# Build dashboard only (avoid building all if desired)
 WORKDIR /app/apps/dashboard
-# Build with base path at /
 RUN pnpm run build
 
-# ---- Nginx runtime ----
-FROM nginx:1.27-alpine
-WORKDIR /usr/share/nginx/html
+# ---- Nginx stage ----
+FROM nginx:1.27-alpine AS runtime
 
-# Static assets
+# Copy static build
 COPY --from=build /app/apps/dashboard/dist /usr/share/nginx/html
 
-# Nginx config (expects an existing nginx.conf in the app)
+# Nginx config to proxy /api -> http://api:8000
 COPY apps/dashboard/nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/apps/dashboard/nginx.conf
+++ b/apps/dashboard/nginx.conf
@@ -2,20 +2,22 @@ server {
   listen 80;
   server_name _;
 
-  # Serve static SPA
   root /usr/share/nginx/html;
   index index.html;
 
-  # Try files for SPA routing
+  # Serve static files
   location / {
     try_files $uri $uri/ /index.html;
   }
 
-  # Simple reverse proxy for local compose to the API service
-  # The dashboard JS should call /api/* paths; nginx proxies them to api:8080
+  # Proxy API calls to the 'api' service in docker-compose
   location /api/ {
-    proxy_pass http://api:8080/;
+    proxy_pass http://api:8000/;
+    proxy_http_version 1.1;
     proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,31 +5,38 @@ services:
     build:
       context: .
       dockerfile: apps/api/Dockerfile
+    container_name: prism-api
     environment:
+      NODE_ENV: production
       PORT: 8000
-      # Provide safe dev defaults; override as needed
       DATA_DIR: /var/lib/prism-apex-tool
-      TRADOVATE_BASE_URL: http://localhost/disabled
-      TRADOVATE_USERNAME: dev
-      TRADOVATE_PASSWORD: dev
-      TRADOVATE_CLIENT_ID: dev
-      TRADOVATE_CLIENT_SECRET: dev
+      # Safe placeholders; override via .env
+      TRADOVATE_BASE_URL: ${TRADOVATE_BASE_URL:-http://localhost/disabled}
+      TRADOVATE_USERNAME: ${TRADOVATE_USERNAME:-dev}
+      TRADOVATE_PASSWORD: ${TRADOVATE_PASSWORD:-dev}
+      TRADOVATE_CLIENT_ID: ${TRADOVATE_CLIENT_ID:-dev}
+      TRADOVATE_CLIENT_SECRET: ${TRADOVATE_CLIENT_SECRET:-dev}
     volumes:
-      - api-data:/var/lib/prism-apex-tool
+      - ./data:/var/lib/prism-apex-tool
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
 
   dashboard:
     build:
       context: .
       dockerfile: apps/dashboard/Dockerfile
-    environment:
-      # Nginx will reverse-proxy to the API via the hostname "api"
-      API_ORIGIN: "http://api:8000"
+    container_name: prism-dashboard
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     ports:
-      - "8080:80"
-
-volumes:
-  api-data:
+      - "3000:80"   # Nginx serves built dashboard on port 80
+    environment:
+      # Nginx uses service DNS name "api" on port 8000; no env needed here.
+      # This is present to allow future templating if required.
+      API_BASE_URL: http://api:8000


### PR DESCRIPTION
## Summary
- add production-style docker-compose for API and dashboard services
- create runtime Dockerfiles for API and dashboard with Nginx proxy
- provide sample env and usage docs for local prod-like run

## Testing
- `pnpm test --run` *(fails: describe is not defined, expect is not defined, playwright test did not expect test() to be called, failed to load url @fastify/cors)*

------
https://chatgpt.com/codex/tasks/task_b_68a65a0e864c832c887e13c01da06dda