### PR TITLE
docs: refine rule engine and tick readiness

### DIFF
--- a/docs/backtest/tick-readiness.md
+++ b/docs/backtest/tick-readiness.md
@@ -9,7 +9,7 @@
 - Queue/latency modeling.
 - Partial fills & order book depth.
 - Realistic slippage tied to spreads & volume.
-- Parquet reader (TODO stub).
+- Parquet reader for high-volume tick data (planned).
 
 ## Usage
 ```bash

--- a/docs/compliance/rule-engine.md
+++ b/docs/compliance/rule-engine.md
@@ -9,6 +9,24 @@ Codify Apex Trader Funding rules into machine-enforceable checks.
 - Returns `{ ok, violations[] }`.
 - Violations feed into the Alerts pipeline.
 
+## Example
+```ts
+import { checkCompliance, AccountState } from '../../apps/api/src/services/rules/engine';
+
+const state: AccountState = {
+  phase: 'evaluation',
+  balance: 50000,
+  equityHigh: 50000,
+  openPositions: [],
+  tradeHistory: [],
+  dayPnL: {},
+  trailingDrawdown: 49000,
+};
+
+const res = checkCompliance(state);
+console.log(res.ok);
+```
+
 ## Rules Covered
 | JSON id | Rule | Apex Reference |
 |---------|------|----------------|
@@ -31,6 +49,6 @@ Codify Apex Trader Funding rules into machine-enforceable checks.
 - Operators see compliance alerts before inputting trades.
 - Violations mean: **do not place ticket**.
 
-## TODO
-- Add complete rule mappings from Apex docs.
-- Add diagrams of compliance flow.
+## Future Work
+- Map remaining Apex rules into `apex/rules.json`.
+- Add a diagram of the compliance flow.


### PR DESCRIPTION
## Summary
- clarify planned parquet support in tick readiness doc
- expand compliance rule engine doc with usage example and future work

## Testing
- `make test` *(fails: No workspaces found --workspace=packages/shared)*

------
https://chatgpt.com/codex/tasks/task_b_68a755d537f0832c8e5c9d67015c2305