### PR TITLE
feat(api): secured accounts REST endpoints (+OpenAPI, tests)

### DIFF
--- a/apps/api/src/__tests__/accounts.spec.ts
+++ b/apps/api/src/__tests__/accounts.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+let buildServer: typeof import('../server.js').buildServer;
+
+beforeEach(async () => {
+  process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'accounts-'));
+  process.env.BEARER_TOKEN = 't';
+  ({ buildServer } = await import('../server.js'));
+});
+
+describe('Accounts API', () => {
+  it('GET /accounts when empty -> []', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/accounts',
+      headers: { authorization: 'Bearer t' },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it('PUT persists and GET retrieves account', async () => {
+    const app = buildServer();
+    const id = 'PA-150K-123456';
+    const payload = { maxContracts: 17, bufferCleared: false, notes: 'plan:150k' };
+    const putRes = await app.inject({
+      method: 'PUT',
+      url: `/accounts/${id}`,
+      headers: { authorization: 'Bearer t' },
+      payload,
+    });
+    expect(putRes.statusCode).toBe(200);
+    const file = path.join(process.env.DATA_DIR!, 'accounts', `${id}.json`);
+    const stored = JSON.parse(fs.readFileSync(file, 'utf8'));
+    expect(stored).toMatchObject({ id, ...payload });
+
+    const getRes = await app.inject({
+      method: 'GET',
+      url: `/accounts/${id}`,
+      headers: { authorization: 'Bearer t' },
+    });
+    expect(getRes.statusCode).toBe(200);
+    const body = getRes.json();
+    expect(body).toMatchObject({ id, ...payload });
+    expect(typeof body.updatedAt).toBe('string');
+  });
+
+  it('PUT partial update keeps other fields', async () => {
+    const app = buildServer();
+    const id = 'PA-150K-123456';
+    await app.inject({
+      method: 'PUT',
+      url: `/accounts/${id}`,
+      headers: { authorization: 'Bearer t' },
+      payload: { maxContracts: 17, bufferCleared: false, notes: 'plan:150k' },
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/accounts/${id}`,
+      headers: { authorization: 'Bearer t' },
+      payload: { bufferCleared: true },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      id,
+      maxContracts: 17,
+      bufferCleared: true,
+      notes: 'plan:150k',
+    });
+  });
+
+  it('requires auth', async () => {
+    const app = buildServer();
+    const resList = await app.inject({ method: 'GET', url: '/accounts' });
+    expect(resList.statusCode).toBe(401);
+    const resPut = await app.inject({
+      method: 'PUT',
+      url: '/accounts/PA-1',
+      payload: { maxContracts: 1 },
+    });
+    expect(resPut.statusCode).toBe(401);
+  });
+
+  it('rejects bad payload', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/accounts/PA-1',
+      headers: { authorization: 'Bearer t' },
+      payload: { maxContracts: -1 },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -35,6 +35,60 @@ registry.registerPath({
   },
 });
 
+// ---- Accounts ----
+const Account = registry.register(
+  'Account',
+  z.object({
+    id: z.string(),
+    maxContracts: z.number(),
+    bufferCleared: z.boolean(),
+    updatedAt: z.string(),
+    notes: z.string().optional(),
+  }),
+);
+const AccountUpsert = registry.register(
+  'AccountUpsert',
+  z.object({
+    maxContracts: z.number().positive().optional(),
+    bufferCleared: z.boolean().optional(),
+    notes: z.string().optional(),
+  }),
+);
+
+registry.registerPath({
+  method: 'get',
+  path: '/accounts',
+  responses: {
+    200: {
+      description: 'Accounts',
+      content: { 'application/json': { schema: z.array(Account) } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/accounts/{id}',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: 'Account', content: { 'application/json': { schema: Account } } },
+    404: { description: 'Not found' },
+  },
+});
+
+registry.registerPath({
+  method: 'put',
+  path: '/accounts/{id}',
+  request: {
+    params: z.object({ id: z.string() }),
+    body: { content: { 'application/json': { schema: AccountUpsert } } },
+  },
+  responses: {
+    200: { description: 'Upserted account', content: { 'application/json': { schema: Account } } },
+    400: { description: 'Invalid payload' },
+  },
+});
+
 // ---- Shared schemas for simple endpoints ----
 const SymbolsResponse = z.object({ symbols: z.array(z.string()) });
 const SessionsResponse = z.object({

--- a/apps/api/src/routes/accounts.ts
+++ b/apps/api/src/routes/accounts.ts
@@ -1,0 +1,36 @@
+import { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { Accounts } from '../lib/accounts.js';
+
+const ParamsSchema = z.object({ id: z.string().min(1) });
+const BodySchema = z.object({
+  maxContracts: z.number().positive().optional(),
+  bufferCleared: z.boolean().optional(),
+  notes: z.string().optional(),
+});
+
+export const accountsRoutes: FastifyPluginAsync = async (app) => {
+  app.get('/accounts', async (_req, _reply) => {
+    return Accounts.list();
+  });
+
+  app.get('/accounts/:id', async (req, reply) => {
+    const p = ParamsSchema.safeParse(req.params);
+    if (!p.success) return reply.code(400).send({ error: 'Invalid id' });
+    const acct = await Accounts.get(p.data.id);
+    if (!acct) return reply.code(404).send({ error: 'Not found' });
+    return acct;
+  });
+
+  app.put('/accounts/:id', async (req, reply) => {
+    const p = ParamsSchema.safeParse(req.params);
+    if (!p.success) return reply.code(400).send({ error: 'Invalid id' });
+    const b = BodySchema.safeParse(req.body);
+    if (!b.success) return reply.code(400).send({ error: 'Invalid payload' });
+    const acct = await Accounts.upsert({ id: p.data.id, ...b.data });
+    app.log.info({ id: p.data.id, updated: b.data }, 'account upsert');
+    return acct;
+  });
+};
+
+export default accountsRoutes;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -17,6 +17,7 @@ import { healthRoutes } from './routes/health.js';
 import { versionRoutes } from './routes/version.js';
 import { analyticsRoutes } from './routes/analytics.js';
 import { auditRoutes } from './routes/audit.js';
+import { accountsRoutes } from './routes/accounts.js';
 import { ticketsRoutes } from './routes/tickets.js';
 import { tradingviewWebhookRoutes } from './routes/webhooks.tradingview.js';
 import { readyRoutes } from './routes/ready.js';
@@ -79,6 +80,7 @@ export function buildServer() {
   app.register(versionRoutes);
   app.register(analyticsRoutes);
   app.register(auditRoutes);
+  app.register(accountsRoutes);
 
   app.register(marketRoutes);
   app.register(signalRoutes);

--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -1,0 +1,34 @@
+# Accounts Registry API
+
+The accounts registry stores account metadata on disk under `DATA_DIR/accounts`. Each account is saved as a JSON file and has the shape:
+
+```json
+{
+  "id": "PA-150K-123456",
+  "maxContracts": 17,
+  "bufferCleared": false,
+  "updatedAt": "2024-01-01T00:00:00.000Z",
+  "notes": "plan:150k"
+}
+```
+
+These REST endpoints mirror the CLI helpers (e.g. `prism-accounts set --id ...`). They are secured and require a bearer token.
+
+## Examples
+
+List accounts:
+
+```bash
+curl -H "authorization: Bearer $TOKEN" http://localhost:8000/accounts
+```
+
+Upsert an account:
+
+```bash
+curl -X PUT -H "authorization: Bearer $TOKEN" \
+     -H "content-type: application/json" \
+     -d '{"maxContracts":17,"bufferCleared":false,"notes":"plan:150k, platform:Tradovate"}' \
+     http://localhost:8000/accounts/PA-150K-123456
+```
+
+Authentication: set `BEARER_TOKEN` in the environment and supply `Authorization: Bearer $TOKEN` on requests.


### PR DESCRIPTION
## Summary
- add secured REST API for listing/getting/upserting accounts
- document Account and AccountUpsert in OpenAPI
- cover with vitest and docs

## Testing
- `pnpm --filter ./apps/api typecheck`
- `pnpm --filter ./apps/api test`

```bash
curl -H "authorization: Bearer $TOKEN" http://localhost:8000/accounts
curl -X PUT -H "authorization: Bearer $TOKEN" -H "content-type: application/json" \
     -d '{"maxContracts":17,"bufferCleared":false,"notes":"plan:150k, platform:Tradovate"}' \
     http://localhost:8000/accounts/PA-150K-123456
```

------
https://chatgpt.com/codex/tasks/task_b_68ac9d158774832c89c320131879f777