### PR TITLE
chore: depcheck runner fix, docs fencing, pnpm align, passWithNoTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ coverage
 dist
 build
 
+# Reports
+reports/
+
 # Env
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -317,7 +317,10 @@ Data lives in the api-data volume at /data inside the container.
 
 ```bash
 pnpm docker:build
-docker run --rm -p 3000:3000 -v api-data:/data prism-apex-api:latest
+docker run --rm \
+ -p 3000:3000 \
+ -v api-data:/data \
+ prism-apex-api:latest
 # In another shell:
 curl http://localhost:3000/health
 curl http://localhost:3000/openapi.json | jq '.info.title, .paths | keys | length'

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-apex-tool",
   "private": true,
-  "packageManager": "pnpm@10.15.0",
+  "packageManager": "pnpm@9.15.9",
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -17,13 +17,13 @@ pnpm install
 
 Copy `.env.example` → `.env`.
 
-Optional auth:
+Optional auth
 
 ```bash
 export BEARER_TOKEN="change-me"
 ```
 
-Optional rate-limit tuning:
+Optional rate-limit tuning
 
 ```bash
 export RATE_LIMIT_MAX=60

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint . --ext .ts",
-    "test": "vitest",
+    "test": "vitest --run --passWithNoTests",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "format": "prettier -w .",
     "format:check": "prettier -c ."

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint . --ext .ts",
-    "test": "vitest",
+    "test": "vitest --run --passWithNoTests",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "format": "prettier -w .",
     "format:check": "prettier -c ."

--- a/packages/clients-tradovate/package.json
+++ b/packages/clients-tradovate/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "vitest"
+    "test": "vitest --run --passWithNoTests"
   },
   "dependencies": {
     "zod": "3.25.76"

--- a/packages/reporting/package.json
+++ b/packages/reporting/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint . --ext .ts",
-    "test": "vitest",
+    "test": "vitest --run --passWithNoTests",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "format": "prettier -w .",
     "format:check": "prettier -c ."

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
-    "test": "vitest"
+    "test": "vitest --run --passWithNoTests"
   },
   "dependencies": {}
 }

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "vitest",
+    "test": "vitest --run --passWithNoTests",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "lint": "eslint . --ext .ts",
     "format": "prettier -w .",

--- a/tools/depcheck.mjs
+++ b/tools/depcheck.mjs
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 
 const cfgPath = path.join(repoRoot, '.depcheckrc.json');
+// Output directory and file for depcheck results
 const outDir = path.join(repoRoot, 'reports');
 const outPath = path.join(outDir, 'depcheck.json');
 


### PR DESCRIPTION
## Summary
- clarify depcheck output paths and ignore generated reports
- align apps/api package manager to pnpm@9.15.9
- ensure vitest scripts pass when no tests exist and polish docs

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68abc469857c832c9a5431b5d65bf880