### PR TITLE
PR-13: Hardening — /ready, lightweight rate-limit, and companion tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ BEARER_TOKEN=
 # Optional process settings
 DATA_DIR=./data
 LOG_LEVEL=info
+
+# Rate limit (per IP per route)
+RATE_LIMIT_MAX=60
+RATE_LIMIT_WINDOW_MS=60000

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -17,6 +17,22 @@ registry.registerComponent('securitySchemes', 'BearerAuth', {
   bearerFormat: 'token',
 });
 
+registry.registerPath({
+  method: 'get',
+  path: '/ready',
+  // Empty security array here marks this endpoint as public,
+  // even though global security is Bearer by default.
+  security: [],
+  responses: {
+    200: {
+      description: 'Readiness',
+      content: {
+        'application/json': { schema: z.object({ ok: z.boolean(), ready: z.boolean() }) },
+      },
+    },
+  },
+});
+
 // ---- Shared schemas for simple endpoints ----
 const SymbolsResponse = z.object({ symbols: z.array(z.string()) });
 const SessionsResponse = z.object({

--- a/apps/api/src/plugins/rateLimit.ts
+++ b/apps/api/src/plugins/rateLimit.ts
@@ -1,0 +1,59 @@
+import fp from 'fastify-plugin';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+
+type Opts = {
+  max?: number; // requests per window per IP
+  windowMs?: number; // window size in ms
+  publicPaths?: (string | RegExp)[];
+};
+
+function isPublic(pathname: string, patterns: (string | RegExp)[]): boolean {
+  return patterns.some((p) =>
+    typeof p === 'string' ? pathname === p || pathname.startsWith(p) : p.test(pathname),
+  );
+}
+
+export default fp<Opts>(async (app, opts) => {
+  const max = Number(process.env.RATE_LIMIT_MAX ?? opts.max ?? 60);
+  const windowMs = Number(process.env.RATE_LIMIT_WINDOW_MS ?? opts.windowMs ?? 60_000);
+  const publicPaths = opts.publicPaths ?? ['/health', '/ready', '/openapi.json', '/version'];
+
+  type Bucket = { count: number; resetAt: number };
+  const buckets = new Map<string, Bucket>();
+
+  // Periodic sweep to drop expired buckets
+  const sweeper = setInterval(
+    () => {
+      const now = Date.now();
+      for (const [k, v] of buckets) if (v.resetAt <= now) buckets.delete(k);
+    },
+    Math.min(windowMs, 30_000),
+  ).unref?.();
+
+  app.addHook('onClose', async () => {
+    clearInterval(sweeper as NodeJS.Timeout);
+  });
+
+  app.addHook('onRequest', async (req: FastifyRequest, reply: FastifyReply) => {
+    const pathname = (req.url || '').split('?')[0] || '/';
+    // Skip public routes and CORS preflight
+    if (isPublic(pathname, publicPaths) || req.method === 'OPTIONS') return;
+
+    const key = `${req.ip || 'ip:unknown'}:${pathname}`;
+    const now = Date.now();
+    const bucket = buckets.get(key);
+
+    if (!bucket || bucket.resetAt <= now) {
+      buckets.set(key, { count: 1, resetAt: now + windowMs });
+      return;
+    }
+
+    if (bucket.count >= max) {
+      const retryAfterSec = Math.ceil((bucket.resetAt - now) / 1000);
+      reply.header('Retry-After', String(retryAfterSec));
+      return reply.code(429).send({ error: 'Too Many Requests' });
+    }
+
+    bucket.count += 1;
+  });
+});

--- a/apps/api/src/routes/ready.ts
+++ b/apps/api/src/routes/ready.ts
@@ -1,0 +1,6 @@
+import type { FastifyInstance } from 'fastify';
+
+export async function readyRoutes(app: FastifyInstance) {
+  app.get('/ready', async () => ({ ok: true, ready: true }));
+}
+export default readyRoutes;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import authPlugin from './plugins/auth.js';
+import rateLimit from './plugins/rateLimit.js';
 import { marketRoutes } from './routes/market.js';
 import { signalRoutes } from './routes/signals.js';
 import { rulesRoutes } from './routes/rules.js';
@@ -17,6 +18,7 @@ import { versionRoutes } from './routes/version.js';
 import { analyticsRoutes } from './routes/analytics.js';
 import { auditRoutes } from './routes/audit.js';
 import { ticketsRoutes } from './routes/tickets.js';
+import { readyRoutes } from './routes/ready.js';
 import { getConfig } from './config/env';
 
 import { registerJob, startJobs, stopJobs } from './jobs/scheduler';
@@ -45,8 +47,13 @@ export function buildServer() {
   });
 
   app.register(cors, { origin: true });
-  app.register(authPlugin, { publicPaths: ['/health', '/openapi.json', '/version'] });
+  // Public paths (no auth/rate-limit)
+  const publicPaths = ['/health', '/ready', '/openapi.json', '/version'];
 
+  app.register(authPlugin, { publicPaths });
+  app.register(rateLimit, { publicPaths });
+
+  app.register(readyRoutes);
   app.register(healthRoutes);
   app.register(versionRoutes);
   app.register(analyticsRoutes);

--- a/apps/api/src/tests/hardening.spec.ts
+++ b/apps/api/src/tests/hardening.spec.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeEach(async () => {
+  vi.resetModules(); // avoid double registration/state
+  process.env.RATE_LIMIT_MAX = '2';
+  process.env.RATE_LIMIT_WINDOW_MS = '60000';
+  delete process.env.BEARER_TOKEN; // ensure auth is OFF for these tests
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('Hardening', () => {
+  it('returns readiness', async () => {
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/ready' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true, ready: true });
+    await app.close();
+  });
+
+  it('applies basic rate limit (429 after threshold)', async () => {
+    const app = buildServer();
+    await app.inject({ method: 'GET', url: '/market/symbols' });
+    await app.inject({ method: 'GET', url: '/market/symbols' });
+    const r3 = await app.inject({ method: 'GET', url: '/market/symbols' });
+    expect(r3.statusCode).toBe(429);
+    await app.close();
+  });
+
+  it('adds CORS header on responses', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/market/sessions',
+      headers: { Origin: 'http://example.com' },
+    });
+    expect(res.statusCode).toBe(200);
+    const acao = res.headers['access-control-allow-origin'];
+    expect(typeof acao).toBe('string');
+    expect(String(acao).length).toBeGreaterThan(0);
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add in-process rate limiter plugin
- expose GET /ready as a readiness probe
- document security & hardening and add env knobs

## Testing
- `pnpm --filter ./apps/api typecheck`
- `pnpm --filter ./apps/api test`

------
https://chatgpt.com/codex/tasks/task_b_68ab871f3d90832c8916191c0578ad7c