### PR TITLE
ops(systemd): unit + Ubuntu runbook for HTTP deploy

### DIFF
--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -1,0 +1,75 @@
+# Prism Apex — Ubuntu VM (systemd) Runbook
+
+## Prereqs
+- Ubuntu 22.04+ VM (you chose VM deployment)
+- Open outbound internet for npm install; inbound TCP :8000 (or reverse proxy)
+- Node LTS and pnpm (installer script handles it)
+
+## One‑time setup (as a sudo‑capable user)
+```bash
+# 1) Clone the repo into prism user's home (or adjust REPO_DIR for your layout)
+sudo useradd -m -s /bin/bash prism || true
+sudo -u prism -H bash -lc 'cd ~ && git clone https://github.com/QuantumFluxAlgo/prism-apex-tool.git || true'
+# If already cloned, pull latest Test branch
+sudo -u prism -H bash -lc 'cd ~/prism-apex-tool && git fetch && git checkout Test && git pull'
+
+# 2) Run the installer
+cd ~/prism-apex-tool
+sudo APP_USER=prism REPO_DIR=/home/prism/prism-apex-tool bash infra/systemd/install-prism-apex.sh
+
+# 3) Edit env and set secrets
+sudo -u prism nano /home/prism/prism-apex.env
+# Set TRADINGVIEW_WEBHOOK_SECRET and (optionally) BEARER_TOKEN
+
+# 4) Start service
+sudo systemctl start prism-apex
+sudo systemctl status prism-apex --no-pager
+
+# 5) Verify health
+curl -s http://127.0.0.1:8000/health | jq .
+```
+
+Logs & lifecycle
+```
+journalctl -u prism-apex -f
+sudo systemctl restart prism-apex
+sudo systemctl stop prism-apex
+```
+
+Data directory
+
+Default: /home/prism/prism-apex-data (tickets, accounts, exports)
+
+Ensure backups if needed.
+
+Reverse proxy (optional, HTTP only here)
+
+Leave service on HOST=0.0.0.0 PORT=8000
+
+Terminate TLS in Nginx/Traefik and forward to 127.0.0.1:8000
+
+If proxy adds X-Forwarded-*, set TRUST_PROXY=true in /home/prism/prism-apex.env
+
+Firewall quickstart (optional)
+```
+sudo ufw allow 22/tcp
+sudo ufw allow 8000/tcp   # or only allow from proxy host
+sudo ufw enable
+```
+
+Health endpoints
+
+GET /health → {"ok":true} when service is up
+
+GET /ready → readiness check
+
+GET /version → version metadata (if enabled)
+
+Updates / redeploy
+```
+sudo -u prism -H bash -lc 'cd ~/prism-apex-tool && git fetch && git checkout Test && git pull'
+sudo -u prism -H bash -lc 'pnpm install && pnpm --filter ./apps/api build'
+sudo systemctl restart prism-apex
+```
+
+---

--- a/infra/systemd/install-prism-apex.sh
+++ b/infra/systemd/install-prism-apex.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Defaults
+APP_USER="${APP_USER:-prism}"
+REPO_DIR="${REPO_DIR:-/home/${APP_USER}/prism-apex-tool}"
+DATA_DIR="${DATA_DIR:-/home/${APP_USER}/prism-apex-data}"
+ENV_FILE="${ENV_FILE:-/home/${APP_USER}/prism-apex.env}"
+SERVICE_SRC="${SERVICE_SRC:-${REPO_DIR}/infra/systemd/prism-apex.service}"
+
+# 1) Create user & dirs
+if ! id -u "$APP_USER" >/dev/null 2>&1; then
+  sudo useradd -m -s /bin/bash "$APP_USER"
+fi
+sudo mkdir -p "$DATA_DIR"
+sudo chown -R "$APP_USER:$APP_USER" "$DATA_DIR"
+
+# 2) Node & pnpm (if not installed)
+if ! command -v node >/dev/null 2>&1; then
+  curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+if ! command -v pnpm >/dev/null 2>&1; then
+  sudo npm -g install pnpm
+fi
+
+# 3) Build app
+cd "$REPO_DIR"
+sudo -u "$APP_USER" pnpm install
+sudo -u "$APP_USER" pnpm --filter ./apps/api build
+
+# 4) Seed env file if missing
+if [ ! -f "$ENV_FILE" ]; then
+  sudo -u "$APP_USER" cp "${REPO_DIR}/infra/systemd/prism-apex.env.example" "$ENV_FILE"
+  echo ">> Edit $ENV_FILE before starting (set TRADINGVIEW_WEBHOOK_SECRET, etc.)"
+fi
+
+# 5) Install systemd unit
+TMP_UNIT="$(mktemp)"
+sudo -u "$APP_USER" cp "$SERVICE_SRC" "$TMP_UNIT"
+sudo mv "$TMP_UNIT" /etc/systemd/system/prism-apex.service
+sudo systemctl daemon-reload
+sudo systemctl enable prism-apex.service
+
+echo ">> To start: sudo systemctl start prism-apex && sudo systemctl status prism-apex"
+echo ">> Health: curl -s http://127.0.0.1:8000/health | jq ."

--- a/infra/systemd/prism-apex.env.example
+++ b/infra/systemd/prism-apex.env.example
@@ -1,0 +1,39 @@
+# --- Prism Apex server env (copy to: /home/prism/prism-apex.env) ---
+NODE_ENV=production
+HOST=0.0.0.0
+PORT=8000
+LOG_LEVEL=info
+DATA_DIR=/home/prism/prism-apex-data
+
+# Rate limit
+RATE_LIMIT_MAX=60
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX_BUCKETS=50000
+
+# Guardrails
+MIN_RR=1.5
+MAX_RR=5
+FLAT_BY_UTC=20:59
+
+# Sizing policy
+SIZE_POLICY=percent-of-max
+PCT_OF_MAX_WHEN_NO_BUFFER=0.5
+PCT_OF_MAX_WHEN_BUFFER=1.0
+HALF_SIZE_UNTIL_BUFFER=true
+
+# Consistency (metrics only)
+CONSISTENCY_TRACKING_ENABLED=true
+CONSISTENCY_DAY_SHARE_LIMIT=0.3
+CONSISTENCY_MIN_PROFIT_DAY_USD=50
+CONSISTENCY_WINDOW_DAYS=8
+
+# Profit floor (leave blank to disable)
+MIN_PROFIT_TICKS=
+MIN_EXPECTED_PROFIT_USD=
+
+# Webhook secret (set a strong value in production)
+TRADINGVIEW_WEBHOOK_SECRET=
+# Optional bearer for private endpoints (leave blank to disable)
+BEARER_TOKEN=
+# Proxy trust (set true if behind reverse proxy like Nginx/Traefik)
+TRUST_PROXY=false

--- a/infra/systemd/prism-apex.service
+++ b/infra/systemd/prism-apex.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Prism Apex API
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=prism
+Group=prism
+WorkingDirectory=%h/prism-apex-tool/apps/api
+EnvironmentFile=%h/prism-apex.env
+# Node.js memory and file limits are reasonable by default; tweak if needed
+ExecStart=/usr/bin/node dist/index.js
+Restart=always
+RestartSec=3
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ProtectControlGroups=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectClock=true
+LockPersonality=true
+ReadWritePaths=%h/prism-apex-tool %h/prism-apex-data
+# Limits
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add hardened prism-apex systemd service and env template for HTTP deployments
- add installer script to create user, build app, and enable service
- document Ubuntu VM runbook for prism-apex systemd deployment

## Testing
- `pnpm --filter ./apps/api typecheck && pnpm --filter ./apps/api test` *(fails: Failed to resolve entry for package "@prism-apex-tool/accounts".)*

```bash
sudo systemctl start prism-apex
curl -s http://127.0.0.1:8000/health
```

------
https://chatgpt.com/codex/tasks/task_b_68ac943322b8832cb65d9693d1bb9f96