### PR TITLE
PR-12.2: Restore @prism-apex-tool/sdk and wire into API tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "node": ">=20 <21"
   },
   "packageManager": "pnpm@9.15.9",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-conventional": "^18.4.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@prism-apex-tool/sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest"
+  },
+  "dependencies": {}
+}

--- a/packages/sdk/src/index.spec.ts
+++ b/packages/sdk/src/index.spec.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { PrismApexClient } from './index.js';
+
+describe('PrismApexClient', () => {
+  it('constructs', () => {
+    const client = new PrismApexClient('http://localhost');
+    expect(client).toBeInstanceOf(PrismApexClient);
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,56 @@
+import type {
+  Bar,
+  OSBInput,
+  VWAPInput,
+  SuggestionResult,
+  SymbolsResponse,
+  SessionsResponse,
+} from './types.js';
+
+export class PrismApexClient {
+  constructor(
+    private baseUrl: string,
+    private fetchImpl: typeof fetch = globalThis.fetch,
+  ) {}
+
+  async getSymbols(): Promise<SymbolsResponse> {
+    const r = await this.fetchImpl(new URL('/market/symbols', this.baseUrl));
+    if (!r.ok) throw new Error(`GET /market/symbols ${r.status}`);
+    return r.json();
+  }
+
+  async getSessions(): Promise<SessionsResponse> {
+    const r = await this.fetchImpl(new URL('/market/sessions', this.baseUrl));
+    if (!r.ok) throw new Error(`GET /market/sessions ${r.status}`);
+    return r.json();
+  }
+
+  async osb(input: OSBInput): Promise<SuggestionResult> {
+    const r = await this.fetchImpl(new URL('/signals/osb', this.baseUrl), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    if (!r.ok) throw new Error(`POST /signals/osb ${r.status}`);
+    return r.json();
+  }
+
+  async vwapFirstTouch(input: VWAPInput): Promise<SuggestionResult> {
+    const r = await this.fetchImpl(new URL('/signals/vwap-first-touch', this.baseUrl), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    if (!r.ok) throw new Error(`POST /signals/vwap-first-touch ${r.status}`);
+    return r.json();
+  }
+}
+
+export type {
+  Bar,
+  OSBInput,
+  VWAPInput,
+  SuggestionResult,
+  SymbolsResponse,
+  SessionsResponse,
+} from './types.js';

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,0 +1,29 @@
+export type Side = 'BUY' | 'SELL';
+export type Bar = {
+  ts: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number;
+};
+export type Suggestion = {
+  id: string;
+  symbol: string;
+  side: Side;
+  qty: number;
+  entry: number;
+  stop: number;
+  targets: number[];
+  apex_blocked?: boolean;
+  reasons: string[];
+  meta?: Record<string, unknown>;
+};
+export type SuggestionResult = { suggestions: Suggestion[] };
+export type SymbolsResponse = { symbols: string[] };
+export type SessionsResponse = {
+  RTH: { start: string; end: string; tz: string };
+  ETH: { start: string; end: string; tz: string };
+};
+export type OSBInput = { symbol: string; session: 'RTH' | 'ETH'; bars: Bar[] };
+export type VWAPInput = { symbol: string; bars: Bar[] };

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({ test: { environment: 'node', globals: true } });


### PR DESCRIPTION
## Summary
- restore @prism-apex-tool/sdk typed client
- expose SDK via workspace config

## Testing
- `pnpm test` *(fails: Failed to resolve entry for package "@prism-apex-tool/signals" and other unresolved modules)*
- `pnpm typecheck` *(fails: Type 'OpenAPIObject' is not assignable to type 'Record<string, unknown>' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ab7fc269b4832c961bb78ccb5a3fc6