### PR TITLE
feat(config): guardrails, sizing, and consistency tracking env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,24 @@ TRUST_PROXY=false
 
 # Rate-limiter memory guard (max unique ip+path buckets to retain)
 RATE_LIMIT_MAX_BUCKETS=50000
+
+# Guardrails
+MIN_RR=1.5
+MAX_RR=5
+FLAT_BY_UTC=20:59
+
+# Sizing policy (percent of account max contracts)
+SIZE_POLICY=percent-of-max
+PCT_OF_MAX_WHEN_NO_BUFFER=0.5
+PCT_OF_MAX_WHEN_BUFFER=1.0
+HALF_SIZE_UNTIL_BUFFER=true
+
+# Consistency tracking (metrics only; no enforcement in V1)
+CONSISTENCY_TRACKING_ENABLED=true
+CONSISTENCY_DAY_SHARE_LIMIT=0.3
+CONSISTENCY_MIN_PROFIT_DAY_USD=50
+CONSISTENCY_WINDOW_DAYS=8
+
+# Profit quality floor (present but OFF by default)
+MIN_PROFIT_TICKS=
+MIN_EXPECTED_PROFIT_USD=

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -1,10 +1,37 @@
+import { z } from 'zod';
+
 export type Config = {
-  nodeEnv: "production" | "development" | "test";
+  nodeEnv: 'production' | 'development' | 'test';
   host: string;
   port: number;
-  requestTimeoutMs: number;     // total request timeout
-  keepAliveTimeoutMs: number;   // socket keep-alive
-  bodyLimitBytes: number;       // max JSON body size
+  requestTimeoutMs: number; // total request timeout
+  keepAliveTimeoutMs: number; // socket keep-alive
+  bodyLimitBytes: number; // max JSON body size
+  guardrails: {
+    minRR: number;
+    maxRR: number;
+  };
+  time: {
+    flatByUtc: string;
+  };
+  sizing: {
+    policy: 'percent-of-max';
+    percent: {
+      noBuffer: number;
+      withBuffer: number;
+    };
+    halfSizeUntilBuffer: boolean;
+  };
+  consistency: {
+    enabled: boolean;
+    dayShareLimit: number;
+    minProfitDayUsd: number;
+    windowDays: number;
+  };
+  profitFloor: {
+    minProfitTicks?: number;
+    minExpectedProfitUsd?: number;
+  };
 };
 
 function parseIntWithDefault(v: string | undefined, def: number): number {
@@ -12,17 +39,47 @@ function parseIntWithDefault(v: string | undefined, def: number): number {
   return Number.isFinite(n) ? n : def;
 }
 
+const envSchema = z.object({
+  MIN_RR: z.coerce.number().gt(0).max(5).default(1.5),
+  MAX_RR: z.coerce.number().gt(0).max(5).default(5),
+  FLAT_BY_UTC: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/)
+    .default('20:59'),
+  SIZE_POLICY: z.literal('percent-of-max').default('percent-of-max'),
+  PCT_OF_MAX_WHEN_NO_BUFFER: z.coerce.number().gt(0).lte(1).default(0.5),
+  PCT_OF_MAX_WHEN_BUFFER: z.coerce.number().gt(0).lte(1).default(1),
+  HALF_SIZE_UNTIL_BUFFER: z.coerce.boolean().default(true),
+  CONSISTENCY_TRACKING_ENABLED: z.coerce.boolean().default(true),
+  CONSISTENCY_DAY_SHARE_LIMIT: z.coerce.number().gt(0).lte(1).default(0.3),
+  CONSISTENCY_MIN_PROFIT_DAY_USD: z.coerce.number().default(50),
+  CONSISTENCY_WINDOW_DAYS: z.coerce.number().int().min(1).default(8),
+  MIN_PROFIT_TICKS: z.preprocess(
+    (v) => (v === '' || v === undefined ? undefined : Number(v)),
+    z.number().gt(0).optional()
+  ),
+  MIN_EXPECTED_PROFIT_USD: z.preprocess(
+    (v) => (v === '' || v === undefined ? undefined : Number(v)),
+    z.number().gt(0).optional()
+  ),
+});
+
 export function getConfig(env = process.env): Config {
-  const nodeEnv = (env.NODE_ENV ?? "production") as Config["nodeEnv"];
+  const nodeEnv = (env.NODE_ENV ?? 'production') as Config['nodeEnv'];
   const port = parseIntWithDefault(env.PORT, 8000);
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error(`Invalid PORT value: ${env.PORT}`);
   }
-  const host = env.HOST ?? "0.0.0.0";
+  const host = env.HOST ?? '0.0.0.0';
 
   const requestTimeoutMs = parseIntWithDefault(env.REQUEST_TIMEOUT_MS, 10000);
   const keepAliveTimeoutMs = parseIntWithDefault(env.KEEP_ALIVE_TIMEOUT_MS, 5000);
   const bodyLimitBytes = parseIntWithDefault(env.BODY_LIMIT_BYTES, 1048576); // 1 MiB
+
+  const parsed = envSchema.parse(env);
+  if (parsed.MIN_RR > parsed.MAX_RR) {
+    throw new Error('MIN_RR cannot exceed MAX_RR');
+  }
 
   return {
     nodeEnv,
@@ -31,5 +88,30 @@ export function getConfig(env = process.env): Config {
     requestTimeoutMs,
     keepAliveTimeoutMs,
     bodyLimitBytes,
+    guardrails: {
+      minRR: parsed.MIN_RR,
+      maxRR: parsed.MAX_RR,
+    },
+    time: {
+      flatByUtc: parsed.FLAT_BY_UTC,
+    },
+    sizing: {
+      policy: parsed.SIZE_POLICY,
+      percent: {
+        noBuffer: parsed.PCT_OF_MAX_WHEN_NO_BUFFER,
+        withBuffer: parsed.PCT_OF_MAX_WHEN_BUFFER,
+      },
+      halfSizeUntilBuffer: parsed.HALF_SIZE_UNTIL_BUFFER,
+    },
+    consistency: {
+      enabled: parsed.CONSISTENCY_TRACKING_ENABLED,
+      dayShareLimit: parsed.CONSISTENCY_DAY_SHARE_LIMIT,
+      minProfitDayUsd: parsed.CONSISTENCY_MIN_PROFIT_DAY_USD,
+      windowDays: parsed.CONSISTENCY_WINDOW_DAYS,
+    },
+    profitFloor: {
+      minProfitTicks: parsed.MIN_PROFIT_TICKS,
+      minExpectedProfitUsd: parsed.MIN_EXPECTED_PROFIT_USD,
+    },
   };
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -47,6 +47,23 @@ export function buildServer() {
     bodyLimit: cfg.bodyLimitBytes,
     trustProxy,
   });
+  app.log.info(
+    {
+      config: {
+        minRR: cfg.guardrails.minRR,
+        maxRR: cfg.guardrails.maxRR,
+        flatByUtc: cfg.time.flatByUtc,
+        sizePolicy: cfg.sizing.policy,
+        percentNoBuffer: cfg.sizing.percent.noBuffer,
+        percentWithBuffer: cfg.sizing.percent.withBuffer,
+        consistency: {
+          enabled: cfg.consistency.enabled,
+          dayShareLimit: cfg.consistency.dayShareLimit,
+        },
+      },
+    },
+    'config summary'
+  );
   app.register(cors, { origin: true });
   // Public paths (no auth/rate-limit)
   const publicPaths = ['/health', '/ready', '/openapi.json', '/version'];

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,19 @@
+# Guardrails & Sizing (Env)
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| MIN_RR | 1.5 | minimum risk/reward |
+| MAX_RR | 5 | maximum risk/reward (≤5) |
+| FLAT_BY_UTC | 20:59 | EOD flat cutoff (UTC) |
+| SIZE_POLICY | percent-of-max | sizing policy |
+| PCT_OF_MAX_WHEN_NO_BUFFER | 0.5 | percent of max contracts without buffer |
+| PCT_OF_MAX_WHEN_BUFFER | 1.0 | percent of max contracts after buffer |
+| HALF_SIZE_UNTIL_BUFFER | true | start half size until buffer cleared |
+| CONSISTENCY_TRACKING_ENABLED | true | metrics only; no enforcement in V1 |
+| CONSISTENCY_DAY_SHARE_LIMIT | 0.3 | 30% single-day share limit |
+| CONSISTENCY_MIN_PROFIT_DAY_USD | 50 | minimum profit to count a day |
+| CONSISTENCY_WINDOW_DAYS | 8 | rolling summary window |
+| MIN_PROFIT_TICKS | (blank) | profit floor disabled |
+| MIN_EXPECTED_PROFIT_USD | (blank) | profit floor disabled |
+
+Consistency is tracked only in V1; enforcement comes later.


### PR DESCRIPTION
## Summary
- extend typed config to include guardrail, sizing, and consistency settings with validation
- document new env keys and log config summary at startup

## Testing
- `pnpm --filter ./apps/api typecheck`
- `pnpm --filter @prism-apex-tool/analytics test`
- `pnpm --filter @prism-apex-tool/audit test`
- `pnpm --filter ./apps/api test`

## Checklist
- [x] Env keys added & validated
- [x] .env.example updated
- [x] Startup logs show non-secret config
- [x] No behavior changes yet (wiring comes later)


------
https://chatgpt.com/codex/tasks/task_b_68ac611fd304832ca2af343ee9fa1e35