### PR TITLE
test(api): add global Vitest setup to reset modules and quiet logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ Each package owns its own `tsconfig.typecheck.json` so CI stays fast and focused
 - Tests are compiled by Vitest at runtime (not by `tsc`).
 - `@ts-expect-error` in test files won’t fail `pnpm typecheck` anymore.
 
+### Test harness (PR-17)
+
+Vitest now loads a small setup file for the API tests:
+
+- resets loaded modules before each test (`vi.resetModules()`), avoiding job double-registration
+- forces quiet logs with `LOG_LEVEL=fatal` unless a test overrides it
+- leaves rate-limiter/auth env vars untouched unless a test sets them
+
+You can still override in a test:
+
+```ts
+process.env.LOG_LEVEL = 'info';
+```
+
 ## Unquarantine Phase 8C — Tickets (local-only)
 
 - Added `POST /tickets/promote` to persist a suggestion as a ticket in the local filesystem store.

--- a/apps/api/src/tests/setup.ts
+++ b/apps/api/src/tests/setup.ts
@@ -1,0 +1,24 @@
+// Global Vitest setup for API package
+import { beforeEach, afterEach, vi } from 'vitest';
+
+// Keep tests isolated: prevents job re-registration & stale singletons
+beforeEach(() => {
+  vi.resetModules();
+  // Keep logs quiet unless explicitly overridden in a test
+  if (!process.env.LOG_LEVEL) process.env.LOG_LEVEL = 'fatal';
+});
+
+// Clean up any env tweaks a test might have applied
+afterEach(() => {
+  // Add keys here if tests set them temporarily
+  for (const k of [
+    'BEARER_TOKEN',
+    'RATE_LIMIT_MAX',
+    'RATE_LIMIT_WINDOW_MS',
+    'RATE_LIMIT_MAX_BUCKETS',
+  ]) {
+    if (Object.prototype.hasOwnProperty.call(process.env, k) && process.env[k] === '') {
+      delete process.env[k];
+    }
+  }
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     coverage: { reporter: ['text', 'json-summary', 'lcov'] },
+    setupFiles: [path.resolve(__dirname, './src/tests/setup.ts')],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add global Vitest setup to reset modules and quiet logs
- wire setup file into API vitest config
- document test harness in README

## Testing
- `pnpm -w i`
- `pnpm --filter ./apps/api test -- --run`
- `pnpm coverage`


------
https://chatgpt.com/codex/tasks/task_b_68aba1ac99a8832c9fc103b4091dbd33