### PR TITLE
PR-04R: Reapply core API routes (report/ingest/alerts/notify/export/rules) using local fs store; tests green

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ Run tests:
 - Packages now include minimal ESLint configs.
 - No jobs/strategies enabled.
 
+## Unquarantine Phase 4
+
+Restored:
+- Local filesystem-backed API routes:
+  - `GET /report/daily?date=YYYY-MM-DD`
+  - `POST /ingest/alert`
+  - `GET /alerts/peek?limit=50`
+  - `POST /alerts/ack`
+  - `POST /notify/recipients`
+  - `GET /export/tickets?date=YYYY-MM-DD`
+  - `POST /rules/check`
+- All persistence remains local-only under `DATA_DIR`.
+
+Run tests:
+- `pnpm --filter ./apps/api typecheck`
+- `pnpm --filter ./apps/api test`
+
 ## Unquarantine Phase 5
 
 - Restored in-process scheduler with deterministic, safe jobs.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "@fastify/sensible": "6.0.3",
     "fastify": "5.5.0",
     "fastify-plugin": "5.0.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@prism-apex-tool/reporting": "workspace:*"
   }
 }

--- a/apps/api/src/__tests__/alerts.spec.ts
+++ b/apps/api/src/__tests__/alerts.spec.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'alerts-'));
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('Alerts API', () => {
+  it('peeks and acknowledges alerts', async () => {
+    const app = buildServer();
+    await app.inject({
+      method: 'POST',
+      url: '/ingest/alert',
+      payload: { alert: { id: 'a1', ts: '2024-08-24T00:00:00Z', raw: {} }, human: { text: 'hi' } },
+    });
+    const peek = await app.inject({ method: 'GET', url: '/alerts/peek?limit=5' });
+    expect(peek.statusCode).toBe(200);
+    expect(peek.json()).toHaveLength(1);
+    const ack = await app.inject({ method: 'POST', url: '/alerts/ack', payload: { id: 'a1' } });
+    expect(ack.statusCode).toBe(200);
+    const peek2 = await app.inject({ method: 'GET', url: '/alerts/peek?limit=5' });
+    expect(peek2.json()).toHaveLength(0);
+  });
+});

--- a/apps/api/src/__tests__/export.spec.ts
+++ b/apps/api/src/__tests__/export.spec.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server.js').buildServer;
+let store: typeof import('../store.js').store;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'export-'));
+  ({ buildServer } = await import('../server.js'));
+  ({ store } = await import('../store.js'));
+});
+
+describe('Export API', () => {
+  it('exports tickets as CSV', async () => {
+    store.appendTicket({
+      when: '2024-08-24T12:00:00Z',
+      ticket: {
+        id: 't1',
+        symbol: 'ES',
+        side: 'BUY',
+        qty: 1,
+        entry: 1,
+        stop: 0,
+        targets: [2],
+      } as any,
+      reasons: [],
+    });
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/export/tickets?date=2024-08-24' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/csv');
+    expect(res.body).toContain('symbol');
+    expect(res.body).toContain('ES');
+  });
+});

--- a/apps/api/src/__tests__/ingest.spec.ts
+++ b/apps/api/src/__tests__/ingest.spec.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server.js').buildServer;
+let store: typeof import('../store.js').store;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'ingest-'));
+  ({ buildServer } = await import('../server.js'));
+  ({ store } = await import('../store.js'));
+});
+
+describe('Ingest API', () => {
+  it('queues alerts', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/ingest/alert',
+      payload: { alert: { id: 'a1', ts: '2024-08-24T00:00:00Z', raw: {} }, human: { text: 'hi' } },
+    });
+    expect(res.statusCode).toBe(200);
+    const q = store.peekAlerts(10);
+    expect(q[0]?.id).toBe('a1');
+  });
+});

--- a/apps/api/src/__tests__/notify.spec.ts
+++ b/apps/api/src/__tests__/notify.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,79 +7,25 @@ let buildServer: typeof import('../server.js').buildServer;
 let store: typeof import('../store.js').store;
 
 beforeEach(async () => {
-  // Isolate store data per test
   process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'notify-'));
   ({ buildServer } = await import('../server.js'));
   ({ store } = await import('../store.js'));
-
-  // Force dry-run by clearing env
-  delete process.env.SMTP_HOST;
-  delete process.env.SMTP_PORT;
-  delete process.env.SMTP_USER;
-  delete process.env.SMTP_PASS;
-  process.env.SMTP_FROM = 'test@example.com';
-
-  delete process.env.TELEGRAM_BOT_TOKEN;
-  delete process.env.SLACK_BOT_TOKEN;
-  delete process.env.TWILIO_SID;
-  delete process.env.TWILIO_TOKEN;
-  delete process.env.TWILIO_FROM;
-
-  // Satisfy Tradovate client env requirements
-  process.env.TRADOVATE_BASE_URL = 'http://localhost';
-  process.env.TRADOVATE_USERNAME = 'u';
-  process.env.TRADOVATE_PASSWORD = 'p';
-  process.env.TRADOVATE_CLIENT_ID = 'cid';
-  process.env.TRADOVATE_CLIENT_SECRET = 'csec';
-
-  vi.useRealTimers();
-  // Seed recipients (including Slack)
-  store.addRecipients({
-    email: ['ops@example.com'],
-    telegram: ['123456789'],
-    slack: ['C0123456'],
-    sms: ['+15555550100'],
-  });
-
-  // Mock fetch for Telegram/Slack/Twilio if env were present
-  (globalThis as any).fetch = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ ok: true }), text: async () => 'ok' }));
 });
 
-describe.skip('Notification API', () => {
-  it('registers recipients (incl. Slack) and sends a dry-run test', async () => {
+describe('Notify API', () => {
+  it('registers recipients', async () => {
     const app = buildServer();
-
-    const reg = await app.inject({
+    const res = await app.inject({
       method: 'POST',
-      url: '/notify/register',
-      payload: { email: ['team@example.com'], telegramChatId: '555', slackChannelId: 'C999', smsNumber: '+15555550123' },
+      url: '/notify/recipients',
+      payload: { email: ['team@example.com'], sms: ['+15555550123'] },
     });
-    expect(reg.statusCode).toBe(200);
-    const rj = reg.json();
-    expect(rj.recipients.email).toContain('team@example.com');
-    expect(rj.recipients.telegram).toContain('555');
-    expect(rj.recipients.slack).toContain('C999');
-    expect(rj.recipients.sms).toContain('+15555550123');
-
-    const testn = await app.inject({
-      method: 'POST',
-      url: '/notify/test',
-      payload: { message: 'Hello', level: 'INFO', tags: ['UNIT'] },
-    });
-    expect(testn.statusCode).toBe(200);
-    const transports = (testn.json().results as any[]).map(x => x.transport).join(',');
-    expect(transports).toMatch(/email-dry-run/);
-    expect(transports).toMatch(/telegram-dry-run/);
-    expect(transports).toMatch(/slack-dry-run/);
-  });
-
-  it('rate-limits repeated keys', async () => {
-    const app = buildServer();
-    const first = await app.inject({ method: 'POST', url: '/notify/test', payload: { message: 'Once', level: 'WARN' } });
-    const second = await app.inject({ method: 'POST', url: '/notify/test', payload: { message: 'Twice', level: 'WARN' } });
-    expect(first.statusCode).toBe(200);
-    expect(second.statusCode).toBe(200);
-    const transports2 = (second.json().results as any[]).map(x => x.transport).join(',');
-    expect(transports2).toContain('suppressed');
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.recipients.email).toContain('team@example.com');
+    expect(body.recipients.sms).toContain('+15555550123');
+    // ensure store updated
+    const recipients = store.getRecipients();
+    expect(recipients.email).toContain('team@example.com');
   });
 });

--- a/apps/api/src/__tests__/report.spec.ts
+++ b/apps/api/src/__tests__/report.spec.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server.js').buildServer;
+let store: typeof import('../store.js').store;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'report-'));
+  ({ buildServer } = await import('../server.js'));
+  ({ store } = await import('../store.js'));
+});
+
+describe('Report API', () => {
+  it('builds daily report', async () => {
+    store.appendTicket({
+      when: '2024-08-24T10:00:00Z',
+      ticket: { id: 't1' } as any,
+      reasons: [],
+    });
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/report/daily?date=2024-08-24' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.date).toBe('2024-08-24');
+    expect(body.trades).toBe(1);
+  });
+});

--- a/apps/api/src/__tests__/rules.spec.ts
+++ b/apps/api/src/__tests__/rules.spec.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'rules-'));
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('Rules API', () => {
+  it('evaluates account state', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/rules/check',
+      payload: {
+        phase: 'evaluation',
+        balance: 50000,
+        equityHigh: 50000,
+        openPositions: [{ contracts: 1 }],
+        tradeHistory: [],
+        dayPnL: {},
+        trailingDrawdown: 1000,
+        isEndOfDay: true,
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ok).toBe(false);
+    expect(body.violations.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -3,8 +3,10 @@ import { store } from '../store';
 import { z } from 'zod';
 
 export async function alertsRoutes(app: FastifyInstance) {
-  app.get('/alerts/queue', async (req, reply) => {
-    const q = z.object({ limit: z.coerce.number().min(1).max(200).default(50) }).safeParse(req.query);
+  app.get('/alerts/peek', async (req, reply) => {
+    const q = z
+      .object({ limit: z.coerce.number().min(1).max(200).default(50) })
+      .safeParse(req.query);
     if (!q.success) return reply.code(400).send({ error: 'Invalid query' });
     return store.peekAlerts(q.data.limit);
   });

--- a/apps/api/src/routes/export.ts
+++ b/apps/api/src/routes/export.ts
@@ -1,12 +1,70 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { store } from '../store';
+import { z } from 'zod';
 
 export const exportRoutes: FastifyPluginAsync = async (app) => {
-  app.get("/export/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "export", mode: "disabled" });
-  });
-
-  app.all("/export/*", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "export-disabled" });
+  app.get('/export/tickets', async (req, reply) => {
+    const q = z
+      .object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) })
+      .safeParse(req.query);
+    if (!q.success) return reply.code(400).send({ error: 'Invalid date' });
+    const date = q.data.date;
+    const ticketsRaw = store.getTicketsForDate(date);
+    const tickets = ticketsRaw.map((t) => ({
+      when: t.when,
+      symbol: (t.ticket as any).symbol,
+      side: (t.ticket as any).side,
+      qty: (t.ticket as any).qty,
+      entry: (t.ticket as any).entry,
+      stop: (t.ticket as any).stop,
+      targets: ((t.ticket as any).targets ?? []) as number[],
+      apex_blocked: t.reasons.length > 0,
+      reasons: t.reasons,
+    }));
+    const alerts = store.getAlertsForDate(date).map((a) => ({
+      id: a.id,
+      ts: a.ts,
+      symbol: a.symbol,
+      side: a.side,
+      price: a.price,
+      reason: a.reason,
+      acknowledged: a.acknowledged,
+    }));
+    const summary = {
+      date,
+      ticketsCount: tickets.length,
+      blockedCount: tickets.filter((t) => t.apex_blocked).length,
+      alertsAcked: alerts.filter((a) => a.acknowledged).length,
+      alertsQueued: alerts.filter((a) => !a.acknowledged).length,
+      pnl: { realized: 0, unrealized: 0, netLiq: 0 },
+    };
+    const json = { summary, tickets, alerts, breaches: [] };
+    let csv: string;
+    try {
+      const mod = await import('@prism-apex-tool/reporting');
+      csv = mod.toDailyCSV(json as any);
+    } catch {
+      const header = 'date,time,symbol,side,qty,entry,stop,targets,apex_blocked,reasons';
+      const rows = tickets.map((t) => {
+        const d = new Date(t.when);
+        const dateStr = d.toISOString().slice(0, 10);
+        const timeStr = d.toISOString().slice(11, 19);
+        return [
+          dateStr,
+          timeStr,
+          t.symbol,
+          t.side,
+          String(t.qty),
+          String(t.entry),
+          String(t.stop),
+          t.targets.join('|'),
+          String(t.apex_blocked),
+          t.reasons.join(' | '),
+        ].join(',');
+      });
+      csv = [header, ...rows].join('\n');
+    }
+    return reply.type('text/csv').send(csv);
   });
 };
 

--- a/apps/api/src/routes/ingest.ts
+++ b/apps/api/src/routes/ingest.ts
@@ -1,12 +1,13 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { store } from '../store';
+import { alertSchema } from '../schemas/alert';
 
 export const ingestRoutes: FastifyPluginAsync = async (app) => {
-  app.get("/ingest/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "ingest", mode: "disabled" });
-  });
-
-  app.all("/ingest/*", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "ingest-disabled" });
+  app.post('/ingest/alert', async (req, reply) => {
+    const p = alertSchema.safeParse(req.body);
+    if (!p.success) return reply.code(400).send({ error: 'Invalid payload' });
+    const entry = store.enqueueAlert(p.data as any);
+    return { ok: true, alert: entry };
   });
 };
 

--- a/apps/api/src/routes/notify.ts
+++ b/apps/api/src/routes/notify.ts
@@ -1,14 +1,13 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { store } from '../store';
+import { recipientsSchema } from '../schemas/recipients';
 
 export const notifyRoutes: FastifyPluginAsync = async (app) => {
-  // Simple ping so we can confirm the plugin is mounted
-  app.get("/notify/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "notify", mode: "disabled" });
-  });
-
-  // Placeholder for email notifications — disabled after cleanup
-  app.post("/notify/email", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "notify-disabled" });
+  app.post('/notify/recipients', async (req, reply) => {
+    const p = recipientsSchema.safeParse(req.body);
+    if (!p.success) return reply.code(400).send({ error: 'Invalid payload' });
+    const r = store.addRecipients(p.data as any);
+    return { ok: true, recipients: r };
   });
 };
 

--- a/apps/api/src/routes/report.ts
+++ b/apps/api/src/routes/report.ts
@@ -1,14 +1,15 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { store } from '../store';
 
 export const reportRoutes: FastifyPluginAsync = async (app) => {
-  // Simple ping so we can confirm the plugin is mounted
-  app.get("/report/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "report", mode: "disabled" });
-  });
-
-  // Placeholder for export/report operations — disabled after cleanup
-  app.all("/report/*", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "reporting-disabled" });
+  app.get('/report/daily', async (req, reply) => {
+    const q = z
+      .object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) })
+      .safeParse(req.query);
+    if (!q.success) return reply.code(400).send({ error: 'Invalid date' });
+    const report = store.buildDailyReport(q.data.date);
+    return report;
   });
 };
 

--- a/apps/api/src/routes/rules.ts
+++ b/apps/api/src/routes/rules.ts
@@ -1,12 +1,12 @@
-import { FastifyPluginAsync } from "fastify";
+import { FastifyPluginAsync } from 'fastify';
+import { checkCompliance } from '../services/rules/engine';
+import { accountStateSchema } from '../schemas/accountState';
 
 export const rulesRoutes: FastifyPluginAsync = async (app) => {
-  app.get("/rules/ping", async (_req, reply) => {
-    return reply.code(200).send({ ok: true, service: "rules", mode: "disabled" });
-  });
-
-  app.all("/rules/*", async (_req, reply) => {
-    return reply.code(501).send({ ok: false, reason: "rules-disabled" });
+  app.post('/rules/check', async (req, reply) => {
+    const p = accountStateSchema.safeParse(req.body);
+    if (!p.success) return reply.code(400).send({ error: 'Invalid payload' });
+    return checkCompliance(p.data as any);
   });
 };
 

--- a/apps/api/src/schemas/accountState.ts
+++ b/apps/api/src/schemas/accountState.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const accountStateSchema = z.object({
+  phase: z.enum(['evaluation', 'funded', 'payout']),
+  balance: z.number(),
+  equityHigh: z.number(),
+  openPositions: z.array(
+    z.object({
+      contracts: z.number(),
+      stopLoss: z.number().optional(),
+    })
+  ),
+  tradeHistory: z.array(
+    z.object({
+      contracts: z.number(),
+      stopLoss: z.number().optional(),
+      day: z.string(),
+      profit: z.number(),
+    })
+  ),
+  dayPnL: z.record(z.number()),
+  trailingDrawdown: z.number(),
+  isEndOfDay: z.boolean().optional(),
+  resetsUsed: z.number().optional(),
+  tradingDuringNews: z.boolean().optional(),
+  payoutHistory: z.array(z.string()).optional(),
+  payoutRequestPct: z.number().optional(),
+});
+
+export type AccountStatePayload = z.infer<typeof accountStateSchema>;

--- a/apps/api/src/schemas/alert.ts
+++ b/apps/api/src/schemas/alert.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const alertSchema = z.object({
+  alert: z.object({
+    id: z.string(),
+    ts: z.string(),
+    symbol: z.string().optional(),
+    side: z.enum(['BUY', 'SELL']).optional(),
+    price: z.number().optional(),
+    reason: z.string().optional(),
+    raw: z.unknown(),
+  }),
+  human: z.object({ text: z.string() }),
+});
+
+export type AlertPayload = z.infer<typeof alertSchema>;

--- a/apps/api/src/schemas/recipients.ts
+++ b/apps/api/src/schemas/recipients.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const recipientsSchema = z.object({
+  email: z.array(z.string().email()).optional(),
+  telegram: z.array(z.string()).optional(),
+  slack: z.array(z.string()).optional(),
+  sms: z.array(z.string()).optional(),
+  tags: z.array(z.string()).optional(),
+});
+
+export type RecipientsPayload = z.infer<typeof recipientsSchema>;

--- a/apps/api/src/schemas/ticket.ts
+++ b/apps/api/src/schemas/ticket.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const ticketSchema = z.object({
+  when: z.string(),
+  symbol: z.string(),
+  side: z.enum(['BUY', 'SELL']),
+  qty: z.number(),
+  entry: z.number(),
+  stop: z.number(),
+  targets: z.array(z.number()),
+  apex_blocked: z.boolean().default(false),
+  reasons: z.array(z.string()).default([]),
+});
+
+export type TicketPayload = z.infer<typeof ticketSchema>;

--- a/apps/api/src/types/reporting.d.ts
+++ b/apps/api/src/types/reporting.d.ts
@@ -1,0 +1,35 @@
+declare module '@prism-apex-tool/reporting' {
+  export interface DailyTicketRow {
+    when: string;
+    symbol: string;
+    side: 'BUY' | 'SELL';
+    qty: number;
+    entry: number;
+    stop: number;
+    targets: number[];
+    apex_blocked: boolean;
+    reasons: string[];
+  }
+
+  export interface DailySummary {
+    date: string;
+    ticketsCount: number;
+    blockedCount: number;
+    alertsAcked: number;
+    alertsQueued: number;
+    pnl: {
+      realized: number;
+      unrealized: number;
+      netLiq: number;
+    };
+  }
+
+  export interface DailyJson {
+    summary: DailySummary;
+    tickets: DailyTicketRow[];
+    alerts: any[];
+    breaches: any[];
+  }
+
+  export function toDailyCSV(j: DailyJson): string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@fastify/sensible':
         specifier: 6.0.3
         version: 6.0.3
+      '@prism-apex-tool/reporting':
+        specifier: workspace:*
+        version: link:../../packages/reporting
       fastify:
         specifier: 5.5.0
         version: 5.5.0


### PR DESCRIPTION
## Summary
- restore local fs-backed API routes for report, ingest, alerts, notify, export, rules with zod validation
- add schemas and reporting type shim, wire @prism-apex-tool/reporting dependency
- add hermetic tests for each endpoint

## Testing
- `pnpm --filter ./apps/api typecheck`
- `pnpm --filter ./apps/api test`


------
https://chatgpt.com/codex/tasks/task_b_68ab2d2d9f50832cbc80bfeb0680fe04