### PR TITLE
feat: guard atr series access

### DIFF
--- a/packages/strategies/src/osbBreakout.ts
+++ b/packages/strategies/src/osbBreakout.ts
@@ -30,6 +30,7 @@ export function openingSwingBreakout(
   const orHigh = Math.max(...orBars.map((b) => b.high));
   const orLow = Math.min(...orBars.map((b) => b.low));
   const atrNow = atrSeries[atrSeries.length - 1];
+  if (atrNow == null) return [];
 
   const widthTicks = Math.round((orHigh - orLow) / tick.tickSize);
   const minWidthTicks = Math.max(

--- a/packages/strategies/src/vwapFirstTouch.ts
+++ b/packages/strategies/src/vwapFirstTouch.ts
@@ -30,6 +30,7 @@ export function vwapFirstTouch(
   const n = bars.length;
   const vnow = vwapSeries[n - 1];
   const atrNow = atrSeries[n - 1];
+  if (atrNow == null) return [];
   const slopeStart = Math.max(0, n - 1 - P.slopeLookback);
   const slopeEnd = n - 1;
   const slope = (vwapSeries[slopeEnd] - vwapSeries[slopeStart]) / P.slopeLookback;

--- a/packages/strategies/tests/osbBreakout.spec.ts
+++ b/packages/strategies/tests/osbBreakout.spec.ts
@@ -111,4 +111,32 @@ describe('openingSwingBreakout', () => {
     const s = res[0];
     expect(ticksBetween(s.entry, s.stop, tick.tickSize)).toBe(3);
   });
+
+  it('returns empty when ATR series has no data', () => {
+    const bars: Candle[] = [];
+    const atr: number[] = [];
+    for (let i = 0; i < 7; i++) {
+      if (i < 5) {
+        bars.push({ ts: `2024-01-01T00:0${i}:00.000Z`, open: 100, high: 101, low: 99, close: 100 });
+      } else if (i === 5) {
+        bars.push({
+          ts: `2024-01-01T00:0${i}:00.000Z`,
+          open: 100.5,
+          high: 101,
+          low: 100,
+          close: 100.5,
+        });
+      } else {
+        bars.push({
+          ts: `2024-01-01T00:0${i}:00.000Z`,
+          open: 101,
+          high: 101.5,
+          low: 100.5,
+          close: 101.25,
+        });
+      }
+    }
+    const res = openingSwingBreakout('ESZ4', bars, atr, tick);
+    expect(res).toHaveLength(0);
+  });
 });

--- a/packages/strategies/tests/vwapFirstTouch.spec.ts
+++ b/packages/strategies/tests/vwapFirstTouch.spec.ts
@@ -49,4 +49,11 @@ describe('vwapFirstTouch', () => {
     const res = vwapFirstTouch('ESZ4', bars, vwap, atr, tick);
     expect(res).toHaveLength(0);
   });
+
+  it('returns empty when ATR series is missing latest value', () => {
+    const { bars, vwap, atr } = buildBars({});
+    atr.pop();
+    const res = vwapFirstTouch('ESZ4', bars, vwap, atr, tick);
+    expect(res).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary
- handle missing ATR values in strategy helpers
- add tests for empty/missing ATR series

## Testing
- `pnpm run typecheck` *(fails: ts errors in repo)*
- `pnpm run test` *(fails: test suites missing dependencies)*
- `pnpm --filter @prism-apex-tool/strategies typecheck`
- `pnpm --filter @prism-apex-tool/strategies test`


------
https://chatgpt.com/codex/tasks/task_b_68af5a725e3c832ca66fe1795a3c7c9d