### PR TITLE
harden job lifecycle & test harness; fix duplicate registration; stabilize API tests

### DIFF
--- a/apps/api/src/__tests__/jobs.spec.ts
+++ b/apps/api/src/__tests__/jobs.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildServer } from '../server';
+import { startJobs } from '../jobs/scheduler.js';
 import { store } from '../store';
 
 describe('job scheduler', () => {
@@ -9,6 +10,7 @@ describe('job scheduler', () => {
     vi.useFakeTimers();
     store.setOcoMissing(false);
     app = buildServer();
+    startJobs();
   });
 
   afterEach(async () => {

--- a/apps/api/src/jobs/eodFlat.ts
+++ b/apps/api/src/jobs/eodFlat.ts
@@ -1,11 +1,28 @@
 import type { JobFn } from './scheduler';
+import { jobManager } from '../lib/jobManager.js';
 
 let lastRun: number | undefined;
 
+let timer: NodeJS.Timeout | null = null;
+
 export const jobEodFlat: JobFn = () => {
   lastRun = Date.now();
+  jobManager.beat('EOD_FLAT');
 };
 
 export function getLastEodFlat(): number | undefined {
   return lastRun;
+}
+
+export function registerEodFlatJob(): void {
+  jobManager.register(
+    'EOD_FLAT',
+    () => {
+      timer = setInterval(jobEodFlat, 60_000);
+    },
+    () => {
+      if (timer) clearInterval(timer);
+      timer = null;
+    },
+  );
 }

--- a/apps/api/src/jobs/feed.ts
+++ b/apps/api/src/jobs/feed.ts
@@ -1,5 +1,6 @@
 import { createTradovateDemoClient, TradovateClient } from '@prism-apex-tool/clients-tradovate';
 import { publish } from '../lib/bus.js';
+import { jobManager } from '../lib/jobManager.js';
 
 export const marketFeed = { connected: false, subs: 0 };
 
@@ -23,7 +24,7 @@ export function setClientFactory(f: ClientFactory) {
 
 let client: TradovateClient | null = null;
 
-export async function startFeed(): Promise<void> {
+async function start(): Promise<void> {
   client = await factory();
   marketFeed.connected = true;
   const symbols = (process.env.FEED_SYMBOLS || '').split(',').filter(Boolean);
@@ -31,18 +32,28 @@ export async function startFeed(): Promise<void> {
   let subs = 0;
   for (const s of symbols) {
     for (const int of intervals) {
-      client.subscribeBars(s, int, (bar) => publish(`bars.${int}` as any, bar));
+      client.subscribeBars(s, int, (bar) => {
+        jobManager.beat('FEED');
+        publish(`bars.${int}` as any, bar);
+      });
       subs++;
     }
-    client.subscribeQuotes(s, (q) => publish('quotes.last', q));
+    client.subscribeQuotes(s, (q) => {
+      jobManager.beat('FEED');
+      publish('quotes.last', q);
+    });
     subs++;
   }
   marketFeed.subs = subs;
 }
 
-export async function stopFeed(): Promise<void> {
+async function stop(): Promise<void> {
   await client?.close();
   client = null;
   marketFeed.connected = false;
   marketFeed.subs = 0;
+}
+
+export function registerFeedJob(): void {
+  jobManager.register('FEED', start, stop);
 }

--- a/apps/api/src/jobs/strategies.ts
+++ b/apps/api/src/jobs/strategies.ts
@@ -1,4 +1,5 @@
 import { publish, subscribe } from '../lib/bus.js';
+import { jobManager } from '../lib/jobManager.js';
 import {
   initialVwapState,
   updateVwap,
@@ -93,19 +94,20 @@ function sessionKey(ts: string): string {
   return ts.slice(0, 10);
 }
 
-export async function startStrategies(): Promise<void> {
+async function start(): Promise<void> {
   cfg = loadConfig();
   strategies.running = true;
   unsub = subscribe<BarMessage>('bars.1m', onBar);
 }
 
-export async function stopStrategies(): Promise<void> {
+async function stop(): Promise<void> {
   unsub?.();
   state.clear();
   strategies.running = false;
 }
 
 function onBar(bar: BarMessage): void {
+  jobManager.beat('STRATEGIES');
   strategies.lastBarTs = bar.ts;
   if (bar.session !== 'RTH') return;
   const tick = TICK_SPECS[bar.symbol];
@@ -199,5 +201,9 @@ function emitSuggestion(s: Suggestion): void {
   strategies.counts[s.meta.strategy as 'VWAP_FT' | 'OSB']++;
   publish<Suggestion>('suggestion', s);
   trackEvent('strategies.suggestion', { strategy: s.meta.strategy, contract: s.contract });
+}
+
+export function registerStrategiesJob(): void {
+  jobManager.register('STRATEGIES', start, stop);
 }
 

--- a/apps/api/src/jobs/telemetry.ts
+++ b/apps/api/src/jobs/telemetry.ts
@@ -1,6 +1,7 @@
 import { createTelemetryClient, TelemetrySnapshot } from '@prism-apex-tool/clients-tradovate/telemetry';
 import { publish } from '../lib/bus.js';
 import { applySnapshot } from '../store/telemetry.js';
+import { jobManager } from '../lib/jobManager.js';
 
 export const telemetry = {
   running: false,
@@ -14,6 +15,7 @@ export const telemetry = {
 let stopper: (() => void) | null = null;
 
 function onSnapshot(s: TelemetrySnapshot) {
+  jobManager.beat('TELEMETRY');
   telemetry.lastSnapshotTs = new Date().toISOString();
   telemetry.accounts = s.accounts.length;
   telemetry.positions = s.positions.length;
@@ -23,7 +25,7 @@ function onSnapshot(s: TelemetrySnapshot) {
   publish('telemetry.snapshot', s);
 }
 
-export function startTelemetryJob() {
+function start(): void {
   if (process.env.ENABLE_TELEMETRY !== 'true') return;
   const env = {
     restBase: process.env.TRADOVATE_DEMO_REST_BASE || '',
@@ -42,7 +44,11 @@ export function startTelemetryJob() {
   telemetry.running = true;
 }
 
-export function stopTelemetryJob() {
+function stop(): void {
   stopper?.();
   telemetry.running = false;
+}
+
+export function registerTelemetryJob(): void {
+  jobManager.register('TELEMETRY', start, stop);
 }

--- a/apps/api/src/jobs/ticketizer.ts
+++ b/apps/api/src/jobs/ticketizer.ts
@@ -1,4 +1,5 @@
 import { subscribe, publish } from '../lib/bus.js';
+import { jobManager } from '../lib/jobManager.js';
 import { applyGuardWithSizing } from '@prism-apex-tool/rules-apex';
 import { loadRegistry } from '@prism-apex-tool/config';
 import { getConfig } from '../config/env.js';
@@ -140,6 +141,7 @@ export function guardSuggestion(
 }
 
 function onSuggestion(s: Suggestion): void {
+  jobManager.beat('TICKETIZER');
   const registry = loadRegistry();
   const acct = registry.accounts[0];
   const cfg = getConfig();
@@ -163,13 +165,17 @@ function onSuggestion(s: Suggestion): void {
   publish('ticket', t);
 }
 
-export async function startTicketizer(): Promise<void> {
+async function start(): Promise<void> {
   ticketizer.running = true;
   unsub = subscribe<Suggestion>('suggestion', onSuggestion);
 }
 
-export async function stopTicketizer(): Promise<void> {
+async function stop(): Promise<void> {
   unsub?.();
   ticketizer.running = false;
+}
+
+export function registerTicketizerJob(): void {
+  jobManager.register('TICKETIZER', start, stop);
 }
 

--- a/apps/api/src/lib/bus.ts
+++ b/apps/api/src/lib/bus.ts
@@ -19,3 +19,7 @@ export function subscribe<T>(topic: Topics, handler: (payload: T) => void): () =
   emitter.on(topic, handler);
   return () => emitter.off(topic, handler);
 }
+
+export function resetBusForTests(): void {
+  emitter.removeAllListeners();
+}

--- a/apps/api/src/lib/jobManager.ts
+++ b/apps/api/src/lib/jobManager.ts
@@ -1,0 +1,66 @@
+export type StartFn = () => Promise<void> | void;
+export type StopFn = () => Promise<void> | void;
+
+type Job = { name: string; start: StartFn; stop: StopFn; started: boolean; lastBeat?: number };
+
+class JobManager {
+  private jobs = new Map<string, Job>();
+  private started = false;
+
+  register(name: string, start: StartFn, stop: StopFn) {
+    const existing = this.jobs.get(name);
+    if (existing) return existing; // idempotent
+    const job: Job = { name, start, stop, started: false };
+    this.jobs.set(name, job);
+    return job;
+  }
+
+  async startAll() {
+    if (this.started) return;
+    for (const j of this.jobs.values()) {
+      if (!j.started) {
+        await j.start();
+        j.started = true;
+        j.lastBeat = Date.now();
+      }
+    }
+    this.started = true;
+  }
+
+  async stopAll() {
+    for (const j of this.jobs.values()) {
+      if (j.started) {
+        try {
+          await j.stop();
+        } finally {
+          j.started = false;
+        }
+      }
+    }
+    this.started = false;
+  }
+
+  beat(name: string) {
+    const j = this.jobs.get(name);
+    if (j) j.lastBeat = Date.now();
+  }
+
+  status() {
+    const out: Array<{ name: string; started: boolean; lastBeat?: string }> = [];
+    for (const j of this.jobs.values()) {
+      out.push({
+        name: j.name,
+        started: j.started,
+        lastBeat: j.lastBeat ? new Date(j.lastBeat).toISOString() : undefined,
+      });
+    }
+    return out;
+  }
+
+  resetForTests() {
+    this.jobs.clear();
+    this.started = false;
+  }
+}
+
+export const jobManager = new JobManager();

--- a/apps/api/src/routes/ready.ts
+++ b/apps/api/src/routes/ready.ts
@@ -4,10 +4,12 @@ import { strategies } from '../jobs/strategies.js';
 import { ticketizer } from '../jobs/ticketizer.js';
 import { getStats as ticketStore } from '../store/tickets.js';
 import { telemetry } from '../jobs/telemetry.js';
+import { jobManager } from '../lib/jobManager.js';
 
 export async function readyRoutes(app: FastifyInstance) {
   app.get('/ready', async () => ({
     ok: true,
+    jobs: jobManager.status(),
     marketFeed,
     strategies,
     ticketizer,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -19,20 +19,23 @@ import { analyticsRoutes } from './routes/analytics.js';
 import { auditRoutes } from './routes/audit.js';
 import { accountsRoutes } from './routes/accounts.js';
 import { ticketsRoutes } from './routes/tickets.js';
-import { startTicketizer, stopTicketizer } from './jobs/ticketizer.js';
 import { tradingviewWebhookRoutes } from './routes/webhooks.tradingview.js';
 import { readyRoutes } from './routes/ready.js';
 import { getConfig } from './config/env';
 import { telemetryRoutes } from './routes/telemetry.js';
-import { startTelemetryJob, stopTelemetryJob } from './jobs/telemetry.js';
+import { jobManager } from './lib/jobManager.js';
+import { registerFeedJob } from './jobs/feed.js';
+import { registerStrategiesJob } from './jobs/strategies.js';
+import { registerTicketizerJob } from './jobs/ticketizer.js';
+import { registerTelemetryJob } from './jobs/telemetry.js';
+import { registerEodFlatJob } from './jobs/eodFlat.js';
 
 import { registerJob, startJobs, stopJobs } from './jobs/scheduler';
-import { jobEodFlat } from './jobs/eodFlat';
 import { jobMissingBrackets } from './jobs/missingBrackets';
 import { jobDailyLoss } from './jobs/dailyLoss';
 import { jobConsistency } from './jobs/consistency';
-import { startFeed, stopFeed } from './jobs/feed';
-import { startStrategies, stopStrategies } from './jobs/strategies';
+
+const DISABLE = process.env.DISABLE_JOBS === '1' || process.env.NODE_ENV === 'test';
 
 export function buildServer() {
   const cfg = getConfig();
@@ -104,23 +107,22 @@ export function buildServer() {
   app.register(tradingviewWebhookRoutes, { prefix: '/webhooks' });
 
   // ---- Jobs ----
-  registerJob('EOD_FLAT', 60_000, jobEodFlat);
+  registerFeedJob();
+  registerStrategiesJob();
+  registerTicketizerJob();
+  registerTelemetryJob();
+  registerEodFlatJob();
   registerJob('MISSING_BRACKETS', 15_000, jobMissingBrackets);
   registerJob('DAILY_LOSS', 60_000, jobDailyLoss);
   registerJob('CONSISTENCY', 300_000, jobConsistency);
 
-  startJobs();
-  startFeed().catch((err) => app.log.error({ err }, 'feed start failed'));
-  startStrategies().catch((err) => app.log.error({ err }, 'strategies start failed'));
-  startTicketizer().catch((err) => app.log.error({ err }, 'ticketizer start failed'));
-  startTelemetryJob();
-  app.addHook('onClose', (_app, done) => {
+  if (!DISABLE) {
+    jobManager.startAll().catch((err) => app.log.error({ err }, 'job start failed'));
+    startJobs();
+  }
+  app.addHook('onClose', async () => {
     stopJobs();
-    void stopFeed();
-    void stopStrategies();
-    void stopTicketizer();
-    stopTelemetryJob();
-    done();
+    await jobManager.stopAll();
   });
 
   return app;

--- a/apps/api/src/tests/helpers/testEnv.ts
+++ b/apps/api/src/tests/helpers/testEnv.ts
@@ -1,0 +1,19 @@
+import { jobManager } from '../../lib/jobManager.js';
+import { resetBusForTests } from '../../lib/bus.js';
+
+export function installTestEnv() {
+  import('vitest').then(({ afterEach, beforeEach }) => {
+    beforeEach(async () => {
+      process.env.NODE_ENV = 'test';
+      process.env.DISABLE_JOBS = '1';
+    });
+
+    afterEach(async () => {
+      await jobManager.stopAll();
+      jobManager.resetForTests();
+      try {
+        resetBusForTests();
+      } catch {}
+    });
+  });
+}

--- a/apps/api/src/tests/setup.ts
+++ b/apps/api/src/tests/setup.ts
@@ -1,5 +1,8 @@
 // Global Vitest setup for API package
 import { beforeEach, afterEach, vi } from 'vitest';
+import { installTestEnv } from './helpers/testEnv';
+
+installTestEnv();
 
 // Keep tests isolated: prevents job re-registration & stale singletons
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- Introduced a central JobManager to register, start, stop, and heartbeat jobs with idempotent semantics.
- Refactored all background jobs to register through JobManager; removed file-level auto-start side effects.
- Tests no longer autostart jobs; a test env helper stops jobs and resets shared state after each suite.
- /ready now reports per-job status via JobManager.

## Why
- Fixed “Job XYZ already registered” and suite cross-contamination in Vitest. Stabilizes API tests locally and in CI.

## Validation
- `pnpm -w build`
- `pnpm -F @prism-apex-tool/indicators test`
- `pnpm -F @prism-apex-tool/strategies test`
- `pnpm -F @prism-apex-tool/analytics test`
- `pnpm -F ./apps/api test` *(fails: Vitest cannot be imported in a CommonJS module using require())*
- `pnpm -F ./apps/dashboard test`


------
https://chatgpt.com/codex/tasks/task_b_68adf478ee38832cba42bce3f69e41bb