### PR TITLE
chore(ci+dx): fix CI tests, add commitlint config, publish OpenAPI artifact, doc openapi:emit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,21 @@ jobs:
         run: pnpm -w run lint
 
       - name: Tests (per workspace)
-        run: pnpm -r --if-present test -- --run
+        # Some packages already pass --run; avoid duplicating the flag here.
+        run: pnpm -r --if-present test
 
       - name: Dead deps (non-blocking)
         run: pnpm scan:dead || true
+
+      - name: Emit OpenAPI
+        run: pnpm --filter ./apps/api run openapi:emit
+
+      - name: Upload OpenAPI
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi.json
+          path: apps/api/openapi.json
 
       - name: Upload depcheck report
         if: always()
@@ -37,4 +48,3 @@ jobs:
         with:
           name: depcheck-report
           path: reports/depcheck.json
-

--- a/README.md
+++ b/README.md
@@ -307,6 +307,14 @@ The final image includes apps/api/dist plus compiled workspace packages (e.g. pa
 
 Data lives in the api-data volume at /data inside the container.
 
+### Generate OpenAPI JSON
+
+- Emit the current OpenAPI document from runtime types:
+  ```bash
+  pnpm --filter ./apps/api run openapi:emit
+  # Output written to: apps/api/openapi.json
+  ```
+
 ## Why this works
 
 - **Workspace-aware**: we build the whole monorepo, then copy `dist/` outputs and a **pruned** `node_modules` that still resolves workspace deps (via pnpm’s virtual store/symlinks).


### PR DESCRIPTION
## Summary
- fix CI test command and publish OpenAPI artifact in CI
- document how to emit OpenAPI JSON

## Testing
- `pnpm -w run lint`
- `pnpm typecheck`
- `pnpm -r --if-present test`
- `pnpm --filter ./apps/api run openapi:emit && jq '.openapi, (.paths | keys | length)' apps/api/openapi.json`


------
https://chatgpt.com/codex/tasks/task_b_68ac3e932e2c832c8f8f3066ec14f151