### PR TITLE
PR-B3: Funding Phase Configs (eval|funded modes + guard matrix wiring)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,8 @@ RATE_LIMIT_MAX_BUCKETS=50000
 MIN_RR=1.5
 MAX_RR=5
 FLAT_BY_UTC=20:59
-# Account phase for sizing/stop rules
+# Account registry (single account for MVP)
+ACCOUNT_ID=A1
 ACCOUNT_PHASE=eval
 # Max contracts allowed per account
 APEX_MAX_CONTRACTS=5

--- a/README.md
+++ b/README.md
@@ -43,13 +43,20 @@ tests/            Integration and end-to-end tests (future)
 Guardrail behavior is configured via environment variables in `.env`:
 
 ```
+ACCOUNT_ID=A1
 ACCOUNT_PHASE=eval  # or funded
 APEX_MAX_CONTRACTS=5
 MIN_RR=1.5
 MAX_RR=5.0
 ```
 
-`ACCOUNT_PHASE` defaults to `eval` for the MVP. `APEX_MAX_CONTRACTS` caps position size per account.
+`ACCOUNT_ID` identifies the primary account. `ACCOUNT_PHASE` defaults to `eval` for the MVP. `APEX_MAX_CONTRACTS` caps position size per account. `bufferCleared` defaults to `false` until telemetry marks the account as buffered.
+
+Verify the active phase with:
+
+```bash
+echo $ACCOUNT_PHASE
+```
 
 ## PR Roadmap (Collapsed)
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "pretest": "pnpm -r --filter @prism-apex-tool/rules-apex --filter @prism-apex-tool/accounts build",
+    "pretest": "pnpm -r --filter @prism-apex-tool/rules-apex --filter @prism-apex-tool/accounts --filter @prism-apex-tool/config --filter @prism-apex-tool/signals --filter @prism-apex-tool/analytics --filter @prism-apex-tool/audit --filter @prism-apex-tool/reporting build",
     "test:api": "vitest run --config apps/api/vitest.config.ts --reporter=verbose --passWithNoTests",
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.build.json",
@@ -45,6 +45,9 @@
     "@prism-apex-tool/reporting": "workspace:*",
     "@prism-apex-tool/signals": "workspace:*",
     "@prism-apex-tool/rules-apex": "workspace:*",
-    "@prism-apex-tool/accounts": "workspace:*"
+    "@prism-apex-tool/accounts": "workspace:*",
+    "@prism-apex-tool/config": "workspace:*",
+    "@prism-apex-tool/analytics": "workspace:*",
+    "@prism-apex-tool/audit": "workspace:*"
   }
 }

--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { store } from '../store.js';
 import { PromoteInput } from '../schemas/ticketsPromote.js';
 import { applyGuardWithSizing } from '@prism-apex-tool/rules-apex';
+import { loadRegistry } from '@prism-apex-tool/config';
 
 export async function ticketsRoutes(app: FastifyInstance) {
   app.post('/tickets/promote', async (req, reply) => {
@@ -11,8 +12,8 @@ export async function ticketsRoutes(app: FastifyInstance) {
 
     const { suggestion } = p.data;
 
-    const accountPhase = process.env.ACCOUNT_PHASE === 'funded' ? 'funded' : 'eval';
-    const bufferCleared = false;
+    const registry = loadRegistry();
+    const acct = registry.accounts[0];
     const today = new Date().toISOString().slice(0, 10);
     const recent = store.getTicketsForDate(today).map(t => (t.ticket as any).qty);
 
@@ -27,9 +28,9 @@ export async function ticketsRoutes(app: FastifyInstance) {
         target: suggestion.targets[0],
       },
       {
-        phase: accountPhase,
-        account: { id: 'A1', maxContracts: Number(process.env.APEX_MAX_CONTRACTS || 5) },
-        bufferCleared,
+        phase: acct.phase,
+        account: { id: acct.id, maxContracts: acct.maxContracts },
+        bufferCleared: acct.bufferCleared,
         recentSizes: recent,
         contract: suggestion.symbol,
       },

--- a/apps/api/src/tests/tickets.promote.spec.ts
+++ b/apps/api/src/tests/tickets.promote.spec.ts
@@ -35,7 +35,7 @@ describe('/tickets/promote', () => {
     expect(res.statusCode).toBe(200);
     const body = res.json() as any;
     expect(body.ticket.qty).toBe(2);
-    expect(body.ticket.meta.guardrails).toContain('rr');
+    expect(body.ticket.meta.guardrails).toContain('rr-clamp');
     await app.close();
   });
 
@@ -86,7 +86,32 @@ describe('/tickets/promote', () => {
     process.env.ACCOUNT_PHASE = 'eval';
   });
 
-  it('rejects windfall qty jumps', async () => {
+  it('accepts missing stop in eval', async () => {
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/tickets/promote',
+      payload: {
+        suggestion: {
+          id: '6',
+          symbol: 'ESZ4',
+          side: 'BUY',
+          qty: 1,
+          entry: 100,
+          targets: [102],
+          reasons: [],
+          meta: { strategy: 'VWAP_FT' },
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as any;
+    expect(body.ticket.meta.guardrails).toContain('stop-optional');
+    await app.close();
+  });
+
+  it('rejects windfall qty jumps in funded', async () => {
+    process.env.ACCOUNT_PHASE = 'funded';
     const app = buildServer();
     // Baseline small ticket
     await app.inject({
@@ -126,5 +151,6 @@ describe('/tickets/promote', () => {
     });
     expect(res.statusCode).toBe(400);
     await app.close();
+    process.env.ACCOUNT_PHASE = 'eval';
   });
 });

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     }
   },
   "bin": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@prism-apex-tool/rules-apex",
+  "name": "@prism-apex-tool/config",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -7,9 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [
@@ -18,12 +17,14 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "eslint . --ext .ts",
-    "test": "vitest --run",
+    "test": "vitest --run --passWithNoTests",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "format": "prettier -w .",
     "format:check": "prettier -c ."
   },
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
   "devDependencies": {
     "eslint": "^9.10.0",
     "@eslint/js": "^9.10.0",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export type AccountPhase = 'eval' | 'funded';
+
+const accountSchema = z.object({
+  id: z.string(),
+  phase: z.enum(['eval', 'funded']),
+  maxContracts: z.number().int().min(1),
+  bufferCleared: z.boolean(),
+});
+
+export type AccountConfig = z.infer<typeof accountSchema>;
+
+export function loadRegistry(): { accounts: AccountConfig[] } {
+  const phase: AccountPhase = process.env.ACCOUNT_PHASE === 'funded' ? 'funded' : 'eval';
+  const max = Number(process.env.APEX_MAX_CONTRACTS ?? 5);
+  const id = process.env.ACCOUNT_ID ?? 'A1';
+  return {
+    accounts: [
+      accountSchema.parse({
+        id,
+        phase,
+        maxContracts: max,
+        bufferCleared: false,
+      }),
+    ],
+  };
+}

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "module": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/packages/rules-apex/src/applyGuards.ts
+++ b/packages/rules-apex/src/applyGuards.ts
@@ -1,4 +1,4 @@
-import { DEFAULTS } from './config.js';
+import { getPhasePolicy } from './config.js';
 import { guardRR, computeRR } from './guards/rr.js';
 import { guardStop } from './guards/stop.js';
 import { guardSize, SizeContext } from './guards/size.js';
@@ -19,30 +19,45 @@ export function applyGuardWithSizing(
 ): { accepted: boolean; ticket?: Ticket; reasons?: string[] } {
   if (s.target == null) return { accepted: false, reasons: ['missing-target'] };
 
-  const stopCheck = guardStop(s, ctx.phase, DEFAULTS.requireStop);
+  const policy = getPhasePolicy(ctx.phase);
+
+  const guardrails = [`phase:${ctx.phase}`];
+  guardrails.push(policy.requireStop ? 'stop-required' : 'stop-optional');
+  guardrails.push('rr-clamp');
+  if (policy.halfSizeUntilBuffer) guardrails.push('half-size-until-buffer');
+  if (policy.antiWindfall) guardrails.push('anti-windfall');
+
+  const stopCheck = guardStop(s, ctx.phase, policy.requireStop);
   if (!stopCheck.ok) return { accepted: false, reasons: [stopCheck.reason!] };
-  if (s.stop == null) return { accepted: false, reasons: ['stop-required'] };
 
-  const rr = computeRR({ entry: s.entry, stop: s.stop, target: s.target });
-  const rrCheck = guardRR(rr, DEFAULTS.MIN_RR, DEFAULTS.MAX_RR);
-  if (!rrCheck.ok) return { accepted: false, reasons: [rrCheck.reason!] };
+  let rr = 0;
+  if (s.stop == null) {
+    if (policy.requireStop) return { accepted: false, reasons: ['stop-required'] };
+  } else {
+    rr = computeRR({ entry: s.entry, stop: s.stop, target: s.target });
+    const rrCheck = guardRR(rr, policy.minRR, policy.maxRR);
+    if (!rrCheck.ok) return { accepted: false, reasons: [rrCheck.reason!] };
+  }
 
-  const sizeRes = guardSize(s, {
-    bufferCleared: ctx.bufferCleared,
-    accountMax: ctx.account.maxContracts,
-    recentSizes: ctx.recentSizes,
-  });
+  const sizeRes = guardSize(
+    s,
+    {
+      bufferCleared: ctx.bufferCleared,
+      accountMax: ctx.account.maxContracts,
+      recentSizes: ctx.recentSizes,
+    },
+    { halfSizeUntilBuffer: policy.halfSizeUntilBuffer, antiWindfall: policy.antiWindfall },
+  );
   if (!('ok' in sizeRes) || !sizeRes.ok) {
     return { accepted: false, reasons: [sizeRes.reason] };
   }
-
-  const guardrails = ['rr', 'stop', ...sizeRes.guardrails];
+  guardrails.push(...sizeRes.guardrails);
 
   const ticket: Ticket = {
     symbol: ctx.contract,
     side: s.side,
     entry: s.entry,
-    stop: s.stop,
+    stop: s.stop ?? s.entry,
     qty: sizeRes.qty,
     accountId: ctx.account.id,
     timestampUtc: (ctx.now ?? new Date()).toISOString(),

--- a/packages/rules-apex/src/config.ts
+++ b/packages/rules-apex/src/config.ts
@@ -1,7 +1,28 @@
-export const DEFAULTS = {
-  MIN_RR: 1.5,
-  MAX_RR: 5.0,
-  requireStop: true,
-  antiWindfallWindow: 10,
-  maxStepIncrease: 2,
+import { AccountPhase } from './types.js';
+
+export type PhasePolicy = {
+  requireStop: boolean;
+  minRR: number;
+  maxRR: number;
+  halfSizeUntilBuffer: boolean;
+  antiWindfall: boolean;
 };
+
+export function getPhasePolicy(phase: AccountPhase): PhasePolicy {
+  if (phase === 'funded') {
+    return {
+      requireStop: true,
+      minRR: 1.5,
+      maxRR: 5.0,
+      halfSizeUntilBuffer: true,
+      antiWindfall: true,
+    };
+  }
+  return {
+    requireStop: false,
+    minRR: 1.5,
+    maxRR: 5.0,
+    halfSizeUntilBuffer: true,
+    antiWindfall: false,
+  };
+}

--- a/packages/rules-apex/src/guards/size.ts
+++ b/packages/rules-apex/src/guards/size.ts
@@ -6,9 +6,15 @@ export type SizeContext = {
   recentSizes: number[];
 };
 
+export type SizePolicy = {
+  halfSizeUntilBuffer: boolean;
+  antiWindfall: boolean;
+};
+
 export function guardSize(
   s: Suggestion,
   ctx: SizeContext,
+  policy: SizePolicy,
 ):
   | { ok: true; qty: number; guardrails: string[]; sizingHint?: string; consistencyNotes?: string }
   | { ok: false; reason: string } {
@@ -17,9 +23,8 @@ export function guardSize(
   let sizingHint: string | undefined;
   let consistencyNotes: string | undefined;
 
-  if (!ctx.bufferCleared) {
+  if (policy.halfSizeUntilBuffer && !ctx.bufferCleared) {
     qty = Math.max(1, Math.floor(qty / 2));
-    guardrails.push('half-size');
     sizingHint = 'half-size-until-buffer';
   }
 
@@ -28,9 +33,11 @@ export function guardSize(
     guardrails.push('apex-max');
   }
 
-  const last = ctx.recentSizes[ctx.recentSizes.length - 1];
-  if (last && qty > last * 2) {
-    return { ok: false, reason: 'windfall' };
+  if (policy.antiWindfall) {
+    const last = ctx.recentSizes[ctx.recentSizes.length - 1];
+    if (last && qty > last * 2) {
+      return { ok: false, reason: 'windfall' };
+    }
   }
 
   return { ok: true, qty, guardrails, sizingHint, consistencyNotes };

--- a/packages/rules-apex/src/guards/stop.ts
+++ b/packages/rules-apex/src/guards/stop.ts
@@ -1,10 +1,9 @@
 import { AccountPhase, Suggestion } from '../types.js';
-import { DEFAULTS } from '../config.js';
 
 export function guardStop(
   s: Suggestion,
   phase: AccountPhase,
-  requireStop: boolean = DEFAULTS.requireStop,
+  requireStop: boolean,
 ): { ok: boolean; reason?: string } {
   if (s.stop == null) {
     if (phase === 'funded' || requireStop) return { ok: false, reason: 'stop-required' };

--- a/packages/rules-apex/test/applyGuards.spec.ts
+++ b/packages/rules-apex/test/applyGuards.spec.ts
@@ -11,7 +11,7 @@ describe('applyGuardWithSizing', () => {
     strategy: 'OSB',
     target: 102,
   };
-  const ctx = {
+  const ctxEval = {
     phase: 'eval' as const,
     account: { id: 'acc', maxContracts: 5 },
     bufferCleared: false,
@@ -19,15 +19,28 @@ describe('applyGuardWithSizing', () => {
     contract: 'ESZ4',
   };
 
-  it('accepts and returns ticket', () => {
-    const r = applyGuardWithSizing(base, ctx);
+  it('half-size enforced when buffer not cleared', () => {
+    const r = applyGuardWithSizing(base, ctxEval);
     expect(r.accepted).toBe(true);
     expect(r.ticket?.qty).toBe(2);
-    expect(r.ticket?.symbol).toBe('ESZ4');
   });
 
-  it('rejects bad rr', () => {
-    const r = applyGuardWithSizing({ ...base, target: 100.5 }, ctx);
+  it('rejects missing stop in funded', () => {
+    const r = applyGuardWithSizing({ ...base, stop: undefined }, { ...ctxEval, phase: 'funded' });
+    expect(r.accepted).toBe(false);
+  });
+
+  it('accepts missing stop in eval with advisory', () => {
+    const r = applyGuardWithSizing({ ...base, stop: undefined }, ctxEval);
+    expect(r.accepted).toBe(true);
+    expect(r.ticket?.meta.guardrails).toContain('stop-optional');
+  });
+
+  it('anti-windfall caps sudden jump', () => {
+    const r = applyGuardWithSizing(
+      { ...base, qty: 5 },
+      { ...ctxEval, phase: 'funded', recentSizes: [1], bufferCleared: true },
+    );
     expect(r.accepted).toBe(false);
   });
 });

--- a/packages/rules-apex/test/rr.spec.ts
+++ b/packages/rules-apex/test/rr.spec.ts
@@ -1,19 +1,18 @@
 import { computeRR, guardRR } from '../src/guards/rr.js';
-import { DEFAULTS } from '../src/config.js';
 
 describe('rr guard', () => {
   it('accepts rr within range', () => {
     const rr = computeRR({ entry: 100, stop: 99, target: 103 });
-    expect(guardRR(rr, DEFAULTS.MIN_RR, DEFAULTS.MAX_RR).ok).toBe(true);
+    expect(guardRR(rr, 1.5, 5).ok).toBe(true);
   });
 
   it('rejects low rr', () => {
     const rr = computeRR({ entry: 100, stop: 99, target: 101 });
-    expect(guardRR(rr, DEFAULTS.MIN_RR, DEFAULTS.MAX_RR).ok).toBe(false);
+    expect(guardRR(rr, 1.5, 5).ok).toBe(false);
   });
 
   it('rejects high rr', () => {
     const rr = computeRR({ entry: 100, stop: 99, target: 110 });
-    expect(guardRR(rr, DEFAULTS.MIN_RR, DEFAULTS.MAX_RR).ok).toBe(false);
+    expect(guardRR(rr, 1.5, 5).ok).toBe(false);
   });
 });

--- a/packages/rules-apex/test/size.spec.ts
+++ b/packages/rules-apex/test/size.spec.ts
@@ -2,25 +2,33 @@ import { guardSize } from '../src/guards/size.js';
 
 describe('size guard', () => {
   it('half-size when buffer uncleared', () => {
-    const res = guardSize({ qty: 4 } as any, {
-      bufferCleared: false,
-      accountMax: 10,
-      recentSizes: [],
-    });
+    const res = guardSize(
+      { qty: 4 } as any,
+      {
+        bufferCleared: false,
+        accountMax: 10,
+        recentSizes: [],
+      },
+      { halfSizeUntilBuffer: true, antiWindfall: false },
+    );
     if (res.ok) {
       expect(res.qty).toBe(2);
-      expect(res.guardrails).toContain('half-size');
+      expect(res.sizingHint).toBe('half-size-until-buffer');
     } else {
       throw new Error('unexpected rejection');
     }
   });
 
   it('clamps to apex max', () => {
-    const res = guardSize({ qty: 10 } as any, {
-      bufferCleared: true,
-      accountMax: 3,
-      recentSizes: [],
-    });
+    const res = guardSize(
+      { qty: 10 } as any,
+      {
+        bufferCleared: true,
+        accountMax: 3,
+        recentSizes: [],
+      },
+      { halfSizeUntilBuffer: true, antiWindfall: false },
+    );
     if (res.ok) {
       expect(res.qty).toBe(3);
       expect(res.guardrails).toContain('apex-max');
@@ -30,11 +38,15 @@ describe('size guard', () => {
   });
 
   it('rejects windfall size jumps', () => {
-    const res = guardSize({ qty: 10 } as any, {
-      bufferCleared: true,
-      accountMax: 20,
-      recentSizes: [2],
-    });
+    const res = guardSize(
+      { qty: 10 } as any,
+      {
+        bufferCleared: true,
+        accountMax: 20,
+        recentSizes: [2],
+      },
+      { halfSizeUntilBuffer: true, antiWindfall: true },
+    );
     expect(res.ok).toBe(false);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,15 @@ importers:
       '@prism-apex-tool/accounts':
         specifier: workspace:*
         version: link:../../packages/accounts
+      '@prism-apex-tool/analytics':
+        specifier: workspace:*
+        version: link:../../packages/analytics
+      '@prism-apex-tool/audit':
+        specifier: workspace:*
+        version: link:../../packages/audit
+      '@prism-apex-tool/config':
+        specifier: workspace:*
+        version: link:../../packages/config
       '@prism-apex-tool/reporting':
         specifier: workspace:*
         version: link:../../packages/reporting
@@ -266,6 +275,25 @@ importers:
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
+
+  packages/config:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.10.0
+        version: 9.33.0
+      eslint:
+        specifier: ^9.10.0
+        version: 9.33.0(jiti@2.5.1)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.6.2
+      typescript-eslint:
+        specifier: ^8.7.0
+        version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
 
   packages/reporting:
     devDependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2022",
     "baseUrl": ".",
@@ -11,7 +11,8 @@
       "@prism-apex-tool/reporting": ["packages/reporting/src"],
       "@prism-apex-tool/signals": ["packages/signals/src"],
       "@prism-apex-tool/rules-apex": ["packages/rules-apex/src"],
-      "@prism-apex-tool/accounts": ["packages/accounts/src"]
+      "@prism-apex-tool/accounts": ["packages/accounts/src"],
+      "@prism-apex-tool/config": ["packages/config/src"]
     },
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Summary
Adds Funding Phase Configs with ACCOUNT_PHASE=eval|funded, a minimal account registry, and wires phase-aware policies into the guard middleware. In funded, stop-loss is required; RR clamped to [1.5, 5.0]; half-size until buffer cleared; anti-windfall active. In eval, RR clamp enforced, size caps active, half-size until buffer cleared; stop is optional (advisory), enabling smoother evaluation while maintaining discipline.

## Changes
- Config & registry for phase/caps/buffer
- rules-apex: getPhasePolicy() + integration in applyGuardWithSizing()
- apps/api: /tickets/promote now passes phase context to guards
- Docs updated for operators

## Testing
- `pnpm -F @prism-apex-tool/rules-apex test`
- `pnpm -F ./apps/api test src/tests/tickets.promote.spec.ts` *(fails: Cannot find module '@prism-apex-tool/analytics')*


------
https://chatgpt.com/codex/tasks/task_b_68acc87e86b0832c8716b12eb304730d