### PR TITLE
feat: add heartbeat and readiness checks

### DIFF
--- a/apps/api/__tests__/ready.spec.ts
+++ b/apps/api/__tests__/ready.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import Fastify from 'fastify';
+import readyRoute from '../src/routes/ready';
+import { setJobBeat } from '@prism-apex-tool/runtime/health';
+
+describe('GET /ready', () => {
+  it('reports healthy when recent beats exist, otherwise degraded', async () => {
+    const app = Fastify();
+    app.register(readyRoute);
+
+    // No beats yet → degraded
+    let res = await app.inject({ method: 'GET', url: '/ready' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().overall).toBe('degraded');
+
+    // Set a beat → healthy
+    setJobBeat('worker-1', Date.now());
+    res = await app.inject({ method: 'GET', url: '/ready' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.overall === 'healthy' || body.overall === 'degraded').toBeTruthy();
+    // With a fresh beat, we expect healthy:
+    expect(body.overall).toBe('healthy');
+    expect(body.jobs['worker-1'].healthy).toBe(true);
+  });
+});

--- a/apps/api/src/routes/ready.ts
+++ b/apps/api/src/routes/ready.ts
@@ -1,8 +1,12 @@
-import type { FastifyInstance } from 'fastify';
-import { getHealth } from '@prism-apex-tool/runtime';
+import { FastifyInstance, FastifyPluginCallback } from 'fastify';
+import { getHealth } from '@prism-apex-tool/runtime/health';
 
-export async function readyRoutes(app: FastifyInstance) {
-  app.get('/ready', async () => getHealth());
-}
+const plugin: FastifyPluginCallback = (app: FastifyInstance, _opts, done) => {
+  app.get('/ready', async (_req, reply) => {
+    const health = getHealth();
+    reply.code(200).send(health);
+  });
+  done();
+};
 
-export default readyRoutes;
+export default plugin;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -20,7 +20,7 @@ import { auditRoutes } from './routes/audit.js';
 import { accountsRoutes } from './routes/accounts.js';
 import { ticketsRoutes } from './routes/tickets.js';
 import { tradingviewWebhookRoutes } from './routes/webhooks.tradingview.js';
-import { readyRoutes } from './routes/ready.js';
+import readyRoute from './routes/ready.js';
 import { getConfig } from './config/env';
 import { telemetryRoutes } from './routes/telemetry.js';
 import { jobManager } from './lib/jobManager.js';
@@ -84,7 +84,7 @@ export function buildServer() {
   app.register(authPlugin, { publicPaths });
   app.register(rateLimit, { publicPaths });
 
-  app.register(readyRoutes);
+  app.register(readyRoute);
   app.register(healthRoutes);
   app.register(versionRoutes);
   app.register(analyticsRoutes);

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -44,6 +44,14 @@ export default defineConfig({
         __dirname,
         '../../packages/rules-apex/src/index.ts',
       ),
+      '@prism-apex-tool/runtime/health': path.resolve(
+        __dirname,
+        '../../packages/runtime/src/health.ts',
+      ),
+      '@prism-apex-tool/runtime/heartbeat': path.resolve(
+        __dirname,
+        '../../packages/runtime/src/heartbeat.ts',
+      ),
       '@prism-apex-tool/runtime': path.resolve(
         __dirname,
         '../../packages/runtime/src/index.ts',

--- a/packages/runtime/__tests__/heartbeat.spec.ts
+++ b/packages/runtime/__tests__/heartbeat.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHeartbeat } from '../src/heartbeat';
+
+describe('heartbeat + stale detection', () => {
+  let now = 0;
+  const nowFn = () => now;
+  const advance = (ms: number) => {
+    now += ms;
+    vi.advanceTimersByTime(ms);
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    now = 0;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends heartbeats at interval', () => {
+    const sends: string[] = [];
+    const hb = createHeartbeat({
+      send: (d) => sends.push(d),
+      onStale: () => {},
+      intervalMs: 1000,
+      staleMs: 5000,
+      nowFn,
+    });
+    hb.start();
+    expect(sends.length).toBe(0);
+    advance(999);
+    expect(sends.length).toBe(0);
+    advance(2);
+    expect(sends.length).toBe(1);
+    advance(1000);
+    expect(sends.length).toBe(2);
+  });
+
+  it('calls onStale after no inbound for staleMs', () => {
+    const onStale = vi.fn();
+    const hb = createHeartbeat({
+      send: () => {},
+      onStale,
+      intervalMs: 1000,
+      staleMs: 3000,
+      nowFn,
+    });
+    hb.start();
+    // Receive something at t=0
+    hb.markRx();
+    advance(2999);
+    expect(onStale).not.toHaveBeenCalled();
+    advance(2);
+    expect(onStale).toHaveBeenCalledTimes(1);
+    // Mark receive again resets timer
+    hb.markRx();
+    advance(2500);
+    expect(onStale).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -10,6 +10,16 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.js"
+    },
+    "./health": {
+      "types": "./src/health.ts",
+      "import": "./src/health.ts",
+      "require": "./src/health.ts"
+    },
+    "./heartbeat": {
+      "types": "./src/heartbeat.ts",
+      "import": "./src/heartbeat.ts",
+      "require": "./src/heartbeat.ts"
     }
   },
   "files": [

--- a/packages/runtime/src/health.ts
+++ b/packages/runtime/src/health.ts
@@ -1,17 +1,22 @@
-const beats = new Map<string, number>();
+type JobStatus = { lastBeatIso: string; healthy: boolean };
 
-export function setJobBeat(jobName: string) {
-  beats.set(jobName, Date.now());
+const state: Record<string, number> = Object.create(null);
+
+export function setJobBeat(jobName: string, nowTs: number = Date.now()): void {
+  state[jobName] = nowTs;
 }
 
-export function getHealth() {
-  const now = Date.now();
-  const jobs: Record<string, { lastBeatIso: string | null; healthy: boolean }> = {};
-  for (const [name, ts] of beats.entries()) {
-    const lastBeatIso = ts ? new Date(ts).toISOString() : null;
-    const healthy = now - ts < 10_000;
-    jobs[name] = { lastBeatIso, healthy };
+export function getHealth(nowTs: number = Date.now()): {
+  jobs: Record<string, JobStatus>;
+  overall: 'healthy' | 'degraded';
+} {
+  const jobs: Record<string, JobStatus> = {};
+  const entries = Object.entries(state);
+  for (const [name, ts] of entries) {
+    const healthy = nowTs - ts < 10_000;
+    jobs[name] = { lastBeatIso: new Date(ts).toISOString(), healthy };
   }
-  const overall = Object.values(jobs).every((j) => j.healthy) ? 'healthy' : 'degraded';
-  return { jobs, overall } as const;
+  const overall: 'healthy' | 'degraded' =
+    entries.length > 0 && entries.every(([, ts]) => nowTs - ts < 10_000) ? 'healthy' : 'degraded';
+  return { jobs, overall };
 }

--- a/packages/runtime/src/heartbeat.ts
+++ b/packages/runtime/src/heartbeat.ts
@@ -1,0 +1,54 @@
+/**
+ * Minimal heartbeat + stale-connection detector.
+ * - Calls `send('[]')` every `intervalMs`
+ * - If no inbound (markRx) for `staleMs`, calls `onStale()`
+ * - Uses `nowFn` for testability
+ */
+export function createHeartbeat(opts: {
+  send: (data: string) => void;
+  onStale: () => void;
+  intervalMs?: number; // default 2500
+  staleMs?: number; // default 5000
+  nowFn?: () => number;
+}) {
+  const intervalMs = opts.intervalMs ?? 2500;
+  const staleMs = opts.staleMs ?? 5000;
+  const now = opts.nowFn ?? (() => Date.now());
+
+  let lastRx = now();
+  let hbId: any = null;
+  let chkId: any = null;
+  let stopped = true;
+
+  function start() {
+    if (!stopped) return;
+    stopped = false;
+    hbId = setInterval(() => {
+      try {
+        opts.send('[]');
+      } catch {}
+    }, intervalMs);
+    chkId = setInterval(() => {
+      const age = now() - lastRx;
+      if (age > staleMs) {
+        try {
+          opts.onStale();
+        } catch {}
+      }
+    }, 250);
+  }
+
+  function stop() {
+    if (stopped) return;
+    stopped = true;
+    if (hbId) clearInterval(hbId);
+    if (chkId) clearInterval(chkId);
+    hbId = chkId = null;
+  }
+
+  function markRx(ts?: number) {
+    lastRx = ts ?? now();
+  }
+
+  return { start, stop, markRx };
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,3 +1,4 @@
 export { expBackoff } from './backoff.js';
 export { ResilientWS, retryWithPenalty } from './ws.js';
+export { createHeartbeat } from './heartbeat.js';
 export { setJobBeat, getHealth } from './health.js';


### PR DESCRIPTION
## Summary
- add runtime heartbeat utility and health tracking
- expose `/ready` route reporting job health
- test heartbeat behavior and readiness reporting

## Testing
- `pnpm --filter @prism-apex-tool/runtime typecheck`
- `pnpm --filter @prism-apex-tool/runtime test`
- `pnpm --filter @prism-apex-tool/api test`


------
https://chatgpt.com/codex/tasks/task_b_68b0256341c4832ca3e4e77600294098