### PR TITLE
feat: add S9 consistency metrics

### DIFF
--- a/apps/api/__tests__/consistency.route.spec.ts
+++ b/apps/api/__tests__/consistency.route.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import Fastify from 'fastify';
+import consistencyRoute from '../src/routes/consistency';
+
+const VAR_DIR = path.resolve(process.cwd(), 'var', 'pnl');
+const FILE = path.join(VAR_DIR, 'daily.json');
+
+function writeDaily(json: unknown) {
+  fs.mkdirSync(VAR_DIR, { recursive: true });
+  fs.writeFileSync(FILE, JSON.stringify(json, null, 2));
+}
+
+function rmDaily() {
+  try {
+    fs.unlinkSync(FILE);
+  } catch {}
+}
+
+describe('GET /report/consistency', () => {
+  beforeEach(() => rmDaily());
+  afterEach(() => rmDaily());
+
+  it('returns 204 when no data present', async () => {
+    const app = Fastify();
+    app.register(consistencyRoute);
+    const res = await app.inject({ method: 'GET', url: '/report/consistency?window=8' });
+    expect(res.statusCode).toBe(204);
+  });
+
+  it('returns 200 with computed metrics when data present', async () => {
+    writeDaily([
+      { date: '2025-08-12', pnl: -80 },
+      { date: '2025-08-13', pnl: 250 },
+      { date: '2025-08-14', pnl: 180 },
+      { date: '2025-08-15', pnl: 90 },
+      { date: '2025-08-18', pnl: 410 },
+      { date: '2025-08-19', pnl: 95 },
+      { date: '2025-08-20', pnl: 200 },
+      { date: '2025-08-21', pnl: 275 },
+    ]);
+    const app = Fastify();
+    app.register(consistencyRoute);
+    const res = await app.inject({ method: 'GET', url: '/report/consistency?window=8' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.window).toBe(8);
+    expect(body.totalPnL).toBe(1420);
+    expect(body.bestDayPnL).toBe(410);
+    expect(body.bestDayShare).toBeCloseTo(410 / 1420, 6);
+    expect(body.profitDayCount).toBe(7);
+    expect(body.eligible).toBe(true);
+  });
+});

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "pretest": "pnpm -r --filter @prism-apex-tool/rules-apex --filter @prism-apex-tool/accounts --filter @prism-apex-tool/config --filter @prism-apex-tool/signals --filter @prism-apex-tool/analytics --filter @prism-apex-tool/audit --filter @prism-apex-tool/reporting --filter @prism-apex-tool/consistency --filter @prism-apex-tool/indicators --filter @prism-apex-tool/strategies --filter @prism-apex-tool/clients-tradovate build",
+    "pretest": "pnpm -r --filter @prism-apex-tool/rules-apex --filter @prism-apex-tool/accounts --filter @prism-apex-tool/config --filter @prism-apex-tool/signals --filter @prism-apex-tool/analytics --filter @prism-apex-tool/audit --filter @prism-apex-tool/reporting --filter @prism-apex-tool/consistency --filter @prism-apex-tool/metrics --filter @prism-apex-tool/indicators --filter @prism-apex-tool/strategies --filter @prism-apex-tool/clients-tradovate build",
     "test:api": "vitest run --config apps/api/vitest.config.ts --reporter=verbose --passWithNoTests",
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.build.json",
@@ -53,6 +53,7 @@
     "@prism-apex-tool/runtime": "workspace:*",
     "fastify": "5.5.0",
     "fastify-plugin": "5.0.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@prism-apex-tool/metrics": "workspace:*"
   }
 }

--- a/apps/api/src/routes/consistency.ts
+++ b/apps/api/src/routes/consistency.ts
@@ -1,0 +1,26 @@
+import { FastifyInstance, FastifyPluginCallback } from 'fastify';
+import { computeConsistency, loadDailyPnLFromDisk } from '@prism-apex-tool/metrics/consistency';
+
+const plugin: FastifyPluginCallback = (app: FastifyInstance, _opts, done) => {
+  app.get('/report/consistency', async (req, reply) => {
+    const q = req.query as { window?: string };
+    const w = clamp(parseInt(q?.window ?? '8', 10), 1, 15);
+
+    const data = loadDailyPnLFromDisk();
+    if (!data || data.length === 0) {
+      return reply.code(204).send();
+    }
+
+    const result = computeConsistency(data, w);
+    return reply.code(200).send(result);
+  });
+
+  done();
+};
+
+function clamp(n: number, lo: number, hi: number) {
+  if (!Number.isFinite(n)) return 8;
+  return Math.max(lo, Math.min(hi, n));
+}
+
+export default plugin;

--- a/packages/metrics/__tests__/consistency.spec.ts
+++ b/packages/metrics/__tests__/consistency.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { computeConsistency, type DailyPnL } from '../src/consistency';
+
+describe('computeConsistency', () => {
+  it('eligible when total>0, >=5 profit days, bestDayShare<=0.30', () => {
+    const days: DailyPnL[] = [
+      { date: '2025-08-12', pnl: -80 },
+      { date: '2025-08-13', pnl: 250 },
+      { date: '2025-08-14', pnl: 180 },
+      { date: '2025-08-15', pnl: 90 },
+      { date: '2025-08-18', pnl: 410 }, // best day
+      { date: '2025-08-19', pnl: 95 },
+      { date: '2025-08-20', pnl: 200 },
+      { date: '2025-08-21', pnl: 275 },
+    ];
+    const r = computeConsistency(days, 8);
+    expect(r.totalPnL).toBe(1420);
+    expect(r.bestDayPnL).toBe(410);
+    expect(r.bestDayShare).toBeCloseTo(410 / 1420, 6);
+    expect(r.profitDayCount).toBe(7);
+    expect(r.eligible).toBe(true);
+  });
+
+  it('ineligible when total<=0', () => {
+    const days: DailyPnL[] = [
+      { date: '2025-08-12', pnl: -80 },
+      { date: '2025-08-13', pnl: -50 },
+    ];
+    const r = computeConsistency(days, 8);
+    expect(r.totalPnL).toBe(-130);
+    expect(r.bestDayShare).toBe(0);
+    expect(r.eligible).toBe(false);
+  });
+
+  it('ineligible when bestDayShare>0.30', () => {
+    const days: DailyPnL[] = [
+      { date: '2025-08-12', pnl: 10 },
+      { date: '2025-08-13', pnl: 10 },
+      { date: '2025-08-14', pnl: 10 },
+      { date: '2025-08-15', pnl: 10 },
+      { date: '2025-08-18', pnl: 200 }, // best day dominates
+      { date: '2025-08-19', pnl: 10 },
+      { date: '2025-08-20', pnl: 10 },
+      { date: '2025-08-21', pnl: 10 },
+    ];
+    const r = computeConsistency(days, 8);
+    expect(r.bestDayPnL).toBe(200);
+    expect(r.bestDayShare).toBeCloseTo(200 / 270, 6);
+    expect(r.eligible).toBe(false);
+  });
+});

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@prism-apex-tool/metrics",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/consistency.cjs",
+  "module": "dist/consistency.js",
+  "types": "dist/consistency.d.ts",
+  "exports": {
+    "./consistency": {
+      "require": "./dist/consistency.cjs",
+      "import": "./dist/consistency.js",
+      "types": "./dist/consistency.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/consistency.ts --format esm,cjs --dts",
+    "lint": "eslint . --ext .ts",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "format": "prettier -w .",
+    "format:check": "prettier -c ."
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "^9.10.0",
+    "@eslint/js": "^9.10.0",
+    "typescript-eslint": "^8.7.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.9.2",
+    "vitest": "^2.0.0",
+    "tsup": "^8.0.1"
+  }
+}

--- a/packages/metrics/src/consistency.ts
+++ b/packages/metrics/src/consistency.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface DailyPnL {
+  date: string;
+  pnl: number;
+}
+
+export interface ConsistencyResult {
+  window: number;
+  totalPnL: number;
+  bestDayPnL: number;
+  bestDayShare: number; // 0..1
+  profitDayCount: number;
+  eligible: boolean;
+  days: DailyPnL[]; // normalized, sorted asc, last `window`
+}
+
+/**
+ * Compute payout consistency metrics over the last `window` days.
+ * Rules:
+ *  - eligible = totalPnL > 0
+ *              && profitDayCount >= 5
+ *              && bestDayShare <= 0.30
+ *  - bestDayShare = (totalPnL > 0 && bestDayPnL > 0) ? bestDayPnL / totalPnL : 0
+ */
+export function computeConsistency(input: DailyPnL[], window = 8): ConsistencyResult {
+  const w = clamp(Math.floor(window), 1, 15);
+
+  // Sanitize: valid date string and finite pnl number
+  const valid = (input ?? []).filter(
+    (r) =>
+      typeof r?.date === 'string' && isFiniteNumber(r?.pnl) && /^\d{4}-\d{2}-\d{2}$/.test(r.date),
+  );
+
+  // Sort ascending by date, take last w
+  valid.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+  const days = valid.slice(-w);
+
+  // Sums and metrics
+  let totalPnL = 0;
+  let bestDayPnL = Number.NEGATIVE_INFINITY;
+  let profitDayCount = 0;
+
+  for (const d of days) {
+    totalPnL += d.pnl;
+    if (d.pnl > bestDayPnL) bestDayPnL = d.pnl;
+    if (d.pnl > 0) profitDayCount += 1;
+  }
+  if (!isFiniteNumber(bestDayPnL)) bestDayPnL = 0;
+
+  const bestDayShare = totalPnL > 0 && bestDayPnL > 0 ? bestDayPnL / totalPnL : 0;
+  const eligible = totalPnL > 0 && profitDayCount >= 5 && bestDayShare <= 0.3;
+
+  return { window: w, totalPnL, bestDayPnL, bestDayShare, profitDayCount, eligible, days };
+}
+
+export function loadDailyPnLFromDisk(): DailyPnL[] | null {
+  const file = path.resolve(process.cwd(), 'var', 'pnl', 'daily.json');
+  if (!fs.existsSync(file)) return null;
+  try {
+    const raw = fs.readFileSync(file, 'utf8').trim();
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    return Array.isArray(arr) ? (arr as DailyPnL[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function isFiniteNumber(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+function clamp(n: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+export default { computeConsistency, loadDailyPnLFromDisk };

--- a/packages/metrics/tsconfig.json
+++ b/packages/metrics/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@prism-apex-tool/indicators':
         specifier: workspace:*
         version: link:../../packages/indicators
+      '@prism-apex-tool/metrics':
+        specifier: workspace:*
+        version: link:../../packages/metrics
       '@prism-apex-tool/reporting':
         specifier: workspace:*
         version: link:../../packages/reporting
@@ -359,6 +362,30 @@ importers:
         version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
 
   packages/indicators:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.10.0
+        version: 9.33.0
+      eslint:
+        specifier: ^9.10.0
+        version: 9.33.0(jiti@2.5.1)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.6.2
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.7.0
+        version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
+
+  packages/metrics:
     devDependencies:
       '@eslint/js':
         specifier: ^9.10.0

--- a/var/pnl/README.md
+++ b/var/pnl/README.md
@@ -1,0 +1,39 @@
+# Daily PnL Data (for Consistency Metrics)
+
+Create `var/pnl/daily.json` with an array of objects:
+
+```json
+[
+  { "date": "2025-08-18", "pnl": 320.5 },
+  { "date": "2025-08-19", "pnl": -150.0 }
+]
+```
+
+date: YYYY-MM-DD
+
+pnl: number (positive for profit, negative for loss)
+
+The API route GET /report/consistency?window=8 reads this file. If it is missing or empty,
+the route responds with 204 No Content.
+
+====================
+INTEGRATION NOTES
+
+Register apps/api/src/routes/consistency.ts in your API server the same way other routes are registered.
+
+No external services required.
+
+Keep the window query between 1..15 (clamped in code).
+
+====================
+RUN / VERIFY
+
+pnpm --filter @prism-apex-tool/metrics typecheck
+
+pnpm --filter @prism-apex-tool/metrics test
+
+pnpm --filter @prism-apex-tool/api test
+
+(Optional) create var/pnl/daily.json and curl:
+curl -s "http://localhost:3000/report/consistency?window=8
+" | jq .


### PR DESCRIPTION
## Summary
- implement computeConsistency utility and disk loader in new `@prism-apex-tool/metrics` package
- expose Fastify route `/report/consistency` using local JSON data
- cover metrics library and API route with vitest tests and sample data docs

## Testing
- `pnpm --filter @prism-apex-tool/metrics typecheck`
- `pnpm --filter @prism-apex-tool/metrics test`
- `pnpm --filter @prism-apex-tool/api test`


------
https://chatgpt.com/codex/tasks/task_b_68af83ab9514832c90765db073b2bdbb