### PR TITLE
feat(api): TradingView webhook + guard validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,6 @@ CONSISTENCY_WINDOW_DAYS=8
 # Profit quality floor (present but OFF by default)
 MIN_PROFIT_TICKS=
 MIN_EXPECTED_PROFIT_USD=
+
+# TradingView Webhook
+TRADINGVIEW_WEBHOOK_SECRET=

--- a/apps/api/src/__tests__/webhooks.tradingview.spec.ts
+++ b/apps/api/src/__tests__/webhooks.tradingview.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { normalizeSymbol } from '../routes/webhooks.tradingview';
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tvw-'));
+  process.env.FLAT_BY_UTC = '23:59';
+});
+
+describe('TradingView webhook', () => {
+  it('returns 422 when secret not configured', async () => {
+    ({ buildServer } = await import('../server.js'));
+    const app = buildServer();
+    const res = await app.inject({ method: 'POST', url: '/webhooks/tradingview', payload: {} });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('returns 401 when secret missing or invalid', async () => {
+    process.env.TRADINGVIEW_WEBHOOK_SECRET = 's';
+    ({ buildServer } = await import('../server.js'));
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/tradingview',
+      headers: { 'x-webhook-secret': 'bad' },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 422 when guard rejects', async () => {
+    process.env.TRADINGVIEW_WEBHOOK_SECRET = 's';
+    ({ buildServer } = await import('../server.js'));
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/tradingview',
+      headers: { 'x-webhook-secret': 's' },
+      payload: { symbol: 'ES', side: 'BUY', entry: 100, stop: 99, target: 101 },
+    });
+    expect(res.statusCode).toBe(422);
+    expect(res.json()).toMatchObject({ accepted: false });
+  });
+
+  it('returns 202 when guard accepts valid payload', async () => {
+    process.env.TRADINGVIEW_WEBHOOK_SECRET = 's';
+    ({ buildServer } = await import('../server.js'));
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/tradingview',
+      headers: { 'x-webhook-secret': 's' },
+      payload: { symbol: 'ES', side: 'BUY', entry: 100, stop: 99, target: 103 },
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.json()).toMatchObject({ accepted: true, rr: expect.any(Number) });
+  });
+
+  it('normalizes ES1! to ES', () => {
+    expect(normalizeSymbol('ES1!')).toBe('ES');
+  });
+});

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -32,6 +32,7 @@ export type Config = {
     minProfitTicks?: number;
     minExpectedProfitUsd?: number;
   };
+  webhook: { tradingviewSecret?: string };
 };
 
 function parseIntWithDefault(v: string | undefined, def: number): number {
@@ -62,6 +63,7 @@ const envSchema = z.object({
     (v) => (v === '' || v === undefined ? undefined : Number(v)),
     z.number().gt(0).optional()
   ),
+  TRADINGVIEW_WEBHOOK_SECRET: z.string().min(1).optional(),
 });
 
 export function getConfig(env = process.env): Config {
@@ -112,6 +114,9 @@ export function getConfig(env = process.env): Config {
     profitFloor: {
       minProfitTicks: parsed.MIN_PROFIT_TICKS,
       minExpectedProfitUsd: parsed.MIN_EXPECTED_PROFIT_USD,
+    },
+    webhook: {
+      tradingviewSecret: parsed.TRADINGVIEW_WEBHOOK_SECRET,
     },
   };
 }

--- a/apps/api/src/lib/ctEqual.ts
+++ b/apps/api/src/lib/ctEqual.ts
@@ -1,0 +1,9 @@
+export function ctEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+export default ctEqual;

--- a/apps/api/src/routes/webhooks.tradingview.ts
+++ b/apps/api/src/routes/webhooks.tradingview.ts
@@ -1,0 +1,78 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import { getConfig } from '../config/env';
+import { applyGuardrails } from '../lib/guard';
+import type { TicketInput } from '@prism-apex-tool/rules-apex';
+import { store } from '../store';
+import { alertSchema } from '../schemas/alert';
+import type { ParseResult } from '../types';
+import { ctEqual } from '../lib/ctEqual';
+
+export function normalizeSymbol(sym: string): string {
+  return sym.replace(/\d+!$/, '');
+}
+
+const rawPayload = z.object({
+  symbol: z.string(),
+  side: z.enum(['BUY', 'SELL']),
+  entry: z.coerce.number(),
+  stop: z.coerce.number(),
+  target: z.coerce.number(),
+  meta: z.record(z.unknown()).optional(),
+});
+
+const normalizedPayload = rawPayload.extend({
+  timestampUtc: z.string(),
+});
+
+const payloadSchema = z.union([normalizedPayload, rawPayload]);
+
+export async function tradingviewWebhookRoutes(app: FastifyInstance) {
+  app.post('/tradingview', async (req, reply) => {
+    const cfg = getConfig();
+    const secret = cfg.webhook.tradingviewSecret;
+    if (!secret) {
+      return reply.code(422).send({ error: 'webhook disabled: secret not configured' });
+    }
+    const headerSecret = req.headers['x-webhook-secret'];
+    if (typeof headerSecret !== 'string' || !ctEqual(headerSecret, secret)) {
+      return reply.code(401).send({ error: 'unauthorized' });
+    }
+
+    const parsed = payloadSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'invalid payload' });
+    }
+    const p = parsed.data;
+    const ticket: TicketInput = {
+      symbol: normalizeSymbol(p.symbol),
+      side: p.side === 'BUY' ? 'long' : 'short',
+      entry: p.entry,
+      stop: p.stop,
+      target: p.target,
+      timestampUtc: 'timestampUtc' in p ? p.timestampUtc : undefined,
+      meta: p.meta,
+    };
+
+    const decision = applyGuardrails(ticket);
+    if (!decision.accepted) {
+      req.log.warn({ rr: decision.rr, reasons: decision.reasons }, 'tradingview webhook rejected');
+      return reply
+        .code(422)
+        .send({ accepted: false, rr: decision.rr, reasons: decision.reasons });
+    }
+
+    let queuedId: string | undefined;
+    const maybeAlert = alertSchema.safeParse(req.body);
+    if (maybeAlert.success) {
+      queuedId = store.enqueueAlert(maybeAlert.data as ParseResult).id;
+    }
+
+    const res: { accepted: true; rr: number; queuedId?: string } = {
+      accepted: true,
+      rr: decision.rr,
+    };
+    if (queuedId) res.queuedId = queuedId;
+    return reply.code(202).send(res);
+  });
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -18,6 +18,7 @@ import { versionRoutes } from './routes/version.js';
 import { analyticsRoutes } from './routes/analytics.js';
 import { auditRoutes } from './routes/audit.js';
 import { ticketsRoutes } from './routes/tickets.js';
+import { tradingviewWebhookRoutes } from './routes/webhooks.tradingview.js';
 import { readyRoutes } from './routes/ready.js';
 import { getConfig } from './config/env';
 
@@ -37,6 +38,8 @@ export function buildServer() {
       redact: [
         'req.headers.authorization',
         'headers.authorization',
+        'req.headers["x-webhook-secret"]',
+        'headers["x-webhook-secret"]',
         'password',
         'token',
         'authorization',
@@ -66,7 +69,7 @@ export function buildServer() {
   );
   app.register(cors, { origin: true });
   // Public paths (no auth/rate-limit)
-  const publicPaths = ['/health', '/ready', '/openapi.json', '/version'];
+  const publicPaths = ['/health', '/ready', '/openapi.json', '/version', '/webhooks/tradingview'];
 
   app.register(authPlugin, { publicPaths });
   app.register(rateLimit, { publicPaths });
@@ -89,6 +92,7 @@ export function buildServer() {
   app.register(openapiRoute);
   app.register(compatRoutes, { prefix: '/compat' });
   app.register(ticketsRoutes);
+  app.register(tradingviewWebhookRoutes, { prefix: '/webhooks' });
 
   // ---- Jobs ----
   registerJob('EOD_FLAT', 60_000, jobEodFlat);

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,3 +17,21 @@
 | MIN_EXPECTED_PROFIT_USD | (blank) | profit floor disabled |
 
 Consistency is tracked only in V1; enforcement comes later.
+
+## TradingView Webhook
+
+Set `TRADINGVIEW_WEBHOOK_SECRET` in your environment.
+
+Example alert:
+
+```json
+{
+  "symbol": "ES1!",
+  "side": "BUY",
+  "entry": 5050.25,
+  "stop": 5046.25,
+  "target": 5055.25
+}
+```
+
+Send to `POST /webhooks/tradingview` with header `x-webhook-secret: <secret>`.


### PR DESCRIPTION
## Summary
- add TradingView webhook route protected by shared secret
- document and wire up webhook config and OpenAPI docs
- include unit tests, constant-time secret check, and docs

## Testing
- `pnpm --filter ./apps/api typecheck`
- `pnpm --filter ./apps/api test`
- `pnpm --filter @prism-apex-tool/rules-apex test`


------
https://chatgpt.com/codex/tasks/task_b_68ac70d58e1c832c8d8a7d2006e4e925