### PR TITLE
docs: release notes, upgrade guide, and README pointers (PR-19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,3 +385,8 @@ curl -s -i http://localhost:PORT/market/symbols | sed -n '1,10p'              # 
 ### CORS
 
 CORS is enabled (`@fastify/cors` with `origin: true`); responses include `Access-Control-Allow-Origin`.
+
+## Release Notes & Upgrade
+
+- See **[docs/RELEASE_NOTES.md](docs/RELEASE_NOTES.md)** for what changed in v0.1.0.
+- Upgrading? Follow **[docs/UPGRADE.md](docs/UPGRADE.md)** for engines, env, and commands.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,0 +1,37 @@
+# Prism Apex Tool — Release Notes
+
+## v0.1.0 (Unquarantine milestone)
+
+### Highlights
+
+- **API** restored on Fastify 5 with typed routes and OpenAPI 3.1 generator.
+- **Strategies**: Open Session Breakout, VWAP First-Touch (read-only suggestions).
+- **Tickets**: `POST /tickets/promote`, `GET /tickets?date=YYYY-MM-DD`, CSV export.
+- **Security**: optional Bearer auth; local rate-limit with public route bypasses; `/ready`.
+- **DX**: SDK package for typed client calls; per-pkg typecheck; Vitest harness; Docker (dev + prod).
+- **Docs**: README overhaul, upgrade guide, release notes.
+
+### Breaking / Behavioral
+
+- Node **20.x** required; ESM everywhere.
+- Bearer auth **off by default**; enable via `BEARER_TOKEN` (public: `/health`, `/ready`, `/openapi.json`, `/version`).
+- Rate-limit defaults: `RATE_LIMIT_MAX=60`, `RATE_LIMIT_WINDOW_MS=60000`, `RATE_LIMIT_MAX_BUCKETS=50000`.
+
+### New Endpoints
+
+- `GET /ready` — readiness probe.
+- `GET /market/symbols`, `GET /market/sessions`
+- `POST /signals/osb`, `POST /signals/vwap-first-touch`
+- `POST /tickets/promote`, `GET /tickets?date=YYYY-MM-DD`
+- `GET /export/tickets?date=YYYY-MM-DD`
+
+### Tooling & Tests
+
+- Per-workspace typecheck via `tsconfig.typecheck.json`.
+- Global Vitest setup resets modules and quiets logs.
+- Docker Compose for dev; multi-stage production Dockerfile.
+
+### Known Gaps
+
+- No auto-execution of orders (by design).
+- No external email/Slack integrations (local-only for now).

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -1,0 +1,68 @@
+# Upgrade Guide
+
+## From older snapshots to v0.1.0
+
+1. **Engines & Package Manager**
+
+- Use Node **20.x** and pnpm **9.x**.
+- `corepack enable && pnpm -v` should show 9.x.
+
+2. **Install**
+
+```bash
+pnpm install
+```
+
+3. **Environment**
+
+Copy `.env.example` → `.env`.
+
+Optional auth:
+
+```bash
+export BEARER_TOKEN="change-me"
+```
+
+Optional rate-limit tuning:
+
+```bash
+export RATE_LIMIT_MAX=60
+export RATE_LIMIT_WINDOW_MS=60000
+export RATE_LIMIT_MAX_BUCKETS=50000
+```
+
+4. **Run locally**
+
+```bash
+pnpm --filter ./apps/api dev
+# or Docker:
+pnpm compose:up
+```
+
+5. **Validate**
+
+```bash
+curl http://localhost:3000/health
+curl http://localhost:3000/ready
+curl http://localhost:3000/openapi.json
+```
+
+6. **Tests / Typecheck**
+
+```bash
+pnpm test          # per-workspace
+pnpm typecheck     # source-only typecheck
+pnpm coverage      # API package coverage
+```
+
+7. **Docker production image**
+
+```bash
+pnpm docker:build
+pnpm docker:run
+```
+
+## Notes
+
+- ESM only. Legacy CJS configs should be removed or converted.
+- Public routes: `/health`, `/ready`, `/openapi.json`, `/version`.


### PR DESCRIPTION
## Summary
- add v0.1.0 release notes
- document upgrade steps from older snapshots
- link README to release notes and upgrade guide

## Testing
- `pnpm test` *(fails: packages/clients-tradovate test, packages/reporting test, packages/sdk test, packages/analytics test, packages/signals test, packages/audit test)*
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68abb7fabd58832c8fe2c4e4ed9de11e