### PR TITLE
feat(api/tradovate): add mockable Tradovate integration and /compat/tradovate/ping; extend env guardrails

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,10 +1,20 @@
+export type TradovateConfig = {
+  baseUrl?: string;
+  username?: string;
+  password?: string;
+  clientId?: string;
+  clientSecret?: string;
+  mock: boolean;
+};
+
 export type Config = {
   nodeEnv: "production" | "development" | "test";
   host: string;
   port: number;
-  requestTimeoutMs: number;     // total request timeout
-  keepAliveTimeoutMs: number;   // socket keep-alive
-  bodyLimitBytes: number;       // max JSON body size
+  requestTimeoutMs: number;
+  keepAliveTimeoutMs: number;
+  bodyLimitBytes: number;
+  tradovate: TradovateConfig;
 };
 
 function parseIntWithDefault(v: string | undefined, def: number): number {
@@ -24,6 +34,15 @@ export function getConfig(env = process.env): Config {
   const keepAliveTimeoutMs = parseIntWithDefault(env.KEEP_ALIVE_TIMEOUT_MS, 5000);
   const bodyLimitBytes = parseIntWithDefault(env.BODY_LIMIT_BYTES, 1048576); // 1 MiB
 
+  const tradovate: TradovateConfig = {
+    baseUrl: env.TRADOVATE_BASE_URL || undefined,
+    username: env.TRADOVATE_USERNAME || undefined,
+    password: env.TRADOVATE_PASSWORD || undefined,
+    clientId: env.TRADOVATE_CLIENT_ID || undefined,
+    clientSecret: env.TRADOVATE_CLIENT_SECRET || undefined,
+    mock: (env.MOCK_TRADOVATE === "1") || !env.TRADOVATE_BASE_URL
+  };
+
   return {
     nodeEnv,
     host,
@@ -31,5 +50,6 @@ export function getConfig(env = process.env): Config {
     requestTimeoutMs,
     keepAliveTimeoutMs,
     bodyLimitBytes,
+    tradovate
   };
 }

--- a/apps/api/src/routes/tradovate.ts
+++ b/apps/api/src/routes/tradovate.ts
@@ -1,0 +1,19 @@
+import { FastifyPluginAsync } from "fastify";
+import { getConfig } from "../config/env";
+
+const tradovateRoutes: FastifyPluginAsync = async (app) => {
+  const cfg = getConfig();
+
+  app.get("/tradovate/ping", async (_req, reply) => {
+    return reply.code(200).send({
+      ok: true,
+      service: "tradovate",
+      mode: cfg.tradovate.mock ? "mock" : "live"
+    });
+  });
+
+  // NOTE: We'll wire real endpoints (orders/positions/tickets) later.
+  // For now, this stable ping lets CI/local runs verify the integration path.
+};
+
+export default tradovateRoutes;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -11,6 +11,7 @@ import { notifyRoutes } from './routes/notify';
 import { jobsRoutes } from './routes/jobs';
 import { openapiRoute } from './routes/openapi';
 import { compatRoutes } from './routes/compat';
+import tradovateRoutes from './routes/tradovate';
 import { getConfig } from './config/env';
 
 import { registerJob, startJobs } from './jobs/scheduler';
@@ -46,6 +47,7 @@ export function buildServer() {
   app.register(notifyRoutes);
   app.register(jobsRoutes);
   app.register(openapiRoute);
+  app.register(tradovateRoutes, { prefix: '/compat' });
   app.register(compatRoutes, { prefix: '/compat' });
 
   // ---- Jobs ----


### PR DESCRIPTION
## Summary
- extend API env config with Tradovate settings and mock flag
- add Tradovate ping route under /compat
- register Tradovate routes in API server

## Testing
- `pnpm --filter @prism-apex-tool/api run build` *(fails: Could not resolve packages)*
- `curl -fsS "http://127.0.0.1:8123/compat/tradovate/ping"` *(fails: Failed to connect to 127.0.0.1 port 8123)*

------
https://chatgpt.com/codex/tasks/task_b_68a84e9b70f8832c9ae1e9be54ea3905