### PR TITLE
ops(nginx): TLS termination via Let’s Encrypt + reverse proxy to systemd API

### DIFF
--- a/infra/nginx/README.md
+++ b/infra/nginx/README.md
@@ -1,0 +1,48 @@
+# Prism Apex — Nginx + Let’s Encrypt TLS
+
+## Prereqs
+- DNS A/AAAA records for **YOUR_DOMAIN** pointing to this VM’s public IP
+- Prism Apex API running via systemd on `127.0.0.1:8000`
+- Ubuntu 22.04+ (or Debian-based)
+
+## One-time setup
+```bash
+# From repo root, as sudo-capable user
+export DOMAIN=YOUR_DOMAIN
+export EMAIL=you@example.com
+bash infra/nginx/setup-nginx-certbot.sh
+```
+
+### What this does
+
+- Installs Nginx + Certbot
+- Places site config at /etc/nginx/sites-available/prism-apex.conf
+- Obtains a Let’s Encrypt cert for $DOMAIN
+- Forces HTTPS + HTTP/2
+- Proxies to http://127.0.0.1:8000
+- Adds rate limiting and security headers
+
+### Verify
+```bash
+curl -I https://$DOMAIN/health
+# Should return HTTP/2 200
+```
+
+### Logs
+
+- /var/log/nginx/prism-apex.access.log
+- /var/log/nginx/prism-apex.error.log
+
+### Renewals
+
+Certbot installs a systemd timer. To test:
+
+```bash
+sudo certbot renew --dry-run
+```
+
+### TradingView
+
+Point your webhook to: https://$DOMAIN/webhooks/tradingview
+
+Add header: x-webhook-secret: <your secret>

--- a/infra/nginx/prism-apex.conf.example
+++ b/infra/nginx/prism-apex.conf.example
@@ -1,0 +1,96 @@
+# Replace YOUR_DOMAIN with the real hostname (e.g., prism.example.com)
+# Install path: /etc/nginx/sites-available/prism-apex.conf
+
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  ''      close;
+}
+
+# Basic rate limit zone (per IP)
+limit_req_zone $binary_remote_addr zone=prism_api:10m rate=5r/s;
+
+server {
+  listen 80;
+  listen [::]:80;
+  server_name YOUR_DOMAIN;
+
+  # Let’s Encrypt HTTP-01 challenge
+  location /.well-known/acme-challenge/ {
+    root /var/www/certbot;
+  }
+
+  # Redirect all other HTTP to HTTPS
+  location / {
+    return 301 https://$host$request_uri;
+  }
+}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name YOUR_DOMAIN;
+
+  # SSL certs (certbot will place/point these)
+  ssl_certificate     /etc/letsencrypt/live/YOUR_DOMAIN/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/YOUR_DOMAIN/privkey.pem;
+  ssl_trusted_certificate /etc/letsencrypt/live/YOUR_DOMAIN/chain.pem;
+
+  # Strong TLS defaults
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:SSL:10m;
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_prefer_server_ciphers on;
+
+  # Security headers
+  add_header X-Frame-Options DENY;
+  add_header X-Content-Type-Options nosniff;
+  add_header Referrer-Policy no-referrer-when-downgrade;
+  add_header X-XSS-Protection "1; mode=block";
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+  # Gzip
+  gzip on;
+  gzip_types application/json application/javascript text/css text/plain;
+
+  # Upstream to local systemd service
+  set $upstream "http://127.0.0.1:8000";
+
+  # Default API proxy (rate limited)
+  location / {
+    limit_req zone=prism_api burst=20 nodelay;
+    proxy_pass $upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Connection "";
+    proxy_read_timeout 30s;
+  }
+
+  # Healthcheck (no rate limit)
+  location = /health {
+    proxy_pass $upstream/health;
+    proxy_set_header Host $host;
+  }
+
+  # TradingView webhook: tighter limits and header pass-through
+  location = /webhooks/tradingview {
+    limit_req zone=prism_api burst=5 nodelay;
+    proxy_pass $upstream/webhooks/tradingview;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Webhook-Secret $http_x_webhook_secret; # forward exact header name
+    proxy_read_timeout 15s;
+  }
+
+  # Max body
+  client_max_body_size 1m;
+
+  # Access/error logs
+  access_log /var/log/nginx/prism-apex.access.log;
+  error_log  /var/log/nginx/prism-apex.error.log warn;
+}

--- a/infra/nginx/setup-nginx-certbot.sh
+++ b/infra/nginx/setup-nginx-certbot.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN="${DOMAIN:?Set DOMAIN, e.g. DOMAIN=prism.example.com}"
+EMAIL="${EMAIL:?Set EMAIL for Let’s Encrypt registration}"
+SITE_AVAIL="/etc/nginx/sites-available/prism-apex.conf"
+SITE_ENABLED="/etc/nginx/sites-enabled/prism-apex.conf"
+
+# 1) Install Nginx & Certbot (Debian/Ubuntu)
+if ! command -v nginx >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y nginx
+fi
+if ! command -v certbot >/dev/null 2>&1; then
+  sudo apt-get install -y certbot python3-certbot-nginx
+fi
+
+# 2) Place HTTP-only bootstrap config and create webroot
+sudo mkdir -p /var/www/certbot
+sudo chown -R www-data:www-data /var/www/certbot
+
+TMP_CONF="$(mktemp)"
+sed "s/YOUR_DOMAIN/${DOMAIN}/g" infra/nginx/prism-apex.conf.example > "$TMP_CONF"
+sudo cp "$TMP_CONF" "$SITE_AVAIL"
+sudo ln -sf "$SITE_AVAIL" "$SITE_ENABLED"
+
+# 3) Open firewall (UFW) if present
+if command -v ufw >/dev/null 2>&1; then
+  sudo ufw allow 'Nginx Full' || true
+fi
+
+# 4) Test and reload Nginx
+sudo nginx -t
+sudo systemctl reload nginx
+
+# 5) Obtain/renew cert (nginx plugin will rewrite the server block for TLS)
+sudo certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos -m "$EMAIL" --redirect
+
+# 6) Final test and reload
+sudo nginx -t
+sudo systemctl reload nginx
+
+echo ">> HTTPS ready at https://${DOMAIN}/health"

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -44,6 +44,8 @@ Ensure backups if needed.
 
 Reverse proxy (optional, HTTP only here)
 
+See [../nginx/README.md](../nginx/README.md) for Nginx + Let's Encrypt TLS termination.
+
 Leave service on HOST=0.0.0.0 PORT=8000
 
 Terminate TLS in Nginx/Traefik and forward to 127.0.0.1:8000


### PR DESCRIPTION
## Summary
- add Nginx vhost and setup script for TLS termination and reverse proxying to the systemd API
- document Nginx + Certbot bootstrap and link from systemd runbook

## Testing
- `pnpm typecheck` *(fails: packages/rules-apex typecheck issues)*
- `pnpm test` *(fails: vitest errors in apps/api)*

------
https://chatgpt.com/codex/tasks/task_b_68ac972ce15c832c907fbbe4d4572894