### PR TITLE
PR-S3: Strategy Modules (VWAP First‑Touch & OSB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "workspaces": [
     "apps/*",
     "packages/*",
-    "packages/analytics"
+    "packages/analytics",
+    "packages/strategies"
   ],
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",

--- a/packages/strategies/package.json
+++ b/packages/strategies/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@prism-apex-tool/strategies",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": { ".": { "import": "./dist/index.js", "require": "./dist/index.cjs", "types": "./dist/index.d.ts" } },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.1",
+    "typescript": "^5.9.0",
+    "vitest": "^2.0.0",
+    "@types/node": "^20.11.0"
+  }
+}

--- a/packages/strategies/src/index.ts
+++ b/packages/strategies/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./inputs.js";
+export { vwapFirstTouch } from "./vwapFirstTouch.js";
+export { openingSwingBreakout } from "./osbBreakout.js";

--- a/packages/strategies/src/inputs.ts
+++ b/packages/strategies/src/inputs.ts
@@ -1,0 +1,25 @@
+export type TickSpec = { tickSize: number; minStopTicks?: number };
+export type VwapSeries = number[]; // aligned to bars
+export type AtrSeries = number[];  // ATR in price units; pass ticks via tickSpec if needed
+
+export type VwapFtParams = {
+  slopeLookback: number;        // default 10 bars
+  minDistanceATR: number;       // default 0.5
+  stopKATR: number;             // default 0.25
+  rrDefault: number;            // default 2.0
+  rrMin: number;                // default 1.5
+  rrMax: number;                // default 3.0 (VWAP FT clamp)
+  minStopTicks?: number;        // default 2
+};
+
+export type OsbParams = {
+  orMinutes: number;            // default 5
+  requireCloseBreak: boolean;   // default true
+  rrDefault: number;            // default 2.0
+  rrMin: number;                // default 1.5
+  rrMax: number;                // default 5.0
+  widthMinTicks: number;        // default 6
+  widthMinATR: number;          // default 0.3
+  widthMaxATR: number;          // default 3.0
+  minRiskTicks?: number;        // default 3 (slippage buffer)
+};

--- a/packages/strategies/src/osbBreakout.ts
+++ b/packages/strategies/src/osbBreakout.ts
@@ -1,0 +1,67 @@
+import { Candle, Suggestion } from "./types.js";
+import { AtrSeries, OsbParams, TickSpec } from "./inputs.js";
+import { clamp, pricePlusTicks, rMultiple, ticksBetween } from "./util.js";
+
+/** Opening Swing Breakout over first N minutes of RTH */
+export function openingSwingBreakout(
+  symbol: string,
+  barsRth: Candle[],
+  atrSeries: AtrSeries,
+  tick: TickSpec,
+  params: Partial<OsbParams> = {},
+  nowIso?: string
+): Suggestion[] {
+  const P: OsbParams = {
+    orMinutes: 5, requireCloseBreak: true,
+    rrDefault: 2.0, rrMin: 1.5, rrMax: 5.0,
+    widthMinTicks: 6, widthMinATR: 0.3, widthMaxATR: 3.0,
+    minRiskTicks: 3, ...params
+  };
+  if (barsRth.length < P.orMinutes + 2) return [];
+
+  const orBars = barsRth.slice(0, P.orMinutes);
+  const rest = barsRth.slice(P.orMinutes);
+  const orHigh = Math.max(...orBars.map(b => b.high));
+  const orLow  = Math.min(...orBars.map(b => b.low));
+  const atrNow = atrSeries[atrSeries.length - 1];
+
+  const widthTicks = Math.round((orHigh - orLow) / tick.tickSize);
+  const minWidthTicks = Math.max(P.widthMinTicks, Math.round((P.widthMinATR * atrNow) / tick.tickSize));
+  const maxWidthTicks = Math.round((P.widthMaxATR * atrNow) / tick.tickSize);
+  if (widthTicks < minWidthTicks || widthTicks > maxWidthTicks) return [];
+
+  const lastBar = rest[rest.length - 1];
+  const brokeUp   = lastBar.close > orHigh && (!P.requireCloseBreak || lastBar.high >= orHigh);
+  const brokeDown = lastBar.close < orLow  && (!P.requireCloseBreak || lastBar.low  <= orLow);
+
+  if (!brokeUp && !brokeDown) return [];
+
+  const side = brokeUp ? "BUY" : "SELL";
+  const entry = side === "BUY" ? pricePlusTicks(orHigh, +1, tick.tickSize)
+                               : pricePlusTicks(orLow,  -1, tick.tickSize);
+  let stop  = side === "BUY" ? pricePlusTicks(orLow,  -1, tick.tickSize)
+                               : pricePlusTicks(orHigh, +1, tick.tickSize);
+
+  let riskTicks = ticksBetween(entry, stop, tick.tickSize);
+  if (riskTicks < (P.minRiskTicks ?? 3)) {
+    // enforce minimum risk ticks to avoid micro boxes
+    const adj = (P.minRiskTicks ?? 3) - riskTicks;
+    stop = side === "BUY"
+      ? pricePlusTicks(stop, -adj, tick.tickSize)
+      : pricePlusTicks(stop, +adj, tick.tickSize);
+    riskTicks += adj;
+  }
+
+  const rr = clamp(P.rrDefault, P.rrMin, P.rrMax);
+  const target = side === "BUY"
+    ? entry + rr * (entry - stop)
+    : entry - rr * (stop - entry);
+  const rrReal = rMultiple(entry, stop, target);
+  if (rrReal < P.rrMin) return [];
+
+  return [{
+    symbol, side, entry, stop, target,
+    timestampUtc: nowIso ?? new Date().toISOString(),
+    meta: { strategy: "OSB", rr: rrReal }
+  }];
+}

--- a/packages/strategies/src/types.ts
+++ b/packages/strategies/src/types.ts
@@ -1,0 +1,22 @@
+export type Candle = {
+  ts: string; // ISO UTC
+  open: number; high: number; low: number; close: number;
+  volume?: number;
+};
+
+export type Suggestion = {
+  symbol: string;               // full contract, e.g., ESZ4
+  side: "BUY" | "SELL";
+  entry: number;
+  stop: number;
+  target: number;
+  qty?: number;                 // suggested size (optional here)
+  timestampUtc: string;         // when generated
+  meta: {
+    strategy: "VWAP_FT" | "OSB";
+    rr: number;
+    notes?: string;
+    guardrails?: string[];      // e.g., ["RR_CLAMPED","MIN_TICKS_BUMP"]
+    sizingHintPctOfMax?: number;
+  };
+};

--- a/packages/strategies/src/util.ts
+++ b/packages/strategies/src/util.ts
@@ -1,0 +1,14 @@
+export const last = <T>(arr: T[]) => arr[arr.length - 1];
+export function rMultiple(entry: number, stop: number, target: number) {
+  const risk = Math.abs(entry - stop);
+  return risk > 0 ? Math.abs(target - entry) / risk : 0;
+}
+export function clamp(v: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, v));
+}
+export function pricePlusTicks(price: number, ticks: number, tickSize: number) {
+  return price + ticks * tickSize;
+}
+export function ticksBetween(a: number, b: number, tickSize: number) {
+  return Math.round(Math.abs(a - b) / tickSize);
+}

--- a/packages/strategies/src/vwapFirstTouch.ts
+++ b/packages/strategies/src/vwapFirstTouch.ts
@@ -1,0 +1,71 @@
+import { Candle, Suggestion } from "./types.js";
+import { VwapSeries, AtrSeries, VwapFtParams, TickSpec } from "./inputs.js";
+import { clamp, last, rMultiple, ticksBetween, pricePlusTicks } from "./util.js";
+
+/**
+ * Assumes bars are RTH-filtered for the session and vwapSeries resets at session open.
+ * Emits at most one suggestion for the first clean touch after a trend leg with slope filter.
+ */
+export function vwapFirstTouch(
+  symbol: string,
+  bars: Candle[],
+  vwapSeries: VwapSeries,
+  atrSeries: AtrSeries,
+  tick: TickSpec,
+  params: Partial<VwapFtParams> = {},
+  nowIso?: string
+): Suggestion[] {
+  const P: VwapFtParams = {
+    slopeLookback: 10, minDistanceATR: 0.5, stopKATR: 0.25,
+    rrDefault: 2.0, rrMin: 1.5, rrMax: 3.0, minStopTicks: 2, ...params
+  };
+  if (bars.length < Math.max(20, P.slopeLookback + 1)) return [];
+
+  const n = bars.length;
+  const vnow = vwapSeries[n - 1];
+  const atrNow = atrSeries[n - 1];
+  const slopeStart = Math.max(0, n - 1 - P.slopeLookback);
+  const slopeEnd = n - 1;
+  const slope = (vwapSeries[slopeEnd] - vwapSeries[slopeStart]) / P.slopeLookback;
+
+  const prevMaxDist = Math.max(
+    ...bars.slice(slopeStart, slopeEnd).map((b, i) => Math.abs(b.close - vwapSeries[slopeStart + i]))
+  );
+  const hadDistance = prevMaxDist >= P.minDistanceATR * atrNow;
+
+  const lastClose = bars[n - 1].close;
+  const side: "BUY" | "SELL" | null =
+    lastClose >= vnow && slope >= 0 ? "BUY" :
+    lastClose <= vnow && slope <= 0 ? "SELL" : null;
+  if (!side || !hadDistance) return [];
+
+  // "Clean touch": price touches VWAP w/o blasting through > 0.25*ATR
+  const touchBar = last(bars);
+  const overshoot = Math.abs(touchBar.close - vnow);
+  if (overshoot > 0.25 * atrNow) return [];
+
+  // Entry at VWAP (one tick inside)
+  const entry = side === "BUY" ? pricePlusTicks(vnow, +1, tick.tickSize) : pricePlusTicks(vnow, -1, tick.tickSize);
+  const stopBuf = Math.max(P.minStopTicks ?? 2, Math.round((P.stopKATR * atrNow) / tick.tickSize));
+  const stop = side === "BUY" ? pricePlusTicks(vnow, -stopBuf, tick.tickSize) : pricePlusTicks(vnow, +stopBuf, tick.tickSize);
+  const riskTicks = ticksBetween(entry, stop, tick.tickSize);
+  if (riskTicks < (P.minStopTicks ?? 2)) return [];
+
+  const rr = clamp(P.rrDefault, P.rrMin, P.rrMax);
+  const target = side === "BUY"
+    ? entry + rr * (entry - stop)
+    : entry - rr * (stop - entry);
+
+  const rrReal = rMultiple(entry, stop, target);
+  if (rrReal < P.rrMin) return [];
+
+  return [{
+    symbol,
+    side,
+    entry,
+    stop,
+    target,
+    timestampUtc: nowIso ?? new Date().toISOString(),
+    meta: { strategy: "VWAP_FT", rr: rrReal }
+  }];
+}

--- a/packages/strategies/tests/osbBreakout.spec.ts
+++ b/packages/strategies/tests/osbBreakout.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { openingSwingBreakout } from "../src/osbBreakout.js";
+import { Candle } from "../src/types.js";
+import { TickSpec } from "../src/inputs.js";
+import { ticksBetween } from "../src/util.js";
+
+describe("openingSwingBreakout", () => {
+  const tick: TickSpec = { tickSize: 0.25 };
+
+  it("triggers BUY on OR breakout with default rr", () => {
+    const bars: Candle[] = [];
+    const atr: number[] = [];
+    for (let i = 0; i < 7; i++) {
+      atr.push(1);
+      if (i < 5) {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 100, high: 101, low: 99, close: 100 });
+      } else if (i === 5) {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 100.5, high: 101, low: 100, close: 100.5 });
+      } else {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 101, high: 101.5, low: 100.5, close: 101.25 });
+      }
+    }
+    const res = openingSwingBreakout("ESZ4", bars, atr, tick);
+    expect(res).toHaveLength(1);
+    const s = res[0];
+    expect(s.side).toBe("BUY");
+    expect(s.stop).toBeCloseTo(98.75, 5); // orLow -1 tick
+    expect(s.meta.rr).toBeCloseTo(2, 5);
+  });
+
+  it("rejects OR width that is too small", () => {
+    const bars: Candle[] = [];
+    const atr: number[] = [];
+    for (let i = 0; i < 7; i++) {
+      atr.push(1);
+      if (i < 5) {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 100, high: 100.5, low: 100, close: 100.25 });
+      } else if (i === 5) {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 100.25, high: 100.5, low: 100, close: 100.25 });
+      } else {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 100.5, high: 100.75, low: 100.25, close: 100.5 });
+      }
+    }
+    const res = openingSwingBreakout("ESZ4", bars, atr, tick);
+    expect(res).toHaveLength(0);
+  });
+
+  it("bumps risk to minimum ticks when OR is tiny", () => {
+    const bars: Candle[] = [];
+    const atr: number[] = [];
+    for (let i = 0; i < 7; i++) {
+      atr.push(1);
+      if (i < 5) {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 100, high: 100, low: 100, close: 100 });
+      } else if (i === 5) {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 100, high: 100.25, low: 100, close: 100.25 });
+      } else {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 100.25, high: 100.5, low: 100.25, close: 100.5 });
+      }
+    }
+    const res = openingSwingBreakout("ESZ4", bars, atr, tick, { widthMinTicks: 0, widthMinATR: 0 });
+    expect(res).toHaveLength(1);
+    const s = res[0];
+    expect(ticksBetween(s.entry, s.stop, tick.tickSize)).toBe(3);
+  });
+});

--- a/packages/strategies/tests/vwapFirstTouch.spec.ts
+++ b/packages/strategies/tests/vwapFirstTouch.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { vwapFirstTouch } from "../src/vwapFirstTouch.js";
+import { Candle } from "../src/types.js";
+import { TickSpec } from "../src/inputs.js";
+import { ticksBetween } from "../src/util.js";
+
+describe("vwapFirstTouch", () => {
+  const tick: TickSpec = { tickSize: 0.25 };
+
+  function buildBars(opts: { overshoot?: number; slope?: number }) {
+    const bars: Candle[] = [];
+    const vwap: number[] = [];
+    const atr: number[] = [];
+    const slope = opts.slope ?? 0.1;
+    for (let i = 0; i < 20; i++) {
+      const v = 100 + i * slope;
+      vwap.push(v);
+      atr.push(1);
+      const close = i === 19 ? v + (opts.overshoot ?? 0) : v + 1;
+      bars.push({
+        ts: `2024-01-01T00:${String(i).padStart(2, "0")}:00.000Z`,
+        open: close,
+        high: close,
+        low: close,
+        close,
+      });
+    }
+    return { bars, vwap, atr };
+  }
+
+  it("produces BUY suggestion on first clean touch", () => {
+    const { bars, vwap, atr } = buildBars({});
+    const res = vwapFirstTouch("ESZ4", bars, vwap, atr, tick);
+    expect(res).toHaveLength(1);
+    const s = res[0];
+    expect(s.side).toBe("BUY");
+    expect(s.meta.rr).toBeGreaterThanOrEqual(1.5);
+    expect(ticksBetween(s.entry, s.stop, tick.tickSize)).toBeGreaterThanOrEqual(2);
+  });
+
+  it("rejects overshoot greater than 0.25 ATR", () => {
+    const { bars, vwap, atr } = buildBars({ overshoot: 0.26 });
+    const res = vwapFirstTouch("ESZ4", bars, vwap, atr, tick);
+    expect(res).toHaveLength(0);
+  });
+
+  it("requires positive slope for long trades", () => {
+    const { bars, vwap, atr } = buildBars({ slope: -0.1, overshoot: 0.01 });
+    const res = vwapFirstTouch("ESZ4", bars, vwap, atr, tick);
+    expect(res).toHaveLength(0);
+  });
+});

--- a/packages/strategies/tsconfig.json
+++ b/packages/strategies/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
   - 'packages/accounts'
   - 'packages/analytics'
   - 'packages/indicators'
+  - 'packages/strategies'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,8 @@
       "@prism-apex-tool/accounts": ["packages/accounts/src"],
       "@prism-apex-tool/config": ["packages/config/src"],
       "@prism-apex-tool/clients-tradovate": ["packages/clients-tradovate/src"],
-      "@prism-apex-tool/indicators": ["packages/indicators/src"]
+      "@prism-apex-tool/indicators": ["packages/indicators/src"],
+      "@prism-apex-tool/strategies": ["packages/strategies/src"]
     },
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Implemented @prism-apex-tool/strategies with pure, typed modules:

- vwapFirstTouch() — session-aware first-touch with slope & distance filters.
- openingSwingBreakout() — OR breakout with confirmation & width bounds.

Minimal Suggestion shape (entry/stop/target/rr + metadata); final ticketization remains in /tickets/promote via guards and registry rules (phase-aware).

Added deterministic tests (synthetic bars) for correctness and edge cases.

No runtime IO; ready for wiring by the S4 Orchestrator job.

Checklist:

- pnpm -F @prism-apex-tool/strategies typecheck
- pnpm -F @prism-apex-tool/strategies build
- pnpm -F @prism-apex-tool/strategies test
- pnpm -w run validate

------
https://chatgpt.com/codex/tasks/task_b_68ace4ea3284832c944c77e422b78343