### PR TITLE
feat(rules): enforce min RR for funded orders

### DIFF
--- a/configs/rules/apex.json
+++ b/configs/rules/apex.json
@@ -1,0 +1,6 @@
+{
+  "minRR": 1.5,
+  "maxRR": 5,
+  "eodFlatCutoffET": "16:59:00",
+  "halfSizeUntilBufferCleared": true
+}

--- a/packages/rules/__tests__/apex.guard.spec.ts
+++ b/packages/rules/__tests__/apex.guard.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { guardApexFundingRules, OrderParams } from '../src/apex.js';
+import { loadApexRules } from '../src/config.js';
+
+const cfg = loadApexRules();
+
+function makeCtx(overrides: Partial<Parameters<typeof guardApexFundingRules>[1]> = {}) {
+  return {
+    mode: 'funded' as const,
+    bufferCleared: true,
+    maxContractsAllowed: 10,
+    now: new Date('2023-06-01T12:00:00Z'),
+    cfg,
+    ...overrides,
+  };
+}
+
+describe('guardApexFundingRules', () => {
+  it('blocks when rr below min', () => {
+    const t: OrderParams = { qty: 1, entryPrice: 100, stopLoss: 99, takeProfit: 101.4 };
+    const res = guardApexFundingRules(t, makeCtx());
+    expect(res).toEqual({ allow: false, reason: 'RR_LT_MIN' });
+  });
+
+  it('allows when rr at min', () => {
+    const t: OrderParams = { qty: 1, entryPrice: 100, stopLoss: 99, takeProfit: 101.5 };
+    const res = guardApexFundingRules(t, makeCtx());
+    expect(res.allow).toBe(true);
+  });
+
+  it('blocks when rr above max', () => {
+    const t: OrderParams = { qty: 1, entryPrice: 100, stopLoss: 99, takeProfit: 105.1 };
+    const res = guardApexFundingRules(t, makeCtx());
+    expect(res).toEqual({ allow: false, reason: 'RR_GT_MAX' });
+  });
+
+  it('blocks when missing stop', () => {
+    const t: OrderParams = { qty: 1, entryPrice: 100, takeProfit: 101.5 } as any;
+    const res = guardApexFundingRules(t, makeCtx());
+    expect(res).toEqual({ allow: false, reason: 'STOP_REQUIRED' });
+  });
+
+  it('blocks in EOD window', () => {
+    const t: OrderParams = { qty: 1, entryPrice: 100, stopLoss: 99, takeProfit: 101.5 };
+    const res = guardApexFundingRules(t, makeCtx({ now: new Date('2023-06-01T20:59:00Z') }));
+    expect(res).toEqual({ allow: false, reason: 'EOD_FLAT_WINDOW' });
+  });
+
+  it('passes in evaluation mode without rr enforcement', () => {
+    const t: OrderParams = { qty: 1, entryPrice: 100, stopLoss: 99, takeProfit: 101.4 };
+    const res = guardApexFundingRules(t, makeCtx({ mode: 'evaluation' }));
+    expect(res.allow).toBe(true);
+  });
+});

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@prism-apex-tool/rules",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier -w .",
+    "format:check": "prettier -c ."
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "^9.10.0",
+    "@eslint/js": "^9.10.0",
+    "typescript-eslint": "^8.7.0",
+    "prettier": "^3.3.3"
+  }
+}

--- a/packages/rules/src/apex.ts
+++ b/packages/rules/src/apex.ts
@@ -1,0 +1,67 @@
+import { ApexRulesCfg, loadApexRules } from './config.js';
+
+export type OrderParams = {
+  qty: number;
+  entryPrice: number;
+  stopLoss?: number;
+  takeProfit?: number;
+};
+
+export type GuardContext = {
+  mode: 'funded' | 'evaluation';
+  bufferCleared: boolean;
+  maxContractsAllowed: number;
+  now?: Date;
+  cfg?: ApexRulesCfg;
+};
+
+export type GuardResult = {
+  allow: boolean;
+  reason?: string;
+  ticket?: OrderParams;
+};
+
+function isEODWindow(now: Date, cutoff: string): boolean {
+  const [h, m, s] = cutoff.split(':').map(Number);
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = fmt.formatToParts(now);
+  const hour = Number(parts.find((p) => p.type === 'hour')?.value);
+  const minute = Number(parts.find((p) => p.type === 'minute')?.value);
+  const second = Number(parts.find((p) => p.type === 'second')?.value);
+  const current = hour * 3600 + minute * 60 + second;
+  const cutoffSec = h * 3600 + m * 60 + s;
+  return current >= cutoffSec;
+}
+
+export function guardApexFundingRules(t: OrderParams, ctx: GuardContext): GuardResult {
+  if (ctx.mode !== 'funded') return { allow: true, ticket: t };
+
+  const cfg = ctx.cfg ?? loadApexRules();
+
+  if (t.stopLoss == null) return { allow: false, reason: 'STOP_REQUIRED' };
+  if (t.takeProfit == null) return { allow: false, reason: 'RR_REQUIRED' };
+
+  const rr = Math.abs(t.takeProfit - t.entryPrice) / Math.abs(t.entryPrice - t.stopLoss);
+  if (!Number.isFinite(rr) || rr <= 0) return { allow: false, reason: 'RR_REQUIRED' };
+  if (rr < cfg.minRR) return { allow: false, reason: 'RR_LT_MIN' };
+  if (rr > cfg.maxRR) return { allow: false, reason: 'RR_GT_MAX' };
+
+  let qty = t.qty;
+  if (cfg.halfSizeUntilBufferCleared && !ctx.bufferCleared) {
+    qty = Math.min(qty, Math.floor(ctx.maxContractsAllowed / 2));
+    if (qty <= 0) return { allow: false, reason: 'SIZE_ZERO_AFTER_HALFSIZE' };
+  }
+  qty = Math.min(qty, ctx.maxContractsAllowed);
+
+  if (isEODWindow(ctx.now ?? new Date(), cfg.eodFlatCutoffET)) {
+    return { allow: false, reason: 'EOD_FLAT_WINDOW' };
+  }
+
+  return { allow: true, ticket: { ...t, qty } };
+}

--- a/packages/rules/src/config.ts
+++ b/packages/rules/src/config.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+
+export type ApexRulesCfg = {
+  minRR: number;
+  maxRR: number;
+  eodFlatCutoffET: string; // "HH:MM:SS" in America/New_York
+  halfSizeUntilBufferCleared: boolean;
+};
+
+export function loadApexRules(): ApexRulesCfg {
+  const url = new URL('../../../configs/rules/apex.json', import.meta.url);
+  const raw = fs.readFileSync(url, 'utf-8');
+  const data = JSON.parse(raw);
+  const keys: (keyof ApexRulesCfg)[] = [
+    'minRR',
+    'maxRR',
+    'eodFlatCutoffET',
+    'halfSizeUntilBufferCleared',
+  ];
+  for (const k of keys) {
+    if (!(k in data)) throw new Error(`Missing key ${k} in apex config`);
+  }
+  return data as ApexRulesCfg;
+}

--- a/packages/rules/tsconfig.json
+++ b/packages/rules/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "__tests__"]
+}


### PR DESCRIPTION
## Summary
- add apex funding policy config with min/max RR and EOD cutoff
- implement loader and guard enforcing min RR in funded mode
- cover funded vs evaluation behavior with tests

## Testing
- `pnpm --filter @prism-apex-tool/rules typecheck`
- `pnpm --filter @prism-apex-tool/rules test`


------
https://chatgpt.com/codex/tasks/task_b_68af6a60be90832cb37fad36f49cf451