### PR TITLE
feat(export): guard metadata in JSON and CSV; optional account sizing

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,6 +43,7 @@
     "zod": "^3.23.8",
     "@prism-apex-tool/reporting": "workspace:*",
     "@prism-apex-tool/signals": "workspace:*",
-    "@prism-apex-tool/rules-apex": "workspace:*"
+    "@prism-apex-tool/rules-apex": "workspace:*",
+    "@prism-apex-tool/accounts": "workspace:*"
   }
 }

--- a/apps/api/src/__tests__/e2e.sdk.spec.ts
+++ b/apps/api/src/__tests__/e2e.sdk.spec.ts
@@ -65,7 +65,7 @@ describe('E2E SDK→API smoke', () => {
     expect(tickets.length).toBeGreaterThan(0);
 
     // --- Export CSV ---
-    const csvRes = await fetch(new URL('/export/tickets?date=2025-01-01', baseUrl));
+    const csvRes = await fetch(new URL('/export/tickets?date=2025-01-01&format=csv', baseUrl));
     expect(csvRes.ok).toBe(true);
     const ct = csvRes.headers.get('content-type') ?? '';
     expect(ct.includes('text/csv')).toBe(true);

--- a/apps/api/src/__tests__/export.spec.ts
+++ b/apps/api/src/__tests__/export.spec.ts
@@ -1,19 +1,21 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 let buildServer: typeof import('../server.js').buildServer;
 let store: typeof import('../store.js').store;
+let Accounts: typeof import('../lib/accounts.js').Accounts;
 
 beforeEach(async () => {
   process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'export-'));
   ({ buildServer } = await import('../server.js'));
   ({ store } = await import('../store.js'));
+  ({ Accounts } = await import('../lib/accounts.js'));
 });
 
 describe('Export API', () => {
-  it('exports tickets as CSV', async () => {
+  it('returns enriched JSON by default', async () => {
     store.appendTicket({
       when: '2024-08-24T12:00:00Z',
       ticket: {
@@ -30,8 +32,89 @@ describe('Export API', () => {
     const app = buildServer();
     const res = await app.inject({ method: 'GET', url: '/export/tickets?date=2024-08-24' });
     expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/json');
+    const body = res.json();
+    expect(body[0]).toHaveProperty('accepted');
+    expect(body[0]).toHaveProperty('rr');
+    expect(body[0].flatByUtc).toBe('20:59');
+  });
+
+  it('exports CSV when format=csv', async () => {
+    store.appendTicket({
+      when: '2024-08-24T12:00:00Z',
+      ticket: {
+        id: 't1',
+        symbol: 'ES',
+        side: 'BUY',
+        qty: 1,
+        entry: 1,
+        stop: 0,
+        targets: [2],
+      } as any,
+      reasons: [],
+    });
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/export/tickets?date=2024-08-24&format=csv',
+    });
+    expect(res.statusCode).toBe(200);
     expect(res.headers['content-type']).toContain('text/csv');
-    expect(res.body).toContain('symbol');
-    expect(res.body).toContain('ES');
+    expect(res.body).toContain('accepted');
+    expect(res.body).toContain('rr');
+  });
+
+  it('includes sizing when accountId provided', async () => {
+    await Accounts.upsert({ id: 'PA-TEST', maxContracts: 10, bufferCleared: true });
+    store.appendTicket({
+      when: '2024-08-24T12:00:00Z',
+      ticket: {
+        id: 't1',
+        symbol: 'ES',
+        side: 'BUY',
+        qty: 1,
+        entry: 1,
+        stop: 0,
+        targets: [2],
+      } as any,
+      reasons: [],
+    });
+    const app = buildServer();
+    const resJson = await app.inject({
+      method: 'GET',
+      url: '/export/tickets?date=2024-08-24&accountId=PA-TEST',
+    });
+    const body = resJson.json();
+    expect(body[0]).toHaveProperty('sizeSuggested');
+    expect(body[0]).toHaveProperty('halfSizeSuggested');
+    const resCsv = await app.inject({
+      method: 'GET',
+      url: '/export/tickets?date=2024-08-24&accountId=PA-TEST&format=csv',
+    });
+    expect(resCsv.body).toContain('size_suggested');
+  });
+
+  it('marks preCloseSuppressed within window', async () => {
+    process.env.FLAT_BY_UTC = '20:59';
+    store.appendTicket({
+      when: '2024-08-24T20:55:00Z',
+      ticket: {
+        id: 't1',
+        symbol: 'ES',
+        side: 'BUY',
+        qty: 1,
+        entry: 1,
+        stop: 0,
+        targets: [2],
+      } as any,
+      reasons: [],
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-08-24T20:55:00Z'));
+    const app = buildServer();
+    const res = await app.inject({ method: 'GET', url: '/export/tickets?date=2024-08-24' });
+    vi.useRealTimers();
+    const body = res.json();
+    expect(body[0].preCloseSuppressed).toBe(true);
   });
 });

--- a/docs/export.md
+++ b/docs/export.md
@@ -1,0 +1,37 @@
+# Ticket export
+
+`GET /export/tickets?date=YYYY-MM-DD&format=json|csv&accountId=ID`
+
+Exports tickets for a given UTC date. The default `format` is `json`. Use `format=csv` for a compact CSV output. When `accountId` is supplied and the account exists, sizing suggestions are included.
+
+## JSON example
+
+```json
+[
+  {
+    "when": "2024-08-24T12:00:00Z",
+    "symbol": "ES",
+    "side": "BUY",
+    "qty": 1,
+    "entry": 1,
+    "stop": 0,
+    "target": 2,
+    "accepted": true,
+    "rr": 2,
+    "reasons": [],
+    "preCloseSuppressed": false,
+    "flatByUtc": "20:59",
+    "sizeSuggested": 2,
+    "halfSizeSuggested": false
+  }
+]
+```
+
+## CSV example
+
+```
+ts,symbol,side,entry,stop,target,rr,accepted,reason_summary,pre_close,flat_by_utc,size_suggested,half_size_suggested
+2024-08-24T12:00:00Z,ES,BUY,1,0,2,2,true,,false,20:59,2,false
+```
+
+Sizing fields appear only when `accountId` is provided and an account file exists in the data directory.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@fastify/sensible':
         specifier: 6.0.3
         version: 6.0.3
+      '@prism-apex-tool/accounts':
+        specifier: workspace:*
+        version: link:../../packages/accounts
       '@prism-apex-tool/reporting':
         specifier: workspace:*
         version: link:../../packages/reporting


### PR DESCRIPTION
## Summary
- enrich ticket export with guard metadata and optional sizing
- support JSON or CSV output via `format`
- document export endpoint usage

## Testing
- `pnpm --filter ./apps/api typecheck`
- `pnpm --filter ./apps/api test`
- `pnpm --filter @prism-apex-tool/accounts test`
- `pnpm --filter @prism-apex-tool/rules-apex test`


------
https://chatgpt.com/codex/tasks/task_b_68ac8ad75030832ca33ba4e2b4ec0e4e