### PR TITLE
chore(tsconfig): set module=NodeNext workspace-wide to match moduleResolution and unblock CI

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## Summary
- set `module` to `NodeNext` in the base tsconfig to align with `moduleResolution`

## Testing
- `pnpm -w run typecheck` *(fails: relative import paths and missing modules)*
- `pnpm -w run build` *(fails: allowImportingTsExtensions requires noEmit or emitDeclarationOnly)*
- `pnpm -w run test` *(fails: tsconfig resolution errors and failed tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a83fab0e30832ca45f4257b16fbae5