### PR TITLE
PR-08C.1: Restore OpenAPI builder and add API ESLint flat config

### DIFF
--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -1,0 +1,24 @@
+// Minimal flat ESLint config for apps/api (ESLint v9)
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default [
+  { ignores: ['dist/**', 'coverage/**', '**/*.d.ts'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended, // non-type-checked, fast and stable
+  {
+    files: ['**/*.ts'],
+    rules: {
+      // Keep lint noise low for the API right now
+      '@typescript-eslint/no-explicit-any': 'off',
+      // Do NOT require plugins we don't use here (e.g., simple-import-sort)
+    },
+  },
+  {
+    files: ['src/__tests__/**/*.ts', 'src/**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'no-console': 'off',
+    },
+  },
+];

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -1,9 +1,78 @@
-import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import {
+  OpenAPIRegistry,
+  OpenApiGeneratorV31,
+  extendZodWithOpenApi,
+} from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
+import { OSBInput, VWAPInput, SuggestionResultSchema } from '../schemas/signals.js';
 import { PromoteInput } from '../schemas/ticketsPromote.js';
+
+extendZodWithOpenApi(z);
 
 export const registry = new OpenAPIRegistry();
 
+// ---- Shared schemas for simple endpoints ----
+const SymbolsResponse = z.object({ symbols: z.array(z.string()) });
+const SessionsResponse = z.object({
+  RTH: z.object({ start: z.string(), end: z.string(), tz: z.string() }),
+  ETH: z.object({ start: z.string(), end: z.string(), tz: z.string() }),
+});
+const ReportDailyQuery = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/) });
+
+// ---- Market ----
+registry.registerPath({
+  method: 'get',
+  path: '/market/symbols',
+  responses: {
+    200: { description: 'Symbols', content: { 'application/json': { schema: SymbolsResponse } } },
+  },
+});
+registry.registerPath({
+  method: 'get',
+  path: '/market/sessions',
+  responses: {
+    200: { description: 'Sessions', content: { 'application/json': { schema: SessionsResponse } } },
+  },
+});
+
+// ---- Signals ----
+registry.registerPath({
+  method: 'post',
+  path: '/signals/osb',
+  request: { body: { content: { 'application/json': { schema: OSBInput } } } },
+  responses: {
+    200: {
+      description: 'OSB suggestion',
+      content: { 'application/json': { schema: SuggestionResultSchema } },
+    },
+  },
+});
+registry.registerPath({
+  method: 'post',
+  path: '/signals/vwap-first-touch',
+  request: { body: { content: { 'application/json': { schema: VWAPInput } } } },
+  responses: {
+    200: {
+      description: 'VWAP FT suggestion',
+      content: { 'application/json': { schema: SuggestionResultSchema } },
+    },
+  },
+});
+
+// ---- Report ----
+registry.registerPath({
+  method: 'get',
+  path: '/report/daily',
+  request: { query: ReportDailyQuery },
+  responses: {
+    200: {
+      description: 'Daily report summary',
+      content: { 'application/json': { schema: z.any() } },
+    },
+  },
+});
+
+// ---- Tickets (Phase 8C) ----
 registry.registerPath({
   method: 'post',
   path: '/tickets/promote',
@@ -19,7 +88,6 @@ registry.registerPath({
     },
   },
 });
-
 registry.registerPath({
   method: 'get',
   path: '/tickets',
@@ -32,4 +100,13 @@ registry.registerPath({
   },
 });
 
+// ---- Builder (kept for routes/openapi.ts) ----
+export function buildOpenApi(): Record<string, unknown> {
+  const generator = new OpenApiGeneratorV31(registry.definitions);
+  return generator.generateDocument({
+    openapi: '3.1.0',
+    info: { title: 'Prism Apex Tool API', version: '0.1.0' },
+    servers: [{ url: '/' }],
+  });
+}
 export default registry;


### PR DESCRIPTION
## Summary
- restore `buildOpenApi` export and register tickets paths
- add flat ESLint config for `apps/api`

## Testing
- `pnpm lint` *(fails: Definition for rule 'simple-import-sort/imports' was not found; import/no-unresolved; Unexpected any)*
- `cd apps/api && pnpm lint` *(fails: console is not defined; Empty block statement; variables unused)*
- `cd apps/api && npx eslint src/openapi/spec.ts`

------
https://chatgpt.com/codex/tasks/task_b_68ab655f6a34832c9f7239cca6773202