### PR TITLE
feat(api/config): add env guardrails + timeouts + log redaction; use config for host/port

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,0 +1,35 @@
+export type Config = {
+  nodeEnv: "production" | "development" | "test";
+  host: string;
+  port: number;
+  requestTimeoutMs: number;     // total request timeout
+  keepAliveTimeoutMs: number;   // socket keep-alive
+  bodyLimitBytes: number;       // max JSON body size
+};
+
+function parseIntWithDefault(v: string | undefined, def: number): number {
+  const n = v ? Number.parseInt(v, 10) : def;
+  return Number.isFinite(n) ? n : def;
+}
+
+export function getConfig(env = process.env): Config {
+  const nodeEnv = (env.NODE_ENV ?? "production") as Config["nodeEnv"];
+  const port = parseIntWithDefault(env.PORT, 8000);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid PORT value: ${env.PORT}`);
+  }
+  const host = env.HOST ?? "0.0.0.0";
+
+  const requestTimeoutMs = parseIntWithDefault(env.REQUEST_TIMEOUT_MS, 10000);
+  const keepAliveTimeoutMs = parseIntWithDefault(env.KEEP_ALIVE_TIMEOUT_MS, 5000);
+  const bodyLimitBytes = parseIntWithDefault(env.BODY_LIMIT_BYTES, 1048576); // 1 MiB
+
+  return {
+    nodeEnv,
+    host,
+    port,
+    requestTimeoutMs,
+    keepAliveTimeoutMs,
+    bodyLimitBytes,
+  };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,16 +1,10 @@
 import { buildServer } from "./server";
+import { getConfig } from "./config/env";
 
-const PORT = Number(process.env.PORT || 8000);
-const HOST = process.env.HOST || "0.0.0.0";
+const cfg = getConfig();
 
 async function main() {
   const app = buildServer();
-
-  // Stable health endpoint: 200 if the server is up and ready to accept requests.
-  app.get("/health", async (_req, reply) => {
-    // Lightweight payload; avoid leaking env or secrets.
-    return reply.code(200).send({ ok: true, service: "api", port: PORT });
-  });
 
   // Graceful shutdown on SIGTERM/SIGINT
   const shutdown = async (signal: string) => {
@@ -27,8 +21,8 @@ async function main() {
   process.on("SIGINT", () => shutdown("SIGINT"));
 
   try {
-    await app.listen({ port: PORT, host: HOST });
-    app.log.info(`API listening on ${HOST}:${PORT}`);
+    await app.listen({ port: cfg.port, host: cfg.host });
+    app.log.info(`API listening on ${cfg.host}:${cfg.port}`);
   } catch (err) {
     app.log.error(err);
     process.exit(1);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -11,6 +11,7 @@ import { notifyRoutes } from './routes/notify';
 import { jobsRoutes } from './routes/jobs';
 import { openapiRoute } from './routes/openapi';
 import { compatRoutes } from './routes/compat';
+import { getConfig } from './config/env';
 
 import { registerJob, startJobs } from './jobs/scheduler';
 import { jobEodFlat } from './jobs/eodFlat';
@@ -19,7 +20,17 @@ import { jobDailyLoss } from './jobs/dailyLoss';
 import { jobConsistency } from './jobs/consistency';
 
 export function buildServer() {
-  const app = Fastify({ logger: true });
+  const cfg = getConfig();
+  const app = Fastify({
+    logger: {
+      level: process.env.LOG_LEVEL ?? 'info',
+      // redact common secret locations; avoid logging raw auth headers or passwords
+      redact: ['req.headers.authorization', 'headers.authorization', 'password', 'token', 'authorization'],
+    },
+    requestTimeout: cfg.requestTimeoutMs,
+    keepAliveTimeout: cfg.keepAliveTimeoutMs,
+    bodyLimit: cfg.bodyLimitBytes,
+  });
 
   app.register(cors, { origin: true });
 


### PR DESCRIPTION
## Summary
- validate environment and provide defaults for host/port/timeouts/body limit
- apply config to Fastify server with request/keep-alive timeouts and log redaction
- use config when starting server

## Testing
- `pnpm --filter @prism-apex/api run build` *(fails: No projects matched the filters in "/workspace/prism-apex-tool")*
- `pnpm --filter @prism-apex-tool/api run build`
- `TRADOVATE_BASE_URL=http://example.com TRADOVATE_USERNAME=a TRADOVATE_PASSWORD=b TRADOVATE_CLIENT_ID=c TRADOVATE_CLIENT_SECRET=d PORT=8000 REQUEST_TIMEOUT_MS=5000 pnpm --filter @prism-apex-tool/api exec node dist/index.js &`
- `curl -i http://localhost:8000/health`


------
https://chatgpt.com/codex/tasks/task_b_68a82e7f7cdc832cafc81888d0e69c62