### PR TITLE
feat(api): add /health endpoint and graceful shutdown; align compose healthcheck

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,27 @@ const HOST = process.env.HOST || "0.0.0.0";
 
 async function main() {
   const app = buildServer();
+
+  // Stable health endpoint: 200 if the server is up and ready to accept requests.
+  app.get("/health", async (_req, reply) => {
+    // Lightweight payload; avoid leaking env or secrets.
+    return reply.code(200).send({ ok: true, service: "api", port: PORT });
+  });
+
+  // Graceful shutdown on SIGTERM/SIGINT
+  const shutdown = async (signal: string) => {
+    try {
+      app.log.info({ signal }, "Shutting down gracefully…");
+      await app.close(); // Closes server and registered resources/plugins
+      process.exit(0);
+    } catch (err) {
+      app.log.error({ err }, "Error during shutdown");
+      process.exit(1);
+    }
+  };
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+
   try {
     await app.listen({ port: PORT, host: HOST });
     app.log.info(`API listening on ${HOST}:${PORT}`);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "8000:8000"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/ || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 10


### PR DESCRIPTION
## Summary
- add stable /health endpoint for API
- handle SIGTERM/SIGINT for graceful shutdown
- point docker-compose API healthcheck at /health

## Testing
- `pnpm --filter @prism-apex-tool/api run build`


------
https://chatgpt.com/codex/tasks/task_b_68a82b9cdbdc832c859ae3004659bae1