### PR TITLE
PR-11: add optional bearer-token auth + OpenAPI security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,8 @@
-# Slack
-SLACK_WEBHOOK=https://hooks.slack.com/services/XXX/YYY/ZZZ
+# Prism Apex Tool
+# If set, all endpoints require "Authorization: Bearer <value>"
+# except /health and /openapi.json (and /version).
+BEARER_TOKEN=
 
-# Email
-SMTP_SERVER=smtp.gmail.com
-SMTP_PORT=587
-SMTP_USER=youruser@gmail.com
-SMTP_PASS=yourpassword
-EMAIL_FROM=alerts@prismapex.local
-EMAIL_TO=operator@example.com
+# Optional process settings
+DATA_DIR=./data
+LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -207,3 +207,19 @@ Run tests:
 - Added `GET /tickets?date=YYYY-MM-DD` to list tickets for a given day.
 - Export and report flows pick up these tickets automatically.
 - No external integrations; purely local.
+
+## Auth (optional, default OFF)
+
+Set `BEARER_TOKEN` to enable bearer auth across the API (read-only endpoints included).
+Public endpoints that remain open:
+
+- `GET /health`
+- `GET /openapi.json`
+- `GET /version`
+
+Example:
+
+```bash
+export BEARER_TOKEN="change-me"
+curl -H "Authorization: Bearer $BEARER_TOKEN" http://localhost:PORT/market/symbols
+```

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -72,7 +72,7 @@ registry.registerPath({
   },
 });
 
-// ---- Tickets (Phase 8C) ----
+// ---- Tickets ----
 registry.registerPath({
   method: 'post',
   path: '/tickets/promote',
@@ -100,13 +100,19 @@ registry.registerPath({
   },
 });
 
-// ---- Builder (kept for routes/openapi.ts) ----
+// ---- Builder (includes security scheme) ----
 export function buildOpenApi(): Record<string, unknown> {
   const generator = new OpenApiGeneratorV31(registry.definitions);
   return generator.generateDocument({
     openapi: '3.1.0',
     info: { title: 'Prism Apex Tool API', version: '0.1.0' },
     servers: [{ url: '/' }],
+    components: {
+      securitySchemes: {
+        BearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'token' },
+      },
+    },
+    security: [{ BearerAuth: [] }],
   });
 }
 export default registry;

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -1,0 +1,34 @@
+import fp from 'fastify-plugin';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+
+type Opts = { publicPaths?: (string | RegExp)[] };
+
+function isPublicPath(pathname: string, patterns: (string | RegExp)[]): boolean {
+  return patterns.some((p) =>
+    typeof p === 'string' ? pathname === p || pathname.startsWith(p) : p.test(pathname),
+  );
+}
+
+export default fp<Opts>(async (app, opts) => {
+  const token = process.env.BEARER_TOKEN;
+  const publicPaths = opts.publicPaths ?? ['/health', '/openapi.json', '/version'];
+
+  if (!token) {
+    app.log.info('auth disabled: BEARER_TOKEN not set');
+    return;
+  }
+
+  app.addHook('onRequest', async (req: FastifyRequest, reply: FastifyReply) => {
+    const pathname = (req.url || '').split('?')[0] || '/';
+    if (isPublicPath(pathname, publicPaths)) return;
+
+    const auth = req.headers.authorization || '';
+    if (!auth.startsWith('Bearer ')) {
+      return reply.code(401).send({ error: 'Missing bearer token' });
+    }
+    const presented = auth.slice('Bearer '.length);
+    if (presented !== token) {
+      return reply.code(403).send({ error: 'Invalid token' });
+    }
+  });
+});

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,5 +1,6 @@
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
+import authPlugin from './plugins/auth.js';
 import { marketRoutes } from './routes/market.js';
 import { signalRoutes } from './routes/signals.js';
 import { rulesRoutes } from './routes/rules.js';
@@ -44,6 +45,7 @@ export function buildServer() {
   });
 
   app.register(cors, { origin: true });
+  app.register(authPlugin, { publicPaths: ['/health', '/openapi.json', '/version'] });
 
   app.register(healthRoutes);
   app.register(versionRoutes);


### PR DESCRIPTION
## Summary
- Optional bearer token gate (disabled when `BEARER_TOKEN` is unset)
- Public: `/health`, `/openapi.json`, `/version`
- OpenAPI 3.1 security scheme added; docs show bearer auth
- No tests executed in this PR

## Testing
- `pnpm exec eslint apps/api/src/plugins/auth.ts apps/api/src/server.ts apps/api/src/openapi/spec.ts && echo 'lint passed'`

------
https://chatgpt.com/codex/tasks/task_b_68ab72dd33a8832c913ea4e41a6b3811