### PR TITLE
fix rules package exports

### DIFF
--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -2,15 +2,24 @@
   "name": "@prism-apex-tool/rules",
   "version": "0.1.0",
   "private": true,
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "commonjs",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
-    }
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./apex": {
+      "types": "./src/apex.ts",
+      "default": "./src/apex.ts"
+    },
+    "./apex.js": "./src/apex.ts",
+    "./config": {
+      "types": "./src/config.ts",
+      "default": "./src/config.ts"
+    },
+    "./config.js": "./src/config.ts"
   },
   "files": [
     "dist"

--- a/packages/rules/src/index.ts
+++ b/packages/rules/src/index.ts
@@ -1,0 +1,2 @@
+export * from './apex';
+export * from './config';

--- a/packages/rules/tsconfig.json
+++ b/packages/rules/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
   },
   "include": ["src", "__tests__"]
 }


### PR DESCRIPTION
## Summary
- expose TypeScript sources through package exports for `@prism-apex-tool/rules`
- add barrel file for public rule APIs
- adjust rules tsconfig for ESNext modules

## Testing
- `pnpm --filter @prism-apex-tool/rules typecheck`
- `pnpm --filter @prism-apex-tool/ticketizer test` *(fails: Failed to resolve entry for package "@prism-apex-tool/accounts" )*

------
https://chatgpt.com/codex/tasks/task_b_68b00c8dc644832c8826b6ab77beeada