### PR TITLE
PR-12.1: Fix OpenAPI generator route and add missing dev deps

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,8 @@
     "tsx": "4.20.4",
     "typescript": "^5.9.2",
     "vitest": "^2.0.0",
+    "@asteasolutions/zod-to-openapi": "^7.1.0",
+    "@prism-apex-tool/sdk": "workspace:*",
     "eslint": "^9.10.0",
     "@eslint/js": "^9.10.0",
     "typescript-eslint": "^8.7.0",

--- a/apps/api/src/routes/openapi.ts
+++ b/apps/api/src/routes/openapi.ts
@@ -1,13 +1,10 @@
 import type { FastifyInstance } from 'fastify';
-import fs from 'node:fs';
-import path from 'node:path';
+import { buildOpenApi } from '../openapi/spec.js';
 
 export async function openapiRoute(app: FastifyInstance) {
   app.get('/openapi.json', async (_req, reply) => {
-    const root = path.resolve(process.cwd(), '../../..');
-    const yaml = fs.readFileSync(path.join(root, 'api/openapi.yaml'), 'utf8');
-    // Lazy convert: for tooling we can serve YAML as text; many tools accept YAML directly.
-    // For stricter JSON serving, bring in 'yaml' lib later. MVP: serve YAML string in JSON field.
-    return reply.send({ openapi: '3.1.0', yaml });
+    const doc = buildOpenApi();
+    return reply.type('application/json').send(doc);
   });
 }
+export default openapiRoute;

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -12,9 +12,16 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@prism-apex-tool/analytics': path.resolve(__dirname, '../../packages/analytics/src/index.ts'),
+      '@prism-apex-tool/analytics': path.resolve(
+        __dirname,
+        '../../packages/analytics/src/index.ts',
+      ),
       '@prism-apex-tool/audit': path.resolve(__dirname, '../../packages/audit/src/index.ts'),
-      '@prism-apex-tool/reporting': path.resolve(__dirname, '../../packages/reporting/src/index.ts'),
+      '@prism-apex-tool/reporting': path.resolve(
+        __dirname,
+        '../../packages/reporting/src/index.ts',
+      ),
+      '@prism-apex-tool/sdk': path.resolve(__dirname, '../../packages/sdk/src/index.ts'),
       '@prism-apex-tool/signals': path.resolve(__dirname, '../../packages/signals/src/index.ts'),
     },
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,17 +13,12 @@
     "baseUrl": ".",
     "allowImportingTsExtensions": true,
     "paths": {
+      "@prism-apex-tool/sdk": ["packages/sdk/src"],
       "@prism-apex-tool/analytics": ["packages/analytics/src"],
       "@prism-apex-tool/audit": ["packages/audit/src"],
       "@prism-apex-tool/reporting": ["packages/reporting/src"],
       "@prism-apex-tool/signals": ["packages/signals/src"]
     }
   },
-  "exclude": [
-    "archive",
-    "packages/clients-tradovate",
-    "apps/dashboard",
-    "apps/e2e",
-    "sdks"
-  ]
+  "exclude": ["archive", "packages/clients-tradovate", "apps/dashboard", "apps/e2e", "sdks"]
 }


### PR DESCRIPTION
## Summary
- serve /openapi.json via zod-to-openapi
- add @asteasolutions/zod-to-openapi and @prism-apex-tool/sdk dev deps for apps/api
- ensure Vitest SDK alias and SDK tsconfig path

## Testing
- `pnpm -w i` *(fails: @prism-apex-tool/sdk workspace package missing)*
- `pnpm --filter ./apps/api typecheck` *(fails: Cannot find module '@prism-apex-tool/sdk' or '@asteasolutions/zod-to-openapi')*
- `pnpm --filter ./apps/api test` *(fails: Failed to load url @asteasolutions/zod-to-openapi)*

------
https://chatgpt.com/codex/tasks/task_b_68ab7ce52758832caa80b7a7861ee9c9