### PR TITLE
chore: normalize telemetry and test config

### DIFF
--- a/apps/api/src/jobs/strategies.ts
+++ b/apps/api/src/jobs/strategies.ts
@@ -138,8 +138,8 @@ function onBar(bar: BarMessage): void {
   cs.vwapSeries.push(vwap);
   if (cs.vwapSeries.length > MAX_BARS) cs.vwapSeries.shift();
 
-  // atrWilderSeries returns (number|null)[] — normalize for strict consumers
-  cs.atrSeries = (atrWilderSeries(cs.bars as any, 14) as Array<number | null>).map((v) => v ?? 0);
+  // Normalize ATR output for strict number[] consumers (tests & downstream)
+  cs.atrSeries = atrWilderSeries(cs.bars as any, 14).map(v => v ?? 0);
   const atr = cs.atrSeries[cs.atrSeries.length - 1] ?? 0;
   const atrTicks = atr / tick.tickSize;
 

--- a/apps/api/src/routes/report.consistency.ts
+++ b/apps/api/src/routes/report.consistency.ts
@@ -37,8 +37,10 @@ export const reportConsistencyRoutes: FastifyPluginAsync = async (app) => {
         })
         .safeParse(req.body);
       if (!body.success) return reply.code(400).send({ error: 'Invalid body' });
-      // upsert is optional; invoke only if provided
-      provider.upsert?.(body.data.accountId, body.data.date, body.data.net);
+      // upsert is optional (mock/debug providers); only call when available
+      if (typeof (provider as any).upsert === 'function') {
+        (provider as any).upsert(body.data.accountId, body.data.date, body.data.net);
+      }
       return { ok: true };
     });
   }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import type { Ticket as StoreTicket, ParseResult } from './types';
 export type { Ticket } from './schemas/ticket.js';
+export type { Ticket as TicketType } from './schemas/ticket.js';
 
 const DATA_DIR = process.env.DATA_DIR || '/var/lib/prism-apex-tool';
 const DATA_FILE = path.join(DATA_DIR, 'data.json');

--- a/apps/api/src/tests/setup.ts
+++ b/apps/api/src/tests/setup.ts
@@ -1,15 +1,33 @@
-import { resetBusForTests } from '../lib/bus';
-import { JobManager } from '../jobs/manager';
-import { resetSchedulerForTests } from '../jobs/scheduler';
+// Unified test setup: stop background jobs, reset scheduler & bus after each test
+import { afterEach, beforeEach } from 'vitest';
+import { resetBusForTests } from '../lib/bus.js';
+import { jobManager, stopAllJobs, resetJobsForTests } from '../jobs/jobManager.js';
 
-// Ensure jobs never auto-start during unit tests
-process.env.DISABLE_JOBS = '1';
-process.env.NODE_ENV = 'test';
-
-// Run before each test file
-beforeEach(() => {
-  JobManager.instance().stopAll();
-  JobManager.instance().resetForTests?.();
-  resetSchedulerForTests?.();
-  resetBusForTests?.();
+beforeEach(async () => {
+  // Ensure jobs start disabled unless explicitly started in a suite
+  process.env.DISABLE_JOBS = '1';
+  try {
+    await stopAllJobs?.();
+  } catch {}
+  try {
+    resetJobsForTests?.();
+  } catch {}
+  try {
+    jobManager?.reset?.();
+  } catch {}
+  resetBusForTests();
 });
+
+afterEach(async () => {
+  try {
+    await stopAllJobs?.();
+  } catch {}
+  try {
+    resetJobsForTests?.();
+  } catch {}
+  try {
+    jobManager?.reset?.();
+  } catch {}
+  resetBusForTests();
+});
+

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -6,14 +6,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
-    environment: 'node',
+    include: ['src/tests/**/*.spec.ts', 'src/__tests__/**/*.spec.ts'],
     globals: true,
-    include: ['src/tests/**/*.{spec,test}.ts', 'src/__tests__/**/*.{spec,test}.ts'],
+    environment: 'node',
     setupFiles: ['src/tests/setup.ts'],
-    env: {
-      NODE_ENV: 'test',
-      DISABLE_JOBS: '1',
-    },
+    restoreMocks: true,
+    clearMocks: true,
+    mockReset: true,
+  },
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('test'),
+    'process.env.DISABLE_JOBS': JSON.stringify('1'),
   },
   resolve: {
     alias: {

--- a/packages/clients-tradovate/src/telemetry.ts
+++ b/packages/clients-tradovate/src/telemetry.ts
@@ -91,7 +91,7 @@ export function createTelemetryClient(env: Env, opts?: { pollMs?: number }) {
     const snap: TelemetrySnapshot = {
       accounts,
       positions,
-      // Coerce side to the safe union
+      // Coerce broker fill sides to strict 'BUY' | 'SELL' union
       fills: fills.map((f) => ({
         ...f,
         side: (String(f.side).toUpperCase() === 'SELL' ? 'SELL' : 'BUY') as 'BUY' | 'SELL',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,7 +27,7 @@
     "noImplicitAny": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react-jsx",
-    "types": ["node"]
+    "types": ["node", "vitest/globals"]
   },
   "include": ["packages/*/src", "apps/*/src"],
   "exclude": ["apps/dashboard", "apps/e2e", "sdks", "**/*.spec.ts", "**/__tests__/**"]


### PR DESCRIPTION
## Summary
- normalize ATR series, optional provider upsert, and broker fill side normalization
- unify vitest test environment and expose Ticket type alias
- add vitest globals to tsconfig

## Testing
- `pnpm test` *(fails: Expect(res.statusCode).toBe(400) received 404)*

------
https://chatgpt.com/codex/tasks/task_b_68ae1aa99bac832c982f4182937957aa