### PR TITLE
PR-12.2: Restore SDK + OpenAPI deps and aliases (fix typecheck/tests)

### DIFF
--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -11,6 +11,12 @@ extendZodWithOpenApi(z);
 
 export const registry = new OpenAPIRegistry();
 
+registry.registerComponent('securitySchemes', 'BearerAuth', {
+  type: 'http',
+  scheme: 'bearer',
+  bearerFormat: 'token',
+});
+
 // ---- Shared schemas for simple endpoints ----
 const SymbolsResponse = z.object({ symbols: z.array(z.string()) });
 const SessionsResponse = z.object({
@@ -107,12 +113,7 @@ export function buildOpenApi(): Record<string, unknown> {
     openapi: '3.1.0',
     info: { title: 'Prism Apex Tool API', version: '0.1.0' },
     servers: [{ url: '/' }],
-    components: {
-      securitySchemes: {
-        BearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'token' },
-      },
-    },
     security: [{ BearerAuth: [] }],
-  });
+  }) as unknown as Record<string, unknown>;
 }
 export default registry;


### PR DESCRIPTION
## Summary
- restore SDK package with type-safe client and tests
- add TypeScript/Vitest path aliases for new SDK
- fix OpenAPI generator typing and register security scheme

## Testing
- `pnpm --filter @prism-apex-tool/sdk typecheck`
- `pnpm --filter @prism-apex-tool/sdk test -- --run`
- `pnpm --filter ./apps/api typecheck`
- `pnpm --filter ./apps/api test`


------
https://chatgpt.com/codex/tasks/task_b_68ab82b40c54832c92c0fd1515a8d026