### PR TITLE
fix(test+deps): add nodemailer to notify; adjust vitest imports

### DIFF
--- a/apps/api/test/rules/engine.test.ts
+++ b/apps/api/test/rules/engine.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { checkCompliance, AccountState } from '../../src/services/rules/engine';
 
 describe('Compliance Rule Engine', () => {

--- a/packages/clients-tradovate/src/__tests__/auth.spec.ts
+++ b/packages/clients-tradovate/src/__tests__/auth.spec.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TokenManager } from '../auth';
 import { TradovateClientError } from '../types';
 

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -11,5 +11,8 @@
     "lint": "eslint . --ext .ts --max-warnings=0 --no-error-on-unmatched-pattern",
     "test": "vitest",
     "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "nodemailer": "^6.9.11"
   }
 }


### PR DESCRIPTION
## Summary
- add nodemailer dependency for notify package
- switch API rule engine test to Vitest imports
- remove duplicate Vitest import in Tradovate client auth tests

## Testing
- `pnpm -w run test` *(fails: Failed to load url nodemailer, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a8258d655c832c9e7bdeb49e146445