### PR TITLE
feat(strategies): externalize strategy params to json

### DIFF
--- a/configs/strategies/opening-session-breakout.json
+++ b/configs/strategies/opening-session-breakout.json
@@ -1,0 +1,14 @@
+{
+  "orMinutes": 5,
+  "requireCloseBreak": true,
+  "rrDefault": 2.0,
+  "rrMin": 1.5,
+  "rrMax": 5.0,
+  "widthMinTicks": 6,
+  "widthMinATR": 0.3,
+  "widthMaxATR": 3.0,
+  "minRiskTicks": 3,
+  "entryOffsetTicks": 1,
+  "stopOffsetTicks": 1,
+  "postOrBars": 2
+}

--- a/configs/strategies/vwap-first-touch.json
+++ b/configs/strategies/vwap-first-touch.json
@@ -1,0 +1,12 @@
+{
+  "slopeLookback": 10,
+  "minDistanceATR": 0.5,
+  "stopKATR": 0.25,
+  "rrDefault": 2.0,
+  "rrMin": 1.5,
+  "rrMax": 3.0,
+  "minStopTicks": 2,
+  "warmupBars": 20,
+  "maxTouchKATR": 0.25,
+  "entryOffsetTicks": 1
+}

--- a/packages/strategies/src/config/strategy-config.ts
+++ b/packages/strategies/src/config/strategy-config.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type StrategyKey = 'vwap-first-touch' | 'opening-session-breakout';
+
+export type VwapFirstTouchParams = {
+  slopeLookback: number;
+  minDistanceATR: number;
+  stopKATR: number;
+  rrDefault: number;
+  rrMin: number;
+  rrMax: number;
+  minStopTicks: number;
+  warmupBars: number;
+  maxTouchKATR: number;
+  entryOffsetTicks: number;
+};
+
+export type OpeningSessionBreakoutParams = {
+  orMinutes: number;
+  requireCloseBreak: boolean;
+  rrDefault: number;
+  rrMin: number;
+  rrMax: number;
+  widthMinTicks: number;
+  widthMinATR: number;
+  widthMaxATR: number;
+  minRiskTicks: number;
+  entryOffsetTicks: number;
+  stopOffsetTicks: number;
+  postOrBars: number;
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export function loadStrategyConfig<T>(key: StrategyKey): T {
+  const filePath = join(__dirname, '../../../../configs/strategies', `${key}.json`);
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(`Failed to load strategy config for ${key}: ${(err as Error).message}`);
+  }
+}
+
+export function mergeParams<T>(defaults: T, overrides?: Partial<T>): T {
+  return { ...defaults, ...(overrides ?? {}) };
+}

--- a/packages/strategies/src/osbBreakout.ts
+++ b/packages/strategies/src/osbBreakout.ts
@@ -1,6 +1,11 @@
 import { Candle, Suggestion } from './types.js';
-import { AtrSeries, OsbParams, TickSpec } from './inputs.js';
+import { AtrSeries, TickSpec } from './inputs.js';
 import { clamp, pricePlusTicks, rMultiple, ticksBetween } from './util.js';
+import {
+  OpeningSessionBreakoutParams,
+  loadStrategyConfig,
+  mergeParams,
+} from './config/strategy-config.js';
 
 /** Opening Swing Breakout over first N minutes of RTH */
 export function openingSwingBreakout(
@@ -8,22 +13,12 @@ export function openingSwingBreakout(
   barsRth: Candle[],
   atrSeries: AtrSeries,
   tick: TickSpec,
-  params: Partial<OsbParams> = {},
+  params: Partial<OpeningSessionBreakoutParams> = {},
   nowIso?: string,
 ): Suggestion[] {
-  const P: OsbParams = {
-    orMinutes: 5,
-    requireCloseBreak: true,
-    rrDefault: 2.0,
-    rrMin: 1.5,
-    rrMax: 5.0,
-    widthMinTicks: 6,
-    widthMinATR: 0.3,
-    widthMaxATR: 3.0,
-    minRiskTicks: 3,
-    ...params,
-  };
-  if (barsRth.length < P.orMinutes + 2) return [];
+  const defaults = loadStrategyConfig<OpeningSessionBreakoutParams>('opening-session-breakout');
+  const P = mergeParams(defaults, params);
+  if (barsRth.length < P.orMinutes + P.postOrBars) return [];
 
   const orBars = barsRth.slice(0, P.orMinutes);
   const rest = barsRth.slice(P.orMinutes);
@@ -49,17 +44,17 @@ export function openingSwingBreakout(
   const side = brokeUp ? 'BUY' : 'SELL';
   const entry =
     side === 'BUY'
-      ? pricePlusTicks(orHigh, +1, tick.tickSize)
-      : pricePlusTicks(orLow, -1, tick.tickSize);
+      ? pricePlusTicks(orHigh, +P.entryOffsetTicks, tick.tickSize)
+      : pricePlusTicks(orLow, -P.entryOffsetTicks, tick.tickSize);
   let stop =
     side === 'BUY'
-      ? pricePlusTicks(orLow, -1, tick.tickSize)
-      : pricePlusTicks(orHigh, +1, tick.tickSize);
+      ? pricePlusTicks(orLow, -P.stopOffsetTicks, tick.tickSize)
+      : pricePlusTicks(orHigh, +P.stopOffsetTicks, tick.tickSize);
 
   let riskTicks = ticksBetween(entry, stop, tick.tickSize);
-  if (riskTicks < (P.minRiskTicks ?? 3)) {
+  if (riskTicks < P.minRiskTicks) {
     // enforce minimum risk ticks to avoid micro boxes
-    const adj = (P.minRiskTicks ?? 3) - riskTicks;
+    const adj = P.minRiskTicks - riskTicks;
     stop =
       side === 'BUY'
         ? pricePlusTicks(stop, -adj, tick.tickSize)

--- a/packages/strategies/src/vwapFirstTouch.ts
+++ b/packages/strategies/src/vwapFirstTouch.ts
@@ -1,6 +1,7 @@
 import { Candle, Suggestion } from './types.js';
-import { VwapSeries, AtrSeries, VwapFtParams, TickSpec } from './inputs.js';
+import { VwapSeries, AtrSeries, TickSpec } from './inputs.js';
 import { clamp, last, rMultiple, ticksBetween, pricePlusTicks } from './util.js';
+import { VwapFirstTouchParams, loadStrategyConfig, mergeParams } from './config/strategy-config.js';
 
 /**
  * Assumes bars are RTH-filtered for the session and vwapSeries resets at session open.
@@ -12,20 +13,12 @@ export function vwapFirstTouch(
   vwapSeries: VwapSeries,
   atrSeries: AtrSeries,
   tick: TickSpec,
-  params: Partial<VwapFtParams> = {},
+  params: Partial<VwapFirstTouchParams> = {},
   nowIso?: string,
 ): Suggestion[] {
-  const P: VwapFtParams = {
-    slopeLookback: 10,
-    minDistanceATR: 0.5,
-    stopKATR: 0.25,
-    rrDefault: 2.0,
-    rrMin: 1.5,
-    rrMax: 3.0,
-    minStopTicks: 2,
-    ...params,
-  };
-  if (bars.length < Math.max(20, P.slopeLookback + 1)) return [];
+  const defaults = loadStrategyConfig<VwapFirstTouchParams>('vwap-first-touch');
+  const P = mergeParams(defaults, params);
+  if (bars.length < Math.max(P.warmupBars, P.slopeLookback + 1)) return [];
 
   const n = bars.length;
   const vnow = vwapSeries[n - 1];
@@ -47,23 +40,23 @@ export function vwapFirstTouch(
     lastClose >= vnow && slope >= 0 ? 'BUY' : lastClose <= vnow && slope <= 0 ? 'SELL' : null;
   if (!side || !hadDistance) return [];
 
-  // "Clean touch": price touches VWAP w/o blasting through > 0.25*ATR
+  // "Clean touch": price touches VWAP w/o blasting through > maxTouchKATR * ATR
   const touchBar = last(bars);
   const overshoot = Math.abs(touchBar.close - vnow);
-  if (overshoot > 0.25 * atrNow) return [];
+  if (overshoot > P.maxTouchKATR * atrNow) return [];
 
-  // Entry at VWAP (one tick inside)
+  // Entry at VWAP (one tick inside by default)
   const entry =
     side === 'BUY'
-      ? pricePlusTicks(vnow, +1, tick.tickSize)
-      : pricePlusTicks(vnow, -1, tick.tickSize);
-  const stopBuf = Math.max(P.minStopTicks ?? 2, Math.round((P.stopKATR * atrNow) / tick.tickSize));
+      ? pricePlusTicks(vnow, +P.entryOffsetTicks, tick.tickSize)
+      : pricePlusTicks(vnow, -P.entryOffsetTicks, tick.tickSize);
+  const stopBuf = Math.max(P.minStopTicks, Math.round((P.stopKATR * atrNow) / tick.tickSize));
   const stop =
     side === 'BUY'
       ? pricePlusTicks(vnow, -stopBuf, tick.tickSize)
       : pricePlusTicks(vnow, +stopBuf, tick.tickSize);
   const riskTicks = ticksBetween(entry, stop, tick.tickSize);
-  if (riskTicks < (P.minStopTicks ?? 2)) return [];
+  if (riskTicks < P.minStopTicks) return [];
 
   const rr = clamp(P.rrDefault, P.rrMin, P.rrMax);
   const target = side === 'BUY' ? entry + rr * (entry - stop) : entry - rr * (stop - entry);

--- a/packages/strategies/tests/vwapFirstTouch.spec.ts
+++ b/packages/strategies/tests/vwapFirstTouch.spec.ts
@@ -44,6 +44,14 @@ describe('vwapFirstTouch', () => {
     expect(res).toHaveLength(0);
   });
 
+  it('applies override for minDistanceATR', () => {
+    const { bars, vwap, atr } = buildBars({});
+    const res = vwapFirstTouch('ESZ4', bars, vwap, atr, tick, {
+      minDistanceATR: 2,
+    });
+    expect(res).toHaveLength(0);
+  });
+
   it('requires positive slope for long trades', () => {
     const { bars, vwap, atr } = buildBars({ slope: -0.1, overshoot: 0.01 });
     const res = vwapFirstTouch('ESZ4', bars, vwap, atr, tick);


### PR DESCRIPTION
## Summary
- load VWAP First Touch defaults from `configs/strategies/vwap-first-touch.json` and allow overrides
- load Opening Session Breakout defaults from `configs/strategies/opening-session-breakout.json` and allow overrides
- add `loadStrategyConfig`/`mergeParams` helper for typed param loading
- add override test for VWAP First Touch

## Testing
- `pnpm --filter @prism-apex-tool/strategies typecheck`
- `pnpm --filter @prism-apex-tool/strategies test`

## Parameters Inventory
### vwap-first-touch
- slopeLookback → 10 (`configs/strategies/vwap-first-touch.json:2`)
- minDistanceATR → 0.5 (`configs/strategies/vwap-first-touch.json:3`)
- stopKATR → 0.25 (`configs/strategies/vwap-first-touch.json:4`)
- rrDefault → 2.0 (`configs/strategies/vwap-first-touch.json:5`)
- rrMin → 1.5 (`configs/strategies/vwap-first-touch.json:6`)
- rrMax → 3.0 (`configs/strategies/vwap-first-touch.json:7`)
- minStopTicks → 2 (`configs/strategies/vwap-first-touch.json:8`)
- warmupBars → 20 (`configs/strategies/vwap-first-touch.json:9`)
- maxTouchKATR → 0.25 (`configs/strategies/vwap-first-touch.json:10`)
- entryOffsetTicks → 1 (`configs/strategies/vwap-first-touch.json:11`)

### opening-session-breakout
- orMinutes → 5 (`configs/strategies/opening-session-breakout.json:2`)
- requireCloseBreak → true (`configs/strategies/opening-session-breakout.json:3`)
- rrDefault → 2.0 (`configs/strategies/opening-session-breakout.json:4`)
- rrMin → 1.5 (`configs/strategies/opening-session-breakout.json:5`)
- rrMax → 5.0 (`configs/strategies/opening-session-breakout.json:6`)
- widthMinTicks → 6 (`configs/strategies/opening-session-breakout.json:7`)
- widthMinATR → 0.3 (`configs/strategies/opening-session-breakout.json:8`)
- widthMaxATR → 3.0 (`configs/strategies/opening-session-breakout.json:9`)
- minRiskTicks → 3 (`configs/strategies/opening-session-breakout.json:10`)
- entryOffsetTicks → 1 (`configs/strategies/opening-session-breakout.json:11`)
- stopOffsetTicks → 1 (`configs/strategies/opening-session-breakout.json:12`)
- postOrBars → 2 (`configs/strategies/opening-session-breakout.json:13`)


------
https://chatgpt.com/codex/tasks/task_b_68af61211134832ca90ef2d4fa83d1e2