### PR TITLE
PR-08C: Promote /signals suggestions to tickets (filesystem store only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ tests/            Integration and end-to-end tests (future)
 ```
 
 ## Local Setup
+
 - Requires Node 20.x (`.nvmrc` / `.node-version`)
 - Install: `pnpm install`
 - Validate: `pnpm run validate`
 - Versions: `pnpm run versions`
 
 ## PR Roadmap (Collapsed)
+
 - PR‑00 Repo scan & dependency sanity
 - PR‑01a API TypeScript baseline
 - PR‑01b API entrypoint & start
@@ -53,10 +55,12 @@ tests/            Integration and end-to-end tests (future)
 ## Unquarantine Phase 1
 
 Restored:
+
 - Read-only `/health` and `/version` API routes
 - `@prism-apex-tool/reporting` utilities with a no-op email adapter
 
 Deferred:
+
 - Any write-side endpoints, jobs, or external integrations
 - Real email delivery (stubbed for now)
 
@@ -65,15 +69,18 @@ Smoke tests cover `/health`, `/version`, and reporting utilities.
 ## Unquarantine Phase 2
 
 Restored:
+
 - `@prism-apex-tool/analytics` helpers for summaries and payout status
 - `@prism-apex-tool/audit` log readers
 - Read-only `/analytics/summary` and `/audit/last` API routes
 
 Deferred:
+
 - Persisting reports or payout status
 - Audit log writes and notifications
 
 Run tests:
+
 - `pnpm --filter @prism-apex-tool/analytics test`
 - `pnpm --filter @prism-apex-tool/audit test`
 - `pnpm --filter ./apps/api test`
@@ -87,6 +94,7 @@ Run tests:
 ## Unquarantine Phase 4
 
 Restored:
+
 - Local filesystem-backed API routes:
   - `GET /report/daily?date=YYYY-MM-DD`
   - `POST /ingest/alert`
@@ -98,6 +106,7 @@ Restored:
 - All persistence remains local-only under `DATA_DIR`.
 
 Run tests:
+
 - `pnpm --filter ./apps/api typecheck`
 - `pnpm --filter ./apps/api test`
 
@@ -186,7 +195,15 @@ Response:
 These endpoints only compute and return suggested tickets; operators still manually enter orders.
 
 Run tests:
+
 - `pnpm --filter @prism-apex-tool/signals typecheck`
 - `pnpm --filter @prism-apex-tool/signals test`
 - `pnpm --filter ./apps/api typecheck`
 - `pnpm --filter ./apps/api test`
+
+## Unquarantine Phase 8C — Tickets (local-only)
+
+- Added `POST /tickets/promote` to persist a suggestion as a ticket in the local filesystem store.
+- Added `GET /tickets?date=YYYY-MM-DD` to list tickets for a given day.
+- Export and report flows pick up these tickets automatically.
+- No external integrations; purely local.

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -1,0 +1,35 @@
+import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import { PromoteInput } from '../schemas/ticketsPromote.js';
+
+export const registry = new OpenAPIRegistry();
+
+registry.registerPath({
+  method: 'post',
+  path: '/tickets/promote',
+  request: { body: { content: { 'application/json': { schema: PromoteInput } } } },
+  responses: {
+    200: {
+      description: 'Promoted suggestion to ticket',
+      content: {
+        'application/json': {
+          schema: z.object({ ok: z.boolean(), when: z.string(), id: z.string() }),
+        },
+      },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/tickets',
+  request: { query: z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) }) },
+  responses: {
+    200: {
+      description: 'Tickets for date',
+      content: { 'application/json': { schema: z.array(z.any()) } },
+    },
+  },
+});
+
+export default registry;

--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -1,0 +1,41 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { store } from '../store.js';
+import { PromoteInput } from '../schemas/ticketsPromote.js';
+
+export async function ticketsRoutes(app: FastifyInstance) {
+  app.post('/tickets/promote', async (req, reply) => {
+    const p = PromoteInput.safeParse(req.body);
+    if (!p.success) return reply.code(400).send({ error: 'Invalid payload' });
+
+    const { suggestion } = p.data;
+    const when = p.data.when ?? new Date().toISOString();
+    const reasons = p.data.reasons ?? [];
+
+    store.appendTicket({
+      when,
+      ticket: {
+        id: suggestion.id,
+        symbol: suggestion.symbol,
+        side: suggestion.side,
+        qty: suggestion.qty,
+        entry: suggestion.entry,
+        stop: suggestion.stop,
+        targets: suggestion.targets,
+        apex_blocked: suggestion.apex_blocked ?? false,
+        meta: suggestion.meta ?? {},
+      } as any,
+      reasons,
+    });
+
+    return { ok: true, when, id: suggestion.id };
+  });
+
+  app.get('/tickets', async (req, reply) => {
+    const q = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) }).safeParse(req.query);
+    if (!q.success) return reply.code(400).send({ error: 'Invalid date' });
+    const rows = store.getTicketsForDate(q.data.date);
+    return rows;
+  });
+}
+export default ticketsRoutes;

--- a/apps/api/src/schemas/ticketsPromote.ts
+++ b/apps/api/src/schemas/ticketsPromote.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { SuggestionSchema } from './signals.js';
+
+export const PromoteInput = z.object({
+  suggestion: SuggestionSchema,
+  when: z.string().optional(), // ISO timestamp; defaults to now
+  reasons: z.array(z.string()).optional(),
+});
+
+export type PromoteInputT = z.infer<typeof PromoteInput>;


### PR DESCRIPTION
## Summary
- Added local-only ticket promotion and listing endpoints
- Extended OpenAPI
- Optional SDK helpers
- No external integrations

## Testing
- `pnpm lint` *(fails: Definition for rule 'simple-import-sort/imports' was not found; Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_b_68ab626dff74832cbaec2e15740023df