### PR TITLE
fix(api+docs): standardize API default port to 8000 and align deployment docs

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,7 +1,7 @@
-import { buildServer } from './server';
+import { buildServer } from "./server";
 
-const PORT = Number(process.env.PORT || 8080);
-const HOST = process.env.HOST || '0.0.0.0';
+const PORT = Number(process.env.PORT || 8000);
+const HOST = process.env.HOST || "0.0.0.0";
 
 async function main() {
   const app = buildServer();

--- a/infra/README-DEPLOY.md
+++ b/infra/README-DEPLOY.md
@@ -2,7 +2,7 @@
 
 ## Overview
 This stack deploys two containers:
-- **API** on port **8080**
+- **API** on port **8000**
 - **Dashboard** on port **80** (proxies `/api/*` to API via Nginx in the image)
 
 ## One-time Server Setup
@@ -26,7 +26,7 @@ This stack deploys two containers:
 
 ## Verify:
 - <http://<server-ip>/> (dashboard)
-- <http://<server-ip>:8080/health> (API)
+- <http://<server-ip>:8000/health> (API)
 
 ## Rollback
 Re-deploy previous tag:


### PR DESCRIPTION
## Summary
- default API port to 8000 and log host/port
- update deployment docs for 8000

## Testing
- `pnpm -w run typecheck` *(fails: Option 'module' must be set to 'NodeNext' when option 'moduleResolution' is set to 'Node Next')*
- `pnpm --filter @prism-apex-tool/api run build`
- `PORT=8000 node apps/api/dist/index.js` *(fails: Cannot find module 'nodemailer')*

------
https://chatgpt.com/codex/tasks/task_b_68a828182958832c855a1c08f42e7254