### PR TITLE
PR-S7: Dashboard — Trade Tickets panel (polling, filters, per-row copy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ Tickets can be listed or exported via the API:
 
 See [docs/tickets.md](docs/tickets.md) for full schema and guardrail details.
 
+## Dashboard
+
+The dashboard provides a `/tickets` view for operators.
+
+```bash
+pnpm --filter ./apps/api dev    # API in one terminal
+pnpm --filter ./apps/dashboard dev # Dashboard in another
+```
+
+Open [http://localhost:5173/tickets](http://localhost:5173/tickets).
+
+The page polls `/tickets` for the selected date (default today) every 5 seconds.
+Use the refresh selector to change interval or turn polling off.
+
+Export CSV opens `/export/tickets?date=YYYY-MM-DD` in a new tab.
+
 ## Telemetry
 
 A temporary no-op `@prism-apex-tool/analytics` package exports helpers (`trackEvent`, `trackError`, `meter`, `createAnalyticsScope`) that currently do nothing. This stub keeps CI green and will be replaced with real telemetry in a future workstream.

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "18.2.0",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@playwright/test": "1.54.2",

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,43 +1,43 @@
-import { useState } from 'react';
-import { TicketsTable } from './components/TicketsTable';
+import { BrowserRouter, Routes, Route, Navigate, Link } from 'react-router-dom';
+import TicketsPage from './pages/Tickets';
 import { AlertsPanel } from './components/AlertsPanel';
 import { AccountStatus } from './components/AccountStatus';
 import { ReportsView } from './components/ReportsView';
+import { SystemStatus } from './components/SystemStatus';
 
 export default function App() {
-  const [view, setView] = useState<'tickets' | 'reports'>('tickets');
-
   return (
-    <div className="min-h-screen bg-gray-50 p-4">
-      <header className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Prism Apex Operator Dashboard</h1>
-        <nav className="space-x-4">
-          <button
-            type="button"
-            onClick={() => setView('tickets')}
-            className="px-3 py-1 bg-blue-600 text-white rounded"
-          >
-            Tickets
-          </button>
-          <button
-            type="button"
-            onClick={() => setView('reports')}
-            className="px-3 py-1 bg-gray-200 text-gray-800 rounded"
-          >
-            Reports
-          </button>
-        </nav>
-      </header>
+    <BrowserRouter>
+      <div className="min-h-screen bg-gray-50 p-4">
+        <header className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-2xl font-bold">Prism Apex Operator Dashboard</h1>
+            <SystemStatus />
+          </div>
+          <nav className="space-x-4">
+            <Link to="/tickets" className="px-3 py-1 bg-blue-600 text-white rounded">
+              Tickets
+            </Link>
+            <Link to="/reports" className="px-3 py-1 bg-gray-200 text-gray-800 rounded">
+              Reports
+            </Link>
+          </nav>
+        </header>
 
-      <main className="grid grid-cols-4 gap-4">
-        <section className="col-span-4 md:col-span-3">
-          {view === 'tickets' ? <TicketsTable /> : <ReportsView />}
-        </section>
-        <aside className="col-span-4 md:col-span-1 space-y-4">
-          <AccountStatus />
-          <AlertsPanel />
-        </aside>
-      </main>
-    </div>
+        <main className="grid grid-cols-4 gap-4">
+          <section className="col-span-4 md:col-span-3">
+            <Routes>
+              <Route path="/" element={<Navigate to="/tickets" replace />} />
+              <Route path="/tickets" element={<TicketsPage />} />
+              <Route path="/reports" element={<ReportsView />} />
+            </Routes>
+          </section>
+          <aside className="col-span-4 md:col-span-1 space-y-4">
+            <AccountStatus />
+            <AlertsPanel />
+          </aside>
+        </main>
+      </div>
+    </BrowserRouter>
   );
 }

--- a/apps/dashboard/src/__tests__/App.test.tsx
+++ b/apps/dashboard/src/__tests__/App.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 // eslint-disable-next-line import/no-unresolved
-import App from '../App.js';
+import App from '../App';
 
 describe('App', () => {
   it('renders dashboard title', () => {

--- a/apps/dashboard/src/__tests__/Tickets.test.tsx
+++ b/apps/dashboard/src/__tests__/Tickets.test.tsx
@@ -1,0 +1,70 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+const sampleTickets = [
+  {
+    symbol: 'ESZ4',
+    side: 'BUY',
+    entry: 4800,
+    stop: 4798,
+    target: 4804,
+    qty: 1,
+    accountId: 'A1',
+    timestampUtc: new Date().toISOString(),
+    meta: { strategy: 'VWAP_FT', rr: 2, guardrails: [] },
+    accepted: true,
+  },
+  {
+    symbol: 'NQZ4',
+    side: 'SELL',
+    entry: 15000,
+    stop: 15010,
+    target: 14980,
+    qty: 1,
+    accountId: 'A1',
+    timestampUtc: new Date().toISOString(),
+    meta: { strategy: 'OSB', rr: 1.5, guardrails: [] },
+    accepted: false,
+    reasons: ['test'],
+  },
+];
+
+const fetchMock = vi.fn().mockResolvedValue({
+  ok: true,
+  json: async () => ({ tickets: sampleTickets, nextCursor: null }),
+});
+vi.stubGlobal('fetch', fetchMock);
+
+import TicketsPage from '../pages/Tickets';
+
+describe('TicketsPage', () => {
+  it('toggles accepted/rejected filters', async () => {
+    render(<TicketsPage />);
+    await screen.findByText('ESZ4');
+
+    const acceptedToggle = screen.getByLabelText('Accepted');
+    fireEvent.click(acceptedToggle);
+    await waitFor(() =>
+      expect(screen.queryByText('ESZ4')).not.toBeInTheDocument(),
+    );
+
+    const rejectedToggle = screen.getByLabelText('Rejected');
+    fireEvent.click(rejectedToggle);
+    await waitFor(() =>
+      expect(screen.queryByText('NQZ4')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('copies entry to clipboard', async () => {
+    const writeText = vi.fn();
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<TicketsPage />);
+    await screen.findByText('ESZ4');
+
+    fireEvent.click(screen.getAllByText('Copy')[1]);
+    const entryBtn = screen.getAllByRole('button', { name: 'Entry' })[0];
+    fireEvent.click(entryBtn);
+    expect(writeText).toHaveBeenCalledWith('4800');
+  });
+});

--- a/apps/dashboard/src/components/FiltersBar.tsx
+++ b/apps/dashboard/src/components/FiltersBar.tsx
@@ -1,0 +1,123 @@
+import { SYMBOLS, STRATEGIES } from '../constants';
+
+interface Props {
+  date: string;
+  setDate: (s: string) => void;
+  symbols: string[];
+  setSymbols: (s: string[]) => void;
+  strategies: string[];
+  setStrategies: (s: string[]) => void;
+  showAccepted: boolean;
+  setShowAccepted: (b: boolean) => void;
+  showRejected: boolean;
+  setShowRejected: (b: boolean) => void;
+  refreshMs: number;
+  setRefreshMs: (n: number) => void;
+  onExport: () => void;
+}
+
+export function FiltersBar({
+  date,
+  setDate,
+  symbols,
+  setSymbols,
+  strategies,
+  setStrategies,
+  showAccepted,
+  setShowAccepted,
+  showRejected,
+  setShowRejected,
+  refreshMs,
+  setRefreshMs,
+  onExport,
+}: Props) {
+  const toggleSymbol = (sym: string) => {
+    setSymbols(
+      symbols.includes(sym)
+        ? symbols.filter((s) => s !== sym)
+        : [...symbols, sym]
+    );
+  };
+
+  const toggleStrategy = (str: string) => {
+    setStrategies(
+      strategies.includes(str)
+        ? strategies.filter((s) => s !== str)
+        : [...strategies, str]
+    );
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-4 mb-4">
+      <input
+        type="date"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        className="border px-2 py-1 rounded"
+      />
+
+      <div className="flex items-center gap-2">
+        {SYMBOLS.map((s) => (
+          <label key={s} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={symbols.includes(s)}
+              onChange={() => toggleSymbol(s)}
+            />
+            {s}
+          </label>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        {STRATEGIES.map((s) => (
+          <label key={s} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={strategies.includes(s)}
+              onChange={() => toggleStrategy(s)}
+            />
+            {s}
+          </label>
+        ))}
+      </div>
+
+      <label className="flex items-center gap-1">
+        <input
+          type="checkbox"
+          checked={showAccepted}
+          onChange={(e) => setShowAccepted(e.target.checked)}
+        />
+        Accepted
+      </label>
+
+      <label className="flex items-center gap-1">
+        <input
+          type="checkbox"
+          checked={showRejected}
+          onChange={(e) => setShowRejected(e.target.checked)}
+        />
+        Rejected
+      </label>
+
+      <select
+        value={refreshMs.toString()}
+        onChange={(e) => setRefreshMs(Number(e.target.value))}
+        className="border px-2 py-1 rounded"
+      >
+        <option value="3000">3s</option>
+        <option value="5000">5s</option>
+        <option value="10000">10s</option>
+        <option value="0">Off</option>
+      </select>
+
+      <button
+        type="button"
+        onClick={onExport}
+        className="px-2 py-1 bg-gray-200 rounded"
+      >
+        Export CSV
+      </button>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/SystemStatus.tsx
+++ b/apps/dashboard/src/components/SystemStatus.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+
+export function SystemStatus() {
+  const [status, setStatus] = useState<any>(null);
+
+  useEffect(() => {
+    api
+      .ready()
+      .then(setStatus)
+      .catch(() => {});
+  }, []);
+
+  if (!status) return null;
+
+  const t = status.ticketizer;
+  return (
+    <div className="text-xs">
+      ticketizer.running {t?.running ? '✓' : '✗'} | acc {t?.accepted ?? 0} / rej {t?.rejected ?? 0}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/TicketsTable.tsx
+++ b/apps/dashboard/src/components/TicketsTable.tsx
@@ -1,62 +1,99 @@
-import { useEffect, useState } from 'react';
-import { api } from '../lib/api';
+import { copyText } from '../lib/copy';
 
-interface Ticket {
+export interface Ticket {
   symbol: string;
-  side: string;
+  side: 'BUY' | 'SELL';
   entry: number;
   stop: number;
   target: number;
-  time: string;
+  qty: number;
+  accountId: string;
+  timestampUtc: string;
+  meta: { strategy: 'VWAP_FT' | 'OSB'; rr: number; guardrails: string[] };
+  accepted: boolean;
+  reasons?: string[];
 }
 
-export function TicketsTable() {
-  const [tickets, setTickets] = useState<Ticket[]>([]);
+interface Props {
+  tickets: Ticket[];
+  hasMore: boolean;
+  onLoadMore: () => void;
+}
 
-  useEffect(() => {
-    api
-      .get('/tickets')
-      .then((rows: any[]) => {
-        const mapped = rows.map((r: any) => ({
-          symbol: r.ticket.symbol,
-          side: r.ticket.side,
-          entry: r.ticket.entry,
-          stop: r.ticket.stop,
-          target: r.ticket.targets?.[0],
-          time: new Date(r.when).toLocaleTimeString(),
-        }));
-        setTickets(mapped);
-      })
-      .catch(() => {});
-  }, []);
+function orderBlock(t: Ticket) {
+  const rr = t.meta.rr.toFixed(2);
+  return `${t.symbol} ${t.side} ${t.qty} @ ${t.entry.toFixed(2)} | SL ${t.stop.toFixed(2)} | TP ${t.target.toFixed(2)} | RR ${rr}`;
+}
+
+export function TicketsTable({ tickets, hasMore, onLoadMore }: Props) {
+  if (tickets.length === 0) {
+    return (
+      <div className="p-4 bg-white rounded shadow">
+        <p>No tickets. Check <a href="/ready" className="underline">/ready</a>?</p>
+      </div>
+    );
+  }
 
   return (
-    <div className="bg-white shadow rounded p-4">
-      <h2 className="mb-2 text-lg font-semibold">Trade Tickets</h2>
+    <div className="bg-white shadow rounded p-4 overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
           <tr className="text-left">
+            <th>Time</th>
             <th>Symbol</th>
             <th>Side</th>
             <th>Entry</th>
             <th>Stop</th>
             <th>Target</th>
-            <th>Time</th>
+            <th>RR</th>
+            <th>Qty</th>
+            <th>Strategy</th>
+            <th>Accepted</th>
+            <th>Copy</th>
           </tr>
         </thead>
         <tbody>
-          {tickets.map((t, i) => (
-            <tr key={i} className="border-t">
+          {tickets.map((t, idx) => (
+            <tr key={`${t.symbol}-${t.timestampUtc}-${idx}`} className="border-t">
+              <td>{new Date(t.timestampUtc).toLocaleTimeString()}</td>
               <td>{t.symbol}</td>
               <td>{t.side}</td>
               <td>{t.entry}</td>
               <td>{t.stop}</td>
               <td>{t.target}</td>
-              <td>{t.time}</td>
+              <td>{t.meta.rr.toFixed(2)}</td>
+              <td>{t.qty}</td>
+              <td>{t.meta.strategy}</td>
+              <td title={t.accepted ? '' : (t.reasons || []).join(', ')}>
+                {t.accepted ? '✓' : '✗'}
+              </td>
+              <td className="relative">
+                <details>
+                  <summary className="cursor-pointer">Copy</summary>
+                  <div className="absolute z-10 bg-white border p-1 text-xs flex flex-col">
+                    <button onClick={() => copyText(t.entry.toString())}>Entry</button>
+                    <button onClick={() => copyText(t.stop.toString())}>Stop</button>
+                    <button onClick={() => copyText(t.target.toString())}>Target</button>
+                    <button onClick={() => copyText(t.qty.toString())}>Qty</button>
+                    <button onClick={() => copyText(orderBlock(t))}>Order Block</button>
+                  </div>
+                </details>
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
+      {hasMore && (
+        <div className="mt-2 text-center">
+          <button
+            type="button"
+            onClick={onLoadMore}
+            className="px-2 py-1 bg-gray-200 rounded"
+          >
+            Load more
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/dashboard/src/constants.ts
+++ b/apps/dashboard/src/constants.ts
@@ -1,0 +1,2 @@
+export const SYMBOLS = ['ES', 'NQ', 'MES', 'MNQ'];
+export const STRATEGIES = ['VWAP_FT', 'OSB'];

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -13,21 +13,24 @@ export type Market = unknown;
 export type Position = unknown;
 export type Order = unknown;
 
-const API_BASE =
-  typeof window === "undefined"
-    ? "http://localhost:3000/api/compat"
-    : "/api/compat";
+const COMPAT_BASE =
+  typeof window === 'undefined' ? 'http://localhost:3000/api/compat' : '/api/compat';
 
-async function request(path: string, init?: RequestInit) {
-  const res = await fetch(`${API_BASE}${path}`, init);
+const DIRECT_BASE =
+  typeof window === 'undefined' ? 'http://localhost:3000' : window.location.origin;
+
+async function request(base: string, path: string, init?: RequestInit) {
+  const res = await fetch(`${base}${path}`, init);
   if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`API error ${res.status}${text ? `: ${text}` : ""}`);
+    const text = await res.text().catch(() => '');
+    throw new Error(`API error ${res.status}${text ? `: ${text}` : ''}`);
   }
   return res.json();
 }
 
 export const api = {
-  get: (path: string) => request(path),
+  get: (path: string) => request(COMPAT_BASE, path),
+  tickets: (date: string, cursor?: string) =>
+    request(DIRECT_BASE, `/tickets?date=${date}${cursor ? `&cursor=${cursor}` : ''}`),
+  ready: () => request(DIRECT_BASE, '/ready'),
 };
-

--- a/apps/dashboard/src/lib/copy.ts
+++ b/apps/dashboard/src/lib/copy.ts
@@ -1,0 +1,18 @@
+export async function copyText(text: string) {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+    } else {
+      const ta = document.createElement('textarea');
+      ta.value = text;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+  } catch (err) {
+    console.error('copy failed', err);
+  }
+}

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
-import App from "./App.js";
+import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/apps/dashboard/src/pages/Tickets.tsx
+++ b/apps/dashboard/src/pages/Tickets.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { FiltersBar } from '../components/FiltersBar';
+import { TicketsTable, Ticket } from '../components/TicketsTable';
+import { api } from '../lib/api';
+
+export default function TicketsPage() {
+  const today = new Date().toISOString().slice(0, 10);
+  const [date, setDate] = useState(today);
+  const [symbols, setSymbols] = useState<string[]>([]);
+  const [strategies, setStrategies] = useState<string[]>([]);
+  const [showAccepted, setShowAccepted] = useState(true);
+  const [showRejected, setShowRejected] = useState(true);
+  const [refreshMs, setRefreshMs] = useState(5000);
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+
+  const applyFilters = (rows: Ticket[]) =>
+    rows.filter((t) => {
+      if (symbols.length && !symbols.some((s) => t.symbol.startsWith(s))) {
+        return false;
+      }
+      if (strategies.length && !strategies.includes(t.meta.strategy)) {
+        return false;
+      }
+      if (!showAccepted && t.accepted) return false;
+      if (!showRejected && !t.accepted) return false;
+      return true;
+    });
+
+  async function fetchTickets(cursor?: string, append = false) {
+    try {
+      const res: any = await api.tickets(date, cursor);
+      const filtered = applyFilters(res.tickets as Ticket[]);
+      setNextCursor(res.nextCursor);
+      setTickets((prev) => (append ? [...prev, ...filtered] : filtered));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  useEffect(() => {
+    fetchTickets();
+  }, [date, symbols, strategies, showAccepted, showRejected]);
+
+  useEffect(() => {
+    if (refreshMs > 0) {
+      const id = setInterval(() => fetchTickets(), refreshMs);
+      return () => clearInterval(id);
+    }
+  }, [refreshMs, date, symbols, strategies, showAccepted, showRejected]);
+
+  const onExport = () => {
+    window.open(`/export/tickets?date=${date}`, '_blank');
+  };
+
+  const loadMore = () => {
+    if (nextCursor) fetchTickets(nextCursor, true);
+  };
+
+  return (
+    <div>
+      <FiltersBar
+        date={date}
+        setDate={setDate}
+        symbols={symbols}
+        setSymbols={setSymbols}
+        strategies={strategies}
+        setStrategies={setStrategies}
+        showAccepted={showAccepted}
+        setShowAccepted={setShowAccepted}
+        showRejected={showRejected}
+        setShowRejected={setShowRejected}
+        refreshMs={refreshMs}
+        setRefreshMs={setRefreshMs}
+        onExport={onExport}
+      />
+      <TicketsTable tickets={tickets} hasMore={!!nextCursor} onLoadMore={loadMore} />
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.2.0)
+      react-router-dom:
+        specifier: ^6.23.0
+        version: 6.30.1(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@playwright/test':
         specifier: 1.54.2
@@ -298,6 +301,8 @@ importers:
         specifier: ^8.7.0
         version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
 
+  packages/indicators: {}
+
   packages/reporting:
     devDependencies:
       '@eslint/js':
@@ -344,6 +349,21 @@ importers:
       typescript-eslint:
         specifier: ^8.7.0
         version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+
+  packages/strategies:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.11
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.2
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
 
 packages:
 
@@ -1002,6 +1022,10 @@ packages:
     resolution: {integrity: sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@remix-run/router@1.23.0':
+    resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
+    engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.30':
     resolution: {integrity: sha512-whXaSoNUFiyDAjkUF8OBpOm77Szdbk5lGNqFe6CbVbJFrhCCPinCbRA3NjawwlNHla1No7xvXXh+CpSxnPfUEw==}
@@ -3245,6 +3269,19 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@6.30.1:
+    resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.1:
+    resolution: {integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -4660,6 +4697,8 @@ snapshots:
   '@playwright/test@1.54.2':
     dependencies:
       playwright: 1.54.2
+
+  '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.30': {}
 
@@ -7050,6 +7089,18 @@ snapshots:
   react-is@18.3.1: {}
 
   react-refresh@0.17.0: {}
+
+  react-router-dom@6.30.1(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.2.0
+      react-dom: 18.3.1(react@18.2.0)
+      react-router: 6.30.1(react@18.2.0)
+
+  react-router@6.30.1(react@18.2.0):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.2.0
 
   react@18.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
Adds a lightweight Dashboard “Trade Tickets” panel that polls `/tickets` for today’s tickets, provides filters (symbol, strategy, accepted/rejected), cursor pagination, and per-row copy actions (entry/stop/target/qty/order block). Includes optional `/ready` status indicator for the ticketizer.

## How to run

```bash
pnpm i
pnpm -w build
pnpm --filter ./apps/api dev   # in one terminal
pnpm --filter ./apps/dashboard dev # in another (or same monorepo if proxied)
# open http://localhost:5173/tickets
```

## Tests

- `pnpm --filter ./apps/dashboard test`


------
https://chatgpt.com/codex/tasks/task_b_68acf9d38a04832c88393033bb3433ae