### PR TITLE
feat(rules-apex): RR bounds, EOD cutoff, percent sizing, consistency helpers

### DIFF
--- a/packages/rules-apex/package.json
+++ b/packages/rules-apex/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@prism-apex-tool/rules-apex",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint . --ext .ts",
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "format": "prettier -w .",
+    "format:check": "prettier -c ."
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "^9.10.0",
+    "@eslint/js": "^9.10.0",
+    "typescript-eslint": "^8.7.0",
+    "prettier": "^3.3.3"
+  }
+}

--- a/packages/rules-apex/src/consistency.ts
+++ b/packages/rules-apex/src/consistency.ts
@@ -1,0 +1,17 @@
+export function summarizeConsistency(
+  daily: { date: string; pnl: number }[],
+  opts: { dayShareLimit: number; minProfitDayUsd: number },
+): {
+  totalProfit: number;
+  topDayShare: number;
+  profitableDays: number;
+  limitBreached: boolean;
+} {
+  const profits = daily.map((d) => Math.max(0, d.pnl));
+  const totalProfit = profits.reduce((sum, p) => sum + p, 0);
+  const maxProfit = profits.length > 0 ? Math.max(...profits) : 0;
+  const topDayShare = totalProfit > 0 ? maxProfit / totalProfit : 0;
+  const profitableDays = daily.filter((d) => d.pnl >= opts.minProfitDayUsd).length;
+  const limitBreached = topDayShare > opts.dayShareLimit;
+  return { totalProfit, topDayShare, profitableDays, limitBreached };
+}

--- a/packages/rules-apex/src/curfew.ts
+++ b/packages/rules-apex/src/curfew.ts
@@ -1,0 +1,23 @@
+function parseUtcTime(flatByUtcHHmm: string, base: Date): Date {
+  const [hh, mm] = flatByUtcHHmm.split(':').map((s) => parseInt(s, 10));
+  const d = new Date(
+    Date.UTC(base.getUTCFullYear(), base.getUTCMonth(), base.getUTCDate(), hh, mm, 0, 0),
+  );
+  return d;
+}
+
+export function isAfterFlat(nowUtc: Date, flatByUtcHHmm: string): boolean {
+  const flatTime = parseUtcTime(flatByUtcHHmm, nowUtc);
+  return nowUtc.getTime() >= flatTime.getTime();
+}
+
+export function withinSuppressionWindow(
+  nowUtc: Date,
+  flatByUtcHHmm: string,
+  minutesBefore: number,
+): boolean {
+  const flatTime = parseUtcTime(flatByUtcHHmm, nowUtc);
+  const diffMs = flatTime.getTime() - nowUtc.getTime();
+  const diffMinutes = diffMs / 60000;
+  return diffMinutes >= 0 && diffMinutes <= minutesBefore;
+}

--- a/packages/rules-apex/src/evaluate.ts
+++ b/packages/rules-apex/src/evaluate.ts
@@ -1,0 +1,31 @@
+import { TicketInput, EvaluateResult } from './types';
+import { calcRR, validateRR } from './rr';
+import { isAfterFlat } from './curfew';
+
+export function evaluateTicket(
+  input: TicketInput,
+  opts: { minRR: number; maxRR: number; flatByUtc: string; now?: Date },
+): EvaluateResult {
+  const rr = calcRR(input);
+  if (!Number.isFinite(rr)) {
+    return { decision: 'reject', reasons: ['invalid risk/reward geometry'] };
+  }
+
+  const check = validateRR(rr, opts.minRR, opts.maxRR);
+  if (!check.ok) {
+    return { decision: 'reject', rr, reasons: [check.reason!] };
+  }
+
+  const now = opts.now ?? new Date();
+  if (isAfterFlat(now, opts.flatByUtc)) {
+    return { decision: 'reject', rr, reasons: ['eod flat cutoff'] };
+  }
+
+  return {
+    decision: 'accept',
+    rr,
+    reasons: [],
+    normalized: input,
+    suggestions: { halfSizeSuggested: false },
+  };
+}

--- a/packages/rules-apex/src/index.ts
+++ b/packages/rules-apex/src/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './rr';
+export * from './curfew';
+export * from './sizing';
+export * from './consistency';
+export * from './evaluate';

--- a/packages/rules-apex/src/rr.ts
+++ b/packages/rules-apex/src/rr.ts
@@ -1,0 +1,30 @@
+import { TicketInput } from './types';
+
+export function calcRR(input: TicketInput): number {
+  const { side, entry, stop, target } = input;
+  let risk: number;
+  let reward: number;
+  if (side === 'long') {
+    risk = entry - stop;
+    reward = target - entry;
+  } else {
+    risk = stop - entry;
+    reward = entry - target;
+  }
+  if (risk <= 0 || reward <= 0) return NaN;
+  return reward / risk;
+}
+
+export function validateRR(
+  rr: number,
+  minRR: number,
+  maxRR: number,
+): { ok: boolean; reason?: string } {
+  if (rr < minRR) {
+    return { ok: false, reason: 'rr below min' };
+  }
+  if (rr > maxRR) {
+    return { ok: false, reason: 'rr above max' };
+  }
+  return { ok: true };
+}

--- a/packages/rules-apex/src/sizing.ts
+++ b/packages/rules-apex/src/sizing.ts
@@ -1,0 +1,11 @@
+export function suggestPercent(
+  maxContracts: number,
+  bufferCleared: boolean,
+  pctWhenNoBuffer: number,
+  pctWithBuffer: number,
+): { contracts: number; halfSizeSuggested: boolean } {
+  const pct = bufferCleared ? pctWithBuffer : pctWhenNoBuffer;
+  const contracts = Math.max(1, Math.floor(maxContracts * pct));
+  const halfSizeSuggested = !bufferCleared && pctWhenNoBuffer < pctWithBuffer;
+  return { contracts, halfSizeSuggested };
+}

--- a/packages/rules-apex/src/types.ts
+++ b/packages/rules-apex/src/types.ts
@@ -1,0 +1,27 @@
+export type Side = 'long' | 'short';
+
+export type TicketInput = {
+  symbol: string; // e.g. ES, NQ, MES, MNQ or full code
+  side: Side;
+  entry: number;
+  stop: number;
+  target: number;
+  timestampUtc?: string; // ISO
+  meta?: Record<string, unknown>;
+};
+
+export type AccountInfo = {
+  id: string;
+  maxContracts: number; // plan max
+  bufferCleared: boolean; // true if trailing DD buffer cleared
+};
+
+export type EvaluateResult =
+  | {
+      decision: 'accept';
+      rr: number;
+      reasons: string[];
+      normalized: TicketInput;
+      suggestions: { halfSizeSuggested: boolean };
+    }
+  | { decision: 'reject'; rr?: number; reasons: string[] };

--- a/packages/rules-apex/tests/consistency.test.ts
+++ b/packages/rules-apex/tests/consistency.test.ts
@@ -1,0 +1,16 @@
+import { summarizeConsistency } from '../src/consistency';
+
+describe('consistency', () => {
+  it('summarizes pnl array', () => {
+    const pnls = [
+      { date: '2024-01-01', pnl: 100 },
+      { date: '2024-01-02', pnl: 300 },
+      { date: '2024-01-03', pnl: -50 },
+    ];
+    const res = summarizeConsistency(pnls, { dayShareLimit: 0.3, minProfitDayUsd: 50 });
+    expect(res.totalProfit).toBe(400);
+    expect(res.topDayShare).toBeCloseTo(0.75);
+    expect(res.profitableDays).toBe(2);
+    expect(res.limitBreached).toBe(true);
+  });
+});

--- a/packages/rules-apex/tests/curfew.test.ts
+++ b/packages/rules-apex/tests/curfew.test.ts
@@ -1,0 +1,15 @@
+import { isAfterFlat } from '../src/curfew';
+
+describe('curfew', () => {
+  const flatByUtc = '20:59';
+
+  it('returns false before cutoff', () => {
+    const now = new Date('2020-01-01T20:58:00Z');
+    expect(isAfterFlat(now, flatByUtc)).toBe(false);
+  });
+
+  it('returns true at cutoff', () => {
+    const now = new Date('2020-01-01T20:59:00Z');
+    expect(isAfterFlat(now, flatByUtc)).toBe(true);
+  });
+});

--- a/packages/rules-apex/tests/evaluate.test.ts
+++ b/packages/rules-apex/tests/evaluate.test.ts
@@ -1,0 +1,29 @@
+import { evaluateTicket } from '../src/evaluate';
+import { TicketInput } from '../src/types';
+
+describe('evaluateTicket', () => {
+  const opts = { minRR: 1.5, maxRR: 5, flatByUtc: '20:59' };
+
+  it('accepts valid long and short before cutoff', () => {
+    const long: TicketInput = { symbol: 'ES', side: 'long', entry: 100, stop: 95, target: 110 };
+    const short: TicketInput = { symbol: 'ES', side: 'short', entry: 100, stop: 105, target: 90 };
+    const now = new Date('2020-01-01T20:58:00Z');
+    expect(evaluateTicket(long, { ...opts, now }).decision).toBe('accept');
+    expect(evaluateTicket(short, { ...opts, now }).decision).toBe('accept');
+  });
+
+  it('rejects after cutoff', () => {
+    const payload: TicketInput = { symbol: 'ES', side: 'long', entry: 100, stop: 95, target: 110 };
+    const now = new Date('2020-01-01T20:59:00Z');
+    const res = evaluateTicket(payload, { ...opts, now });
+    expect(res.decision).toBe('reject');
+    expect(res.reasons).toContain('eod flat cutoff');
+  });
+
+  it('rejects invalid geometry', () => {
+    const bad: TicketInput = { symbol: 'ES', side: 'long', entry: 100, stop: 101, target: 110 };
+    const res = evaluateTicket(bad, { ...opts, now: new Date('2020-01-01T20:58:00Z') });
+    expect(res.decision).toBe('reject');
+    expect(res.reasons).toContain('invalid risk/reward geometry');
+  });
+});

--- a/packages/rules-apex/tests/rr.test.ts
+++ b/packages/rules-apex/tests/rr.test.ts
@@ -1,0 +1,18 @@
+import { validateRR } from '../src/rr';
+
+describe('validateRR', () => {
+  it('rejects rr below min', () => {
+    const res = validateRR(1.3, 1.5, 5);
+    expect(res).toEqual({ ok: false, reason: 'rr below min' });
+  });
+
+  it('rejects rr above max', () => {
+    const res = validateRR(6, 1.5, 5);
+    expect(res).toEqual({ ok: false, reason: 'rr above max' });
+  });
+
+  it('accepts rr within range', () => {
+    const res = validateRR(2, 1.5, 5);
+    expect(res).toEqual({ ok: true });
+  });
+});

--- a/packages/rules-apex/tests/sizing.test.ts
+++ b/packages/rules-apex/tests/sizing.test.ts
@@ -1,0 +1,13 @@
+import { suggestPercent } from '../src/sizing';
+
+describe('sizing', () => {
+  it('suggests half size when buffer not cleared', () => {
+    const res = suggestPercent(10, false, 0.5, 1.0);
+    expect(res).toEqual({ contracts: 5, halfSizeSuggested: true });
+  });
+
+  it('suggests full size when buffer cleared', () => {
+    const res = suggestPercent(10, true, 0.5, 1.0);
+    expect(res).toEqual({ contracts: 10, halfSizeSuggested: false });
+  });
+});

--- a/packages/rules-apex/tsconfig.json
+++ b/packages/rules-apex/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src", "tests", "vitest.config.ts"]
+}

--- a/packages/rules-apex/vitest.config.ts
+++ b/packages/rules-apex/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,21 @@ importers:
         specifier: ^8.7.0
         version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
 
+  packages/rules-apex:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.10.0
+        version: 9.33.0
+      eslint:
+        specifier: ^9.10.0
+        version: 9.33.0(jiti@2.5.1)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.6.2
+      typescript-eslint:
+        specifier: ^8.7.0
+        version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+
   packages/sdk: {}
 
   packages/signals:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+  - 'packages/rules-apex'


### PR DESCRIPTION
## Summary
- Pure package only; no API wiring yet
- Vitest unit tests for rr/curfew/sizing/consistency/evaluate
- Workspace updated to include package

### Exports
- `calcRR` and `validateRR` for risk/reward calculations
- `isAfterFlat` and `withinSuppressionWindow` for end-of-day cutoff
- `suggestPercent` for percent-based position sizing
- `summarizeConsistency` for PnL consistency metrics
- `evaluateTicket` composition helper

## Testing
- `pnpm --filter @prism-apex-tool/rules-apex test`


------
https://chatgpt.com/codex/tasks/task_b_68ac6949377c832c992692983c7f146a