### PR TITLE
PR-01b: API entrypoint & start (CJS)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
-    "start:prod": "node --enable-source-maps dist/index.js",
+    "start": "node dist/index.js",
     "test": "vitest run --reporter=verbose --passWithNoTests"
   },
   "devDependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,31 +1,17 @@
-import { buildServer } from "./server";
+import Fastify from "fastify";
 
 async function main() {
-  // Hard-bind for Docker reliability
-  const port = Number(process.env.PORT ?? 8000);
-  const host = "0.0.0.0";
+  const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+  const app = Fastify({ logger: true });
 
-  const app = buildServer();
-
-  // Minimal routes
-  app.get("/", async () => ({ ok: true, uptime: process.uptime() }));
-  app.get("/health", async () => ({ status: "ok", time: new Date().toISOString() }));
-
-  // Start
   try {
-    const address = await app.listen({ port, host });
-    const msg = `➡️  API running at ${address}`;
-    app.log?.info?.(msg);
-    console.log("\n" + "=".repeat(60));
-    console.log(msg);
-    console.log("Open this in your browser:");
-    console.log(address);
-    console.log("Health: " + address.replace(/\/$/, "") + "/health");
-    console.log("".padEnd(60, "=") + "\n");
+    await app.listen({ port, host: "0.0.0.0" });
+    app.log.info(`API listening on ${port}`);
   } catch (err) {
-    console.error("❌ Failed to start API:", err);
+    app.log.error(err);
     process.exit(1);
   }
 }
 
-main();
+void main();
+


### PR DESCRIPTION
- Adds standalone Fastify index.ts that boots without importing server/routes
- Ensures package.json has start/dev scripts
- Keeps CJS build; defers routes/tests to PR-01c/PR-03

------
https://chatgpt.com/codex/tasks/task_b_68aae1072744832c9e09ac49569adc62