### PR TITLE
feat: add deterministic ticket fanout

### DIFF
--- a/configs/accounts.json
+++ b/configs/accounts.json
@@ -1,0 +1,24 @@
+{
+  "accounts": [
+    {
+      "name": "PA-1",
+      "accountId": 123456,
+      "accountSpec": "PA123456",
+      "mode": "funded",
+      "planMaxContracts": 10,
+      "baseSize": 2,
+      "multiplier": 1.0,
+      "minQty": 1
+    },
+    {
+      "name": "PA-2",
+      "accountId": 234567,
+      "accountSpec": "PA234567",
+      "mode": "funded",
+      "planMaxContracts": 10,
+      "baseSize": 2,
+      "multiplier": 1.0,
+      "minQty": 1
+    }
+  ]
+}

--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types.js';
 export * from './fs.js';
+export * from './registry.js';

--- a/packages/accounts/src/registry.ts
+++ b/packages/accounts/src/registry.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+export type AccountMode = 'eval' | 'funded';
+
+export interface AccountRecord {
+  name: string;
+  accountId: number;
+  accountSpec: string;
+  mode: AccountMode;
+  planMaxContracts: number;
+  baseSize: number;
+  multiplier?: number;
+  minQty?: number;
+}
+
+export interface AccountsFile {
+  accounts: AccountRecord[];
+}
+
+function validateRecord(a: AccountRecord): void {
+  if (!a.name) throw new Error('name required');
+  if (typeof a.accountId !== 'number') throw new Error('accountId must be number');
+  if (!a.accountSpec) throw new Error('accountSpec required');
+  if (a.mode !== 'eval' && a.mode !== 'funded') throw new Error('mode invalid');
+  if (typeof a.planMaxContracts !== 'number') throw new Error('planMaxContracts required');
+  if (typeof a.baseSize !== 'number') throw new Error('baseSize required');
+  if (a.multiplier !== undefined && typeof a.multiplier !== 'number')
+    throw new Error('multiplier must be number');
+  if (a.minQty !== undefined && typeof a.minQty !== 'number')
+    throw new Error('minQty must be number');
+}
+
+export function loadAccounts(
+  filePath: string = path.resolve('configs/accounts.json'),
+): AccountsFile {
+  const data = JSON.parse(readFileSync(filePath, 'utf8')) as AccountsFile;
+  if (!Array.isArray(data.accounts)) throw new Error('accounts must be array');
+  for (const a of data.accounts) validateRecord(a);
+  return data;
+}
+
+export function getAccounts(): AccountRecord[] {
+  return loadAccounts().accounts;
+}

--- a/packages/ticketizer/__tests__/fanout.spec.ts
+++ b/packages/ticketizer/__tests__/fanout.spec.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildFanoutOrders,
+  fanoutAndPlace,
+  type FanoutInput,
+  type BrokerClient,
+} from '../src/fanout.js';
+
+const mockAccounts = vi.hoisted(() => [
+  {
+    name: 'PA-1',
+    accountId: 1,
+    accountSpec: 'A1',
+    mode: 'funded',
+    planMaxContracts: 10,
+    baseSize: 2,
+  },
+  {
+    name: 'PA-2',
+    accountId: 2,
+    accountSpec: 'A2',
+    mode: 'funded',
+    planMaxContracts: 10,
+    baseSize: 2,
+  },
+]);
+vi.mock('@prism-apex-tool/accounts', () => ({ getAccounts: () => mockAccounts }));
+const guard = vi.hoisted(() => vi.fn());
+vi.mock('@prism-apex-tool/rules/apex.js', () => ({ guardApexFundingRules: guard }));
+
+interface AccountRecord {
+  name: string;
+  accountId: number;
+  accountSpec: string;
+  mode: 'eval' | 'funded';
+  planMaxContracts: number;
+  baseSize: number;
+  multiplier?: number;
+  minQty?: number;
+}
+
+describe('deterministic fanout, two accounts', () => {
+  it('builds stable orders with multipliers', () => {
+    const accounts: AccountRecord[] = [
+      {
+        name: 'PA-1',
+        accountId: 1,
+        accountSpec: 'A1',
+        mode: 'funded',
+        planMaxContracts: 10,
+        baseSize: 2,
+        multiplier: 1.0,
+        minQty: 1,
+      },
+      {
+        name: 'PA-2',
+        accountId: 2,
+        accountSpec: 'A2',
+        mode: 'funded',
+        planMaxContracts: 10,
+        baseSize: 2,
+        multiplier: 1.5,
+        minQty: 1,
+      },
+    ];
+    const input: FanoutInput = {
+      intent: { symbol: 'ES', side: 'Buy', entryPrice: 10, qty: 2 },
+      telemetryByAccount: {},
+    };
+    const orders = buildFanoutOrders(input, accounts);
+    expect(orders.map((o) => o.account.name)).toEqual(['PA-1', 'PA-2']);
+    expect(orders.map((o) => o.ticket.qty)).toEqual([2, 3]);
+  });
+});
+
+describe('cap by plan & minQty', () => {
+  it('clamps to planMaxContracts and minQty', () => {
+    const accounts: AccountRecord[] = [
+      {
+        name: 'A1',
+        accountId: 1,
+        accountSpec: 'A1',
+        mode: 'funded',
+        planMaxContracts: 4,
+        baseSize: 2,
+        multiplier: 3,
+        minQty: 1,
+      },
+      {
+        name: 'A2',
+        accountId: 2,
+        accountSpec: 'A2',
+        mode: 'funded',
+        planMaxContracts: 10,
+        baseSize: 2,
+        multiplier: 0.1,
+        minQty: 1,
+      },
+      {
+        name: 'A3',
+        accountId: 3,
+        accountSpec: 'A3',
+        mode: 'funded',
+        planMaxContracts: 10,
+        baseSize: 2,
+        multiplier: 0.1,
+        minQty: 0,
+      },
+    ];
+    const input: FanoutInput = {
+      intent: { symbol: 'ES', side: 'Buy', entryPrice: 10 },
+      telemetryByAccount: {},
+    };
+    const orders = buildFanoutOrders(input, accounts);
+    expect(orders.map((o) => o.account.name)).toEqual(['A1', 'A2']);
+    expect(orders.map((o) => o.ticket.qty)).toEqual([4, 1]);
+  });
+});
+
+describe('error isolation', () => {
+  it('continues after broker error', async () => {
+    const accounts = mockAccounts as AccountRecord[];
+    guard.mockReset();
+    guard.mockReturnValue({ allow: true, ticket: { qty: 2 } });
+    const placeOrder = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, id: '1' })
+      .mockRejectedValueOnce(new Error('fail'));
+    const broker: BrokerClient = { placeOrder };
+    const res = await fanoutAndPlace(
+      { intent: { symbol: 'ES', side: 'Buy', entryPrice: 10, qty: 2 }, telemetryByAccount: {} },
+      broker,
+    );
+    expect(res.results).toEqual([
+      { account: 'PA-1', ok: true, id: '1' },
+      { account: 'PA-2', ok: false, error: 'Error: fail' },
+    ]);
+  });
+});
+
+describe('guard invocation', () => {
+  it('records guard denial per account', async () => {
+    const accounts = mockAccounts as AccountRecord[];
+    guard.mockReset();
+    guard
+      .mockReturnValueOnce({ allow: true, ticket: { qty: 2 } })
+      .mockReturnValueOnce({ allow: false, reason: 'DENIED' });
+    const placeOrder = vi.fn().mockResolvedValue({ ok: true, id: '1' });
+    const broker: BrokerClient = { placeOrder };
+    const res = await fanoutAndPlace(
+      { intent: { symbol: 'ES', side: 'Buy', entryPrice: 10, qty: 2 }, telemetryByAccount: {} },
+      broker,
+    );
+    expect(placeOrder).toHaveBeenCalledTimes(1);
+    expect(placeOrder).toHaveBeenCalledWith(
+      accounts[0],
+      expect.objectContaining({ isAutomated: true }),
+    );
+    expect(res.results).toEqual([
+      { account: 'PA-1', ok: true, id: '1' },
+      { account: 'PA-2', ok: false, reason: 'DENIED' },
+    ]);
+    expect(guard).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ticketizer/package.json
+++ b/packages/ticketizer/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@prism-apex-tool/ticketizer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest --run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier -w ."
+  },
+  "dependencies": {
+    "@prism-apex-tool/accounts": "workspace:*",
+    "@prism-apex-tool/rules": "workspace:*"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.10.0",
+    "eslint": "^9.10.0",
+    "prettier": "^3.3.3",
+    "typescript-eslint": "^8.7.0",
+    "vitest": "^2.0.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/ticketizer/src/fanout.ts
+++ b/packages/ticketizer/src/fanout.ts
@@ -1,0 +1,114 @@
+import { getAccounts } from '@prism-apex-tool/accounts';
+import type { AccountRecord } from '@prism-apex-tool/accounts';
+import { guardApexFundingRules } from '@prism-apex-tool/rules/apex.js';
+
+export interface TicketIntent {
+  symbol: string;
+  side: 'Buy' | 'Sell';
+  entryPrice: number;
+  qty?: number;
+  takeProfit?: number;
+  stopLoss?: number;
+}
+
+export interface AccountTelemetry {
+  startingBalance: number;
+  currentBalance: number;
+  trailingDrawdown: number;
+  drawdownStopLocksAt?: number;
+  maxContractsAllowed: number;
+}
+
+export interface FanoutInput {
+  intent: TicketIntent;
+  telemetryByAccount: Record<string, AccountTelemetry>;
+  signalId?: string;
+}
+
+export interface FanoutOrder {
+  account: AccountRecord;
+  ticket: TicketIntent;
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.min(Math.max(v, min), max);
+}
+
+export function buildFanoutOrders(input: FanoutInput, accounts: AccountRecord[]): FanoutOrder[] {
+  const { intent, telemetryByAccount } = input;
+  const sorted = [...accounts].sort((a, b) => a.name.localeCompare(b.name));
+  const orders: FanoutOrder[] = [];
+  for (const acc of sorted) {
+    const tele = telemetryByAccount[acc.name] ?? telemetryByAccount[acc.accountSpec] ?? {};
+    const base = intent.qty ?? acc.baseSize;
+    const mult = acc.multiplier ?? 1;
+    const raw = Math.floor(base * mult);
+    const maxAllowed = Math.min(
+      acc.planMaxContracts,
+      tele.maxContractsAllowed ?? acc.planMaxContracts,
+    );
+    const derivedQty = clamp(raw, acc.minQty ?? 1, maxAllowed);
+    if (derivedQty <= 0) continue;
+    orders.push({
+      account: acc,
+      ticket: { ...intent, qty: derivedQty },
+    });
+  }
+  return orders;
+}
+
+export interface BrokerClient {
+  placeOrder(
+    a: AccountRecord,
+    t: TicketIntent & { isAutomated?: boolean },
+  ): Promise<{ ok: boolean; id?: string; error?: string }>;
+}
+
+export async function fanoutAndPlace(
+  input: FanoutInput,
+  broker: BrokerClient,
+  now: Date = new Date(),
+) {
+  const accounts = getAccounts();
+  const orders = buildFanoutOrders(input, accounts);
+  const results: Array<{
+    account: string;
+    ok: boolean;
+    id?: string;
+    error?: string;
+    reason?: string;
+  }> = [];
+  for (const o of orders) {
+    const tele = input.telemetryByAccount[o.account.name] ?? {};
+    const guard = guardApexFundingRules(
+      {
+        qty: o.ticket.qty ?? 0,
+        entryPrice: o.ticket.entryPrice,
+        stopLoss: o.ticket.stopLoss,
+        takeProfit: o.ticket.takeProfit,
+      },
+      {
+        mode: o.account.mode === 'funded' ? 'funded' : 'evaluation',
+        bufferCleared: true,
+        maxContractsAllowed: tele.maxContractsAllowed ?? o.account.planMaxContracts,
+        now,
+      },
+    );
+    if (!guard.allow) {
+      results.push({ account: o.account.name, ok: false, reason: guard.reason });
+      continue;
+    }
+    try {
+      const qty = guard.ticket?.qty ?? o.ticket.qty;
+      const res = await broker.placeOrder(o.account, {
+        ...o.ticket,
+        qty,
+        isAutomated: true,
+      });
+      results.push({ account: o.account.name, ...res });
+    } catch (err) {
+      results.push({ account: o.account.name, ok: false, error: String(err) });
+    }
+  }
+  return { orders, results };
+}

--- a/packages/ticketizer/src/index.ts
+++ b/packages/ticketizer/src/index.ts
@@ -1,0 +1,1 @@
+export * from './fanout.js';

--- a/packages/ticketizer/tsconfig.json
+++ b/packages/ticketizer/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "../..",
+    "declaration": true,
+    "declarationMap": true,
+    "allowImportingTsExtensions": false,
+    "emitDeclarationOnly": false,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/ticketizer/vitest.config.ts
+++ b/packages/ticketizer/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,8 @@
       "@prism-apex-tool/reporting": ["packages/reporting/src"],
       "@prism-apex-tool/signals": ["packages/signals/src"],
       "@prism-apex-tool/rules-apex": ["packages/rules-apex/src"],
-      "@prism-apex-tool/accounts": ["packages/accounts/src"],
+      "@prism-apex-tool/rules/*": ["packages/rules/src/*"],
+      "@prism-apex-tool/accounts": ["packages/accounts/src/index.ts"],
       "@prism-apex-tool/config": ["packages/config/src"],
       "@prism-apex-tool/clients-tradovate": ["packages/clients-tradovate/src"],
       "@prism-apex-tool/clients-tradovate/telemetry": [
@@ -19,7 +20,8 @@
       ],
       "@prism-apex-tool/indicators": ["packages/indicators/src"],
       "@prism-apex-tool/strategies": ["packages/strategies/src"],
-      "@prism-apex-tool/consistency": ["packages/consistency/src"]
+      "@prism-apex-tool/consistency": ["packages/consistency/src"],
+      "@prism-apex-tool/ticketizer": ["packages/ticketizer/src"]
     },
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Summary
- add JSON account registry and loader
- introduce deterministic fan-out and per-account placement
- test fan-out sizing, caps, isolation, and guard integration

## Testing
- `pnpm --filter @prism-apex-tool/ticketizer typecheck`
- `pnpm --filter @prism-apex-tool/ticketizer test`


------
https://chatgpt.com/codex/tasks/task_b_68af70252ce0832c85504078e4e80b4b