### PR TITLE
feat(accounts): per-account FS registry + CLI (buffer & sizing readiness)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ reports/
 
 # Misc
 .DS_Store
+data/accounts/

--- a/apps/api/src/lib/accounts.ts
+++ b/apps/api/src/lib/accounts.ts
@@ -1,0 +1,12 @@
+import { listAccounts, readAccount, upsertAccount, type AccountFile } from '@prism-apex-tool/accounts';
+import path from 'node:path';
+
+function dataDir(): string {
+  return process.env.DATA_DIR ?? path.resolve(process.cwd(), 'data');
+}
+
+export const Accounts = {
+  list: () => listAccounts(dataDir()),
+  get: (id: string) => readAccount(dataDir(), id),
+  upsert: (input: Partial<AccountFile> & { id: string }) => upsertAccount(dataDir(), input),
+};

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@prism-apex-tool/accounts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "prism-accounts": "dist/cli.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier -w ."
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@eslint/js": "^9.10.0",
+    "eslint": "^9.10.0",
+    "prettier": "^3.3.3",
+    "typescript-eslint": "^8.7.0",
+    "vitest": "^2.0.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/accounts/src/cli.ts
+++ b/packages/accounts/src/cli.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { listAccounts, readAccount, upsertAccount } from './fs.js';
+
+function parseArgs(argv: string[]): Record<string, string> {
+  const opts: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const value = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+      opts[key] = value;
+    }
+  }
+  return opts;
+}
+
+function help(): void {
+  console.log(`Usage: prism-accounts <command> [options]
+
+Commands:
+  list
+  add --id <id> --max <n> [--cleared true|false] [--notes "..."]
+  set --id <id> [--max <n>] [--cleared true|false] [--notes "..."]
+  get --id <id>
+
+Options:
+  --data-dir <path>
+`);
+}
+
+async function main(): Promise<void> {
+  const [cmd, ...rest] = process.argv.slice(2);
+  if (!cmd || cmd === '-h' || cmd === '--help') {
+    help();
+    process.exit(0);
+  }
+  const opts = parseArgs(rest);
+  const dataDir = opts['data-dir'] ?? process.env.DATA_DIR ?? './data';
+  try {
+    switch (cmd) {
+      case 'list': {
+        const accounts = await listAccounts(dataDir);
+        console.log(JSON.stringify(accounts, null, 2));
+        break;
+      }
+      case 'add': {
+        const id = opts['id'];
+        const max = opts['max'];
+        if (!id || max === undefined) throw new Error('id and max required');
+        const cleared = opts['cleared'] ? opts['cleared'] === 'true' : undefined;
+        const acct = await upsertAccount(dataDir, {
+          id,
+          maxContracts: Number(max),
+          bufferCleared: cleared,
+          notes: opts['notes'],
+        });
+        console.log(JSON.stringify(acct, null, 2));
+        break;
+      }
+      case 'set': {
+        const id = opts['id'];
+        if (!id) throw new Error('id required');
+        const cleared = opts['cleared'] ? opts['cleared'] === 'true' : undefined;
+        const acct = await upsertAccount(dataDir, {
+          id,
+          maxContracts: opts['max'] !== undefined ? Number(opts['max']) : undefined,
+          bufferCleared: cleared,
+          notes: opts['notes'],
+        });
+        console.log(JSON.stringify(acct, null, 2));
+        break;
+      }
+      case 'get': {
+        const id = opts['id'];
+        if (!id) throw new Error('id required');
+        const acct = await readAccount(dataDir, id);
+        if (!acct) throw new Error('not found');
+        console.log(JSON.stringify(acct, null, 2));
+        break;
+      }
+      default:
+        help();
+        process.exit(1);
+    }
+  } catch (err: any) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/accounts/src/fs.ts
+++ b/packages/accounts/src/fs.ts
@@ -1,0 +1,87 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { AccountFile } from './types.js';
+
+const DEFAULT_DATA_DIR = process.env.DATA_DIR ?? './data';
+
+export function accountPath(dataDir: string = DEFAULT_DATA_DIR, id: string): string {
+  return path.join(dataDir, 'accounts', `${id}.json`);
+}
+
+export async function ensureDir(dataDir: string = DEFAULT_DATA_DIR): Promise<string> {
+  const dir = path.join(dataDir, 'accounts');
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function validate(acct: AccountFile): void {
+  if (!acct.id) throw new Error('id required');
+  if (typeof acct.maxContracts !== 'number') throw new Error('maxContracts required');
+  if (typeof acct.bufferCleared !== 'boolean') throw new Error('bufferCleared required');
+  if (acct.notes !== undefined && typeof acct.notes !== 'string')
+    throw new Error('notes must be string');
+}
+
+export async function listAccounts(dataDir: string = DEFAULT_DATA_DIR): Promise<AccountFile[]> {
+  const dir = await ensureDir(dataDir);
+  const files = await fs.readdir(dir);
+  const accounts: AccountFile[] = [];
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue;
+    try {
+      const content = await fs.readFile(path.join(dir, file), 'utf8');
+      const acct = JSON.parse(content) as AccountFile;
+      validate(acct);
+      accounts.push(acct);
+    } catch {
+      /* skip invalid */
+    }
+  }
+  return accounts;
+}
+
+export async function readAccount(
+  dataDir: string = DEFAULT_DATA_DIR,
+  id: string,
+): Promise<AccountFile | undefined> {
+  const file = accountPath(dataDir, id);
+  try {
+    const content = await fs.readFile(file, 'utf8');
+    const acct = JSON.parse(content) as AccountFile;
+    validate(acct);
+    return acct;
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') return undefined;
+    throw err;
+  }
+}
+
+export async function writeAccount(
+  dataDir: string = DEFAULT_DATA_DIR,
+  acct: AccountFile,
+): Promise<void> {
+  const dir = await ensureDir(dataDir);
+  validate(acct);
+  acct.updatedAt = new Date().toISOString();
+  const finalPath = path.join(dir, `${acct.id}.json`);
+  const tmpPath = path.join(dir, `.${acct.id}.tmp`);
+  const data = JSON.stringify(acct, null, 2);
+  await fs.writeFile(tmpPath, data);
+  await fs.rename(tmpPath, finalPath);
+}
+
+export async function upsertAccount(
+  dataDir: string = DEFAULT_DATA_DIR,
+  input: { id: string; maxContracts?: number; bufferCleared?: boolean; notes?: string },
+): Promise<AccountFile> {
+  const existing = await readAccount(dataDir, input.id);
+  const acct: AccountFile = {
+    id: input.id,
+    maxContracts: input.maxContracts ?? existing?.maxContracts ?? 0,
+    bufferCleared: input.bufferCleared ?? existing?.bufferCleared ?? false,
+    notes: input.notes ?? existing?.notes,
+    updatedAt: '',
+  };
+  await writeAccount(dataDir, acct);
+  return acct;
+}

--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './fs.js';

--- a/packages/accounts/src/types.ts
+++ b/packages/accounts/src/types.ts
@@ -1,0 +1,7 @@
+export type AccountFile = {
+  id: string;
+  maxContracts: number;
+  bufferCleared: boolean;
+  updatedAt: string;
+  notes?: string;
+};

--- a/packages/accounts/tests/fs.test.ts
+++ b/packages/accounts/tests/fs.test.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { promises as fs } from 'node:fs';
+import { expect, test } from 'vitest';
+import { accountPath, listAccounts, readAccount, upsertAccount } from '../src/fs.js';
+import type { AccountFile } from '../src/types.js';
+
+async function tempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(tmpdir(), 'accounts-test-'));
+}
+
+test('add then get → matches schema; updatedAt set', async () => {
+  const dir = await tempDir();
+  const acct = await upsertAccount(dir, { id: 'A1', maxContracts: 5 });
+  expect(acct.id).toBe('A1');
+  expect(acct.maxContracts).toBe(5);
+  expect(acct.bufferCleared).toBe(false);
+  expect(typeof acct.updatedAt).toBe('string');
+  const read = await readAccount(dir, 'A1');
+  expect(read).toEqual(acct);
+});
+
+test('set --cleared true persists', async () => {
+  const dir = await tempDir();
+  await upsertAccount(dir, { id: 'A1', maxContracts: 1 });
+  await upsertAccount(dir, { id: 'A1', bufferCleared: true });
+  const read = await readAccount(dir, 'A1');
+  expect(read?.bufferCleared).toBe(true);
+});
+
+test('list returns all files', async () => {
+  const dir = await tempDir();
+  await upsertAccount(dir, { id: 'A1', maxContracts: 1 });
+  await upsertAccount(dir, { id: 'A2', maxContracts: 2 });
+  const list = await listAccounts(dir);
+  const ids = list.map((a) => a.id).sort();
+  expect(ids).toEqual(['A1', 'A2']);
+});
+
+test('atomic write leaves valid JSON', async () => {
+  const dir = await tempDir();
+  await upsertAccount(dir, { id: 'A1', maxContracts: 1 });
+  const file = accountPath(dir, 'A1');
+  const data = JSON.parse(await fs.readFile(file, 'utf8')) as AccountFile;
+  expect(data.id).toBe('A1');
+  const tmp = path.join(path.dirname(file), '.A1.tmp');
+  await expect(fs.access(tmp)).rejects.toBeTruthy();
+});

--- a/packages/accounts/tsconfig.json
+++ b/packages/accounts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src"]
+}

--- a/packages/accounts/vitest.config.ts
+++ b/packages/accounts/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,27 @@ importers:
         specifier: ^1.47.2
         version: 1.54.2
 
+  packages/accounts:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.10.0
+        version: 9.33.0
+      eslint:
+        specifier: ^9.10.0
+        version: 9.33.0(jiti@2.5.1)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.6.2
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.7.0
+        version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
+
   packages/analytics:
     devDependencies:
       '@eslint/js':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - 'apps/*'
   - 'packages/*'
   - 'packages/rules-apex'
+  - 'packages/accounts'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,7 +18,8 @@
       "@prism-apex-tool/audit": ["packages/audit/src"],
       "@prism-apex-tool/reporting": ["packages/reporting/src"],
       "@prism-apex-tool/signals": ["packages/signals/src"],
-      "@prism-apex-tool/rules-apex": ["packages/rules-apex/src"]
+      "@prism-apex-tool/rules-apex": ["packages/rules-apex/src"],
+      "@prism-apex-tool/accounts": ["packages/accounts/src"]
     }
   },
   "exclude": ["packages/clients-tradovate", "apps/dashboard", "apps/e2e", "sdks"]


### PR DESCRIPTION
## Summary
- add filesystem-backed account registry with per-account JSON files
- provide prism-accounts CLI for list/add/get/set
- expose Accounts wrapper inside API app

## Testing
- `pnpm --filter @prism-apex-tool/accounts typecheck`
- `pnpm --filter @prism-apex-tool/accounts test`
- `pnpm --filter ./apps/api typecheck`

## Usage
```bash
pnpm --filter @prism-apex-tool/accounts build
node packages/accounts/dist/cli.js add --id Apex-PA-12345 --max 5
node packages/accounts/dist/cli.js list
```

## Checklist
- [x] Per-account files under data/accounts/
- [x] Atomic write & validation
- [x] CLI: list/add/get/set
- [x] API wrapper added (no route changes)


------
https://chatgpt.com/codex/tasks/task_b_68ac7b67a060832cb168f47130adb095