### PR TITLE
feat(api): guard provider upsert in report consistency

### DIFF
--- a/apps/api/src/routes/report.consistency.ts
+++ b/apps/api/src/routes/report.consistency.ts
@@ -38,7 +38,7 @@ export const reportConsistencyRoutes: FastifyPluginAsync = async (app) => {
         .safeParse(req.body);
       if (!body.success) return reply.code(400).send({ error: 'Invalid body' });
       // Some mock/debug providers don’t implement upsert — guard it.
-      if (typeof (provider as any).upsert === 'function') {
+      if (provider && 'upsert' in provider && typeof (provider as any).upsert === 'function') {
         (provider as any).upsert(body.data.accountId, body.data.date, body.data.net);
       }
       return { ok: true };


### PR DESCRIPTION
## Summary
- guard provider upsert call in report consistency route

## Testing
- `pnpm -w build` *(fails: Module '@prism-apex-tool/audit' has no exported member 'readEventsFromLines')*

------
https://chatgpt.com/codex/tasks/task_b_68af46b1327c832cbdcd695eb8066c55