### PR TITLE
PR-04: Restore core API routes (report/ingest/alerts/notify/export/rules) using local fs store; tests green

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,21 @@ Run tests:
 - API typecheck stabilized; placeholders added where implementations are pending.
 - Packages now include minimal ESLint configs.
 - No jobs/strategies enabled.
+
+## Unquarantine Phase 4
+
+Restored core API routes backed by a local JSON store:
+- `GET /report/daily?date=YYYY-MM-DD`
+- `POST /ingest/alert`
+- `GET /alerts/peek?limit=50`
+- `POST /alerts/ack`
+- `POST /notify/recipients`
+- `GET /export/tickets?date=YYYY-MM-DD`
+- `POST /rules/check`
+
+All persistence uses the filesystem-based store at `apps/api/src/store.ts` and remains local-only.
+External integrations (email, Telegram, Slack, SMS, exchanges) are still disabled.
+
+Run tests:
+- `pnpm --filter ./apps/api typecheck`
+- `pnpm --filter ./apps/api test`

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "@fastify/sensible": "6.0.3",
     "fastify": "5.5.0",
     "fastify-plugin": "5.0.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@prism-apex-tool/reporting": "workspace:*"
   }
 }

--- a/apps/api/src/__tests__/alerts.spec.ts
+++ b/apps/api/src/__tests__/alerts.spec.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server').buildServer;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'alerts-'));
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('Alerts API', () => {
+  it('acks alerts and removes from peek', async () => {
+    const app = buildServer();
+    const payload = { alert: { id: 'a1', ts: '2025-01-01T00:00:00Z', raw: {} }, human: { text: 'hi' } };
+    await app.inject({ method: 'POST', url: '/ingest/alert', payload });
+    const peek1 = await app.inject({ method: 'GET', url: '/alerts/peek' });
+    expect(peek1.json()).toHaveLength(1);
+    const ack = await app.inject({ method: 'POST', url: '/alerts/ack', payload: { id: 'a1' } });
+    expect(ack.statusCode).toBe(200);
+    expect(ack.json()).toEqual({ ok: true });
+    const peek2 = await app.inject({ method: 'GET', url: '/alerts/peek' });
+    expect(peek2.json()).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/export.spec.ts
+++ b/apps/api/src/__tests__/export.spec.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server').buildServer;
+let store: typeof import('../store').store;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'export-'));
+  ({ buildServer } = await import('../server.js'));
+  ({ store } = await import('../store.js'));
+});
+
+describe('Export API', () => {
+  it('returns CSV for tickets', async () => {
+    store.appendTicket({ when: '2025-01-01T00:00:00Z', ticket: { id: '1', symbol: 'ES', side: 'BUY', qty: 1, entry: 1, stop: 0, targets: [] }, reasons: [] });
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/export/tickets?date=2025-01-01' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/csv');
+    expect(res.body.split('\n')[0]).toContain('symbol');
+  });
+});

--- a/apps/api/src/__tests__/ingest.spec.ts
+++ b/apps/api/src/__tests__/ingest.spec.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server').buildServer;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'ingest-'));
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('Ingest API', () => {
+  it('stores alert and exposes via peek', async () => {
+    const app = buildServer();
+    const payload = { alert: { id: '1', ts: '2025-01-01T00:00:00Z', raw: {} }, human: { text: 'hi' } };
+    const post = await app.inject({ method: 'POST', url: '/ingest/alert', payload });
+    expect(post.statusCode).toBe(200);
+    const peek = await app.inject({ method: 'GET', url: '/alerts/peek?limit=10' });
+    expect(peek.statusCode).toBe(200);
+    const arr = peek.json();
+    expect(arr[0]?.id).toBe('1');
+  });
+});

--- a/apps/api/src/__tests__/notify.spec.ts
+++ b/apps/api/src/__tests__/notify.spec.ts
@@ -1,85 +1,26 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-let buildServer: typeof import('../server.js').buildServer;
-let store: typeof import('../store.js').store;
+let buildServer: typeof import('../server').buildServer;
 
 beforeEach(async () => {
-  // Isolate store data per test
   process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-'));
   ({ buildServer } = await import('../server.js'));
-  ({ store } = await import('../store.js'));
-
-  // Force dry-run by clearing env
-  delete process.env.SMTP_HOST;
-  delete process.env.SMTP_PORT;
-  delete process.env.SMTP_USER;
-  delete process.env.SMTP_PASS;
-  process.env.SMTP_FROM = 'test@example.com';
-
-  delete process.env.TELEGRAM_BOT_TOKEN;
-  delete process.env.SLACK_BOT_TOKEN;
-  delete process.env.TWILIO_SID;
-  delete process.env.TWILIO_TOKEN;
-  delete process.env.TWILIO_FROM;
-
-  // Satisfy Tradovate client env requirements
-  process.env.TRADOVATE_BASE_URL = 'http://localhost';
-  process.env.TRADOVATE_USERNAME = 'u';
-  process.env.TRADOVATE_PASSWORD = 'p';
-  process.env.TRADOVATE_CLIENT_ID = 'cid';
-  process.env.TRADOVATE_CLIENT_SECRET = 'csec';
-
-  vi.useRealTimers();
-  // Seed recipients (including Slack)
-  store.addRecipients({
-    email: ['ops@example.com'],
-    telegram: ['123456789'],
-    slack: ['C0123456'],
-    sms: ['+15555550100'],
-  });
-
-  // Mock fetch for Telegram/Slack/Twilio if env were present
-  (globalThis as any).fetch = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ ok: true }), text: async () => 'ok' }));
 });
 
-describe.skip('Notification API', () => {
-  it('registers recipients (incl. Slack) and sends a dry-run test', async () => {
+describe('Notify API', () => {
+  it('merges recipients with de-duplication', async () => {
     const app = buildServer();
-
-    const reg = await app.inject({
+    const res = await app.inject({
       method: 'POST',
-      url: '/notify/register',
-      payload: { email: ['team@example.com'], telegramChatId: '555', slackChannelId: 'C999', smsNumber: '+15555550123' },
+      url: '/notify/recipients',
+      payload: { email: ['a@example.com', 'a@example.com'], telegram: ['1', '1'] },
     });
-    expect(reg.statusCode).toBe(200);
-    const rj = reg.json();
-    expect(rj.recipients.email).toContain('team@example.com');
-    expect(rj.recipients.telegram).toContain('555');
-    expect(rj.recipients.slack).toContain('C999');
-    expect(rj.recipients.sms).toContain('+15555550123');
-
-    const testn = await app.inject({
-      method: 'POST',
-      url: '/notify/test',
-      payload: { message: 'Hello', level: 'INFO', tags: ['UNIT'] },
-    });
-    expect(testn.statusCode).toBe(200);
-    const transports = (testn.json().results as any[]).map(x => x.transport).join(',');
-    expect(transports).toMatch(/email-dry-run/);
-    expect(transports).toMatch(/telegram-dry-run/);
-    expect(transports).toMatch(/slack-dry-run/);
-  });
-
-  it('rate-limits repeated keys', async () => {
-    const app = buildServer();
-    const first = await app.inject({ method: 'POST', url: '/notify/test', payload: { message: 'Once', level: 'WARN' } });
-    const second = await app.inject({ method: 'POST', url: '/notify/test', payload: { message: 'Twice', level: 'WARN' } });
-    expect(first.statusCode).toBe(200);
-    expect(second.statusCode).toBe(200);
-    const transports2 = (second.json().results as any[]).map(x => x.transport).join(',');
-    expect(transports2).toContain('suppressed');
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.email).toEqual(['a@example.com']);
+    expect(body.telegram).toEqual(['1']);
   });
 });

--- a/apps/api/src/__tests__/report.spec.ts
+++ b/apps/api/src/__tests__/report.spec.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server').buildServer;
+let store: typeof import('../store').store;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'report-'));
+  ({ buildServer } = await import('../server.js'));
+  ({ store } = await import('../store.js'));
+});
+
+describe('Report API', () => {
+  it('returns daily report summary', async () => {
+    store.appendTicket({ when: '2025-01-01T00:00:00Z', ticket: { id: '1' }, reasons: [] });
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/report/daily?date=2025-01-01' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toMatchObject({ date: '2025-01-01', trades: 1, blocked: 0 });
+  });
+});

--- a/apps/api/src/__tests__/rules.spec.ts
+++ b/apps/api/src/__tests__/rules.spec.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server').buildServer;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'rules-'));
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('Rules API', () => {
+  it('evaluates account state compliance', async () => {
+    const app = buildServer();
+    const state = {
+      phase: 'funded',
+      balance: 10000,
+      equityHigh: 10000,
+      openPositions: [{ contracts: 1 }],
+      tradeHistory: [],
+      dayPnL: {},
+      trailingDrawdown: 6000,
+    };
+    const res = await app.inject({ method: 'POST', url: '/rules/check', payload: state });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ok).toBe(false);
+    expect(body.violations.some((v: any) => v.id === 'funded-stoploss')).toBe(true);
+  });
+});

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -1,9 +1,9 @@
-import type { FastifyInstance } from 'fastify';
-import { store } from '../store';
+import { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
+import { store } from '../store';
 
-export async function alertsRoutes(app: FastifyInstance) {
-  app.get('/alerts/queue', async (req, reply) => {
+export const alertsRoutes: FastifyPluginAsync = async (app) => {
+  app.get('/alerts/peek', async (req, reply) => {
     const q = z.object({ limit: z.coerce.number().min(1).max(200).default(50) }).safeParse(req.query);
     if (!q.success) return reply.code(400).send({ error: 'Invalid query' });
     return store.peekAlerts(q.data.limit);
@@ -16,4 +16,6 @@ export async function alertsRoutes(app: FastifyInstance) {
     if (!ok) return reply.code(404).send({ error: 'Not found' });
     return { ok: true };
   });
-}
+};
+
+export default alertsRoutes;

--- a/apps/api/src/routes/export.ts
+++ b/apps/api/src/routes/export.ts
@@ -1,12 +1,76 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { store } from '../store';
 
 export const exportRoutes: FastifyPluginAsync = async (app) => {
-  app.get("/export/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "export", mode: "disabled" });
-  });
+  let reporting: any;
+  try {
+    reporting = await import('@prism-apex-tool/reporting');
+  } catch {}
 
-  app.all("/export/*", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "export-disabled" });
+  app.get('/export/tickets', async (req, reply) => {
+    const q = z
+      .object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) })
+      .safeParse(req.query);
+    if (!q.success) return reply.code(400).send({ error: 'Invalid date' });
+
+    const tickets = store.getTicketsForDate(q.data.date);
+    const alerts = store.getAlertsForDate(q.data.date);
+    let csv: string;
+
+    if (reporting && 'toDailyCSV' in reporting) {
+      const rows = tickets.map(t => ({
+        when: t.when,
+        symbol: (t.ticket as any).symbol ?? '',
+        side: (t.ticket as any).side ?? '',
+        qty: Number((t.ticket as any).qty ?? 0),
+        entry: Number((t.ticket as any).entry ?? 0),
+        stop: Number((t.ticket as any).stop ?? 0),
+        targets: ((t.ticket as any).targets as number[] | undefined) ?? [],
+        apex_blocked: (t.ticket as any).apex_blocked ?? false,
+        reasons: t.reasons,
+      }));
+      csv = reporting.toDailyCSV({
+        summary: {
+          date: q.data.date,
+          ticketsCount: rows.length,
+          blockedCount: rows.filter(r => r.apex_blocked || r.reasons.length > 0).length,
+          alertsAcked: alerts.filter(a => a.acknowledged).length,
+          alertsQueued: alerts.filter(a => !a.acknowledged).length,
+          pnl: { realized: 0, unrealized: 0, netLiq: 0 },
+        },
+        tickets: rows,
+        alerts: alerts.map(a => ({
+          id: a.id,
+          ts: a.ts,
+          symbol: a.symbol,
+          side: a.side,
+          price: a.price,
+          reason: a.reason,
+          acknowledged: a.acknowledged,
+        })),
+        breaches: [],
+      });
+    } else {
+      const header = 'id,ts,symbol,side,price,reason,reasons';
+      const lines = [header];
+      for (const t of tickets) {
+        const ticket: any = t.ticket;
+        lines.push([
+          ticket.id,
+          t.when,
+          ticket.symbol ?? '',
+          ticket.side ?? '',
+          ticket.price ?? '',
+          ticket.reason ?? '',
+          t.reasons.join('|'),
+        ].join(','));
+      }
+      csv = lines.join('\n');
+    }
+
+    reply.header('Content-Type', 'text/csv');
+    return reply.send(csv);
   });
 };
 

--- a/apps/api/src/routes/ingest.ts
+++ b/apps/api/src/routes/ingest.ts
@@ -1,12 +1,14 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { parseResultSchema } from '../schemas/alert';
+import { store } from '../store';
+import type { ParseResult } from '../types';
 
 export const ingestRoutes: FastifyPluginAsync = async (app) => {
-  app.get("/ingest/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "ingest", mode: "disabled" });
-  });
-
-  app.all("/ingest/*", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "ingest-disabled" });
+  app.post('/ingest/alert', async (req, reply) => {
+    const body = parseResultSchema.safeParse(req.body);
+    if (!body.success) return reply.code(400).send({ error: 'Invalid alert' });
+    const stored = store.enqueueAlert(body.data as ParseResult);
+    return stored;
   });
 };
 

--- a/apps/api/src/routes/notify.ts
+++ b/apps/api/src/routes/notify.ts
@@ -1,14 +1,13 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { recipientsSchema } from '../schemas/recipients';
+import { store } from '../store';
 
 export const notifyRoutes: FastifyPluginAsync = async (app) => {
-  // Simple ping so we can confirm the plugin is mounted
-  app.get("/notify/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "notify", mode: "disabled" });
-  });
-
-  // Placeholder for email notifications — disabled after cleanup
-  app.post("/notify/email", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "notify-disabled" });
+  app.post('/notify/recipients', async (req, reply) => {
+    const body = recipientsSchema.safeParse(req.body);
+    if (!body.success) return reply.code(400).send({ error: 'Invalid payload' });
+    const recipients = store.addRecipients(body.data as any);
+    return recipients;
   });
 };
 

--- a/apps/api/src/routes/report.ts
+++ b/apps/api/src/routes/report.ts
@@ -1,14 +1,15 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { store } from '../store';
 
 export const reportRoutes: FastifyPluginAsync = async (app) => {
-  // Simple ping so we can confirm the plugin is mounted
-  app.get("/report/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "report", mode: "disabled" });
-  });
-
-  // Placeholder for export/report operations — disabled after cleanup
-  app.all("/report/*", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "reporting-disabled" });
+  app.get('/report/daily', async (req, reply) => {
+    const q = z
+      .object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) })
+      .safeParse(req.query);
+    if (!q.success) return reply.code(400).send({ error: 'Invalid date' });
+    const report = store.buildDailyReport(q.data.date);
+    return report;
   });
 };
 

--- a/apps/api/src/routes/rules.ts
+++ b/apps/api/src/routes/rules.ts
@@ -1,12 +1,13 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { accountStateSchema } from '../schemas/accountState';
+import { checkCompliance } from '../services/rules/engine';
 
 export const rulesRoutes: FastifyPluginAsync = async (app) => {
-  app.get("/rules/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "rules", mode: "disabled" });
-  });
-
-  app.all("/rules/*", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "rules-disabled" });
+  app.post('/rules/check', async (req, reply) => {
+    const body = accountStateSchema.safeParse(req.body);
+    if (!body.success) return reply.code(400).send({ error: 'Invalid state' });
+    const result = checkCompliance(body.data as any);
+    return result;
   });
 };
 

--- a/apps/api/src/schemas/accountState.ts
+++ b/apps/api/src/schemas/accountState.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const positionSchema = z.object({
+  contracts: z.number(),
+  stopLoss: z.number().optional(),
+});
+
+export const tradeSchema = z.object({
+  contracts: z.number(),
+  stopLoss: z.number().optional(),
+  day: z.string(),
+  profit: z.number(),
+});
+
+export const accountStateSchema = z.object({
+  phase: z.enum(['evaluation','funded','payout']),
+  balance: z.number(),
+  equityHigh: z.number(),
+  openPositions: z.array(positionSchema),
+  tradeHistory: z.array(tradeSchema),
+  dayPnL: z.record(z.number()),
+  trailingDrawdown: z.number(),
+  isEndOfDay: z.boolean().optional(),
+  resetsUsed: z.number().optional(),
+  tradingDuringNews: z.boolean().optional(),
+  payoutHistory: z.array(z.string()).optional(),
+  payoutRequestPct: z.number().optional(),
+});
+
+export type AccountState = z.infer<typeof accountStateSchema>;

--- a/apps/api/src/schemas/alert.ts
+++ b/apps/api/src/schemas/alert.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const alertSchema = z.object({
+  id: z.string(),
+  ts: z.string(),
+  symbol: z.string().optional(),
+  side: z.enum(['BUY','SELL']).optional(),
+  price: z.number().optional(),
+  reason: z.string().optional(),
+  raw: z.unknown(),
+});
+
+export const parseResultSchema = z.object({
+  alert: alertSchema,
+  human: z.object({ text: z.string() }),
+});
+
+export const alertEntrySchema = alertSchema.extend({
+  human: z.string(),
+  acknowledged: z.boolean(),
+  hash: z.string(),
+});
+
+export type AlertParseResult = z.infer<typeof parseResultSchema>;
+export type AlertEntry = z.infer<typeof alertEntrySchema>;

--- a/apps/api/src/schemas/recipients.ts
+++ b/apps/api/src/schemas/recipients.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const recipientsSchema = z.object({
+  email: z.array(z.string()).optional(),
+  telegram: z.array(z.string()).optional(),
+  slack: z.array(z.string()).optional(),
+  sms: z.array(z.string()).optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+export const recipientsResultSchema = z.object({
+  email: z.array(z.string()),
+  telegram: z.array(z.string()),
+  slack: z.array(z.string()),
+  sms: z.array(z.string()),
+  tags: z.array(z.string()).optional(),
+});
+
+export type RecipientsInput = z.infer<typeof recipientsSchema>;
+export type Recipients = z.infer<typeof recipientsResultSchema>;

--- a/apps/api/src/schemas/ticket.ts
+++ b/apps/api/src/schemas/ticket.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const ticketSchema = z.object({
+  id: z.string(),
+  ts: z.string().optional(),
+  symbol: z.string().optional(),
+  side: z.string().optional(),
+  qty: z.number().optional(),
+  entry: z.number().optional(),
+  stop: z.number().optional(),
+  targets: z.array(z.number()).optional(),
+  apex_blocked: z.boolean().optional(),
+  reasons: z.array(z.string()).optional(),
+});
+
+export const ticketEntrySchema = z.object({
+  when: z.string(),
+  ticket: ticketSchema,
+  reasons: z.array(z.string()),
+});
+
+export type Ticket = z.infer<typeof ticketSchema>;
+export type TicketEntry = z.infer<typeof ticketEntrySchema>;

--- a/apps/api/src/types/reporting.d.ts
+++ b/apps/api/src/types/reporting.d.ts
@@ -1,0 +1,3 @@
+declare module '@prism-apex-tool/reporting' {
+  export function toDailyCSV(input: any): string;
+}


### PR DESCRIPTION
## Summary
- restore report, ingest, alerts, notify, export and rules API routes with zod validation and fs-based persistence
- add DTO schemas, ambient reporting module stub and full smoke tests
- document restored endpoints and note local-only store

## Inventory & Plan
| Archived Python | TypeScript destination |
| --- | --- |
| archive/2025-08-22/api/accounts.py | deferred |
| archive/2025-08-22/api/copytrader.py | deferred |
| archive/2025-08-22/api/dashboard.py | apps/api/src/routes/report.ts |
| archive/2025-08-22/api/jobs_multi.py | deferred |
| archive/2025-08-22/api/jobs_scheduler.py | deferred |
| archive/2025-08-22/api/panic.py | deferred |
| archive/2025-08-22/api/rules_cross.py | apps/api/src/routes/rules.ts |
| archive/2025-08-22/api/strategy_switch.py | deferred |

## Testing
- `pnpm --filter ./apps/api typecheck`
- `pnpm --filter ./apps/api test`


------
https://chatgpt.com/codex/tasks/task_b_68ab22bb1fa4832c907179fe84126587