### PR TITLE
feat: add config validators and checks

### DIFF
--- a/configs/accounts.example.json
+++ b/configs/accounts.example.json
@@ -1,0 +1,24 @@
+{
+  "accounts": [
+    {
+      "name": "PA-1",
+      "accountId": 123456,
+      "accountSpec": "PA123456",
+      "mode": "funded",
+      "planMaxContracts": 10,
+      "baseSize": 2,
+      "multiplier": 1.0,
+      "minQty": 1
+    },
+    {
+      "name": "PA-2",
+      "accountId": 234567,
+      "accountSpec": "PA234567",
+      "mode": "eval",
+      "planMaxContracts": 5,
+      "baseSize": 1,
+      "multiplier": 1.0,
+      "minQty": 1
+    }
+  ]
+}

--- a/configs/strategies/opening-session-breakout.example.json
+++ b/configs/strategies/opening-session-breakout.example.json
@@ -1,0 +1,7 @@
+{
+  "//": "Replace keys to match your strategy; names below are examples only",
+  "sessionWindowMinutes": 60,
+  "bufferTicks": 3,
+  "cooldownBars": 2,
+  "minRR": 1.5
+}

--- a/configs/strategies/opening-session-breakout.json
+++ b/configs/strategies/opening-session-breakout.json
@@ -1,6 +1,6 @@
 {
   "orMinutes": 5,
-  "requireCloseBreak": true,
+  "requireCloseBreak": 1,
   "rrDefault": 2.0,
   "rrMin": 1.5,
   "rrMax": 5.0,

--- a/configs/strategies/vwap-first-touch.example.json
+++ b/configs/strategies/vwap-first-touch.example.json
@@ -1,0 +1,7 @@
+{
+  "//": "Replace keys to match your strategy; names below are examples only",
+  "cooldownBars": 3,
+  "rangeLookbackMinutes": 30,
+  "bufferTicks": 2,
+  "minRR": 1.5
+}

--- a/docs/configs/ACCOUNTS.md
+++ b/docs/configs/ACCOUNTS.md
@@ -1,0 +1,15 @@
+# accounts.json — Fields
+
+- **name**: label for the account (e.g., "PA-1")
+- **accountId**: Tradovate numeric account ID
+- **accountSpec**: Tradovate account spec (e.g., "PA123456")
+- **mode**: "eval" or "funded"
+- **planMaxContracts**: hard cap from the plan
+- **baseSize**: our default ticket size before guards (≥1)
+- **multiplier**: per-account multiplier (e.g., 1.2 to scale up)
+- **minQty**: clamp low (≥0)
+
+Start from `configs/accounts.example.json` and run:
+
+
+pnpm config:check

--- a/docs/configs/README.md
+++ b/docs/configs/README.md
@@ -1,0 +1,31 @@
+# Configs — Accounts & Strategies
+
+## Accounts (`configs/accounts.json`)
+**Shape**
+- `name` (string) — label for the account
+- `accountId` (integer > 0)
+- `accountSpec` (string) — broker account spec
+- `mode` ("eval" | "funded")
+- `planMaxContracts` (integer > 0)
+- `baseSize` (integer > 0, default 1)
+- `multiplier` (number > 0, default 1)
+- `minQty` (integer ≥ 0, default 1)
+
+Copy `configs/accounts.example.json` and edit your values.
+
+## Strategies (`configs/strategies/*.json`)
+Each strategy file contains the **numeric knobs** your strategy reads at runtime.
+Common fields (examples):
+- `lookbackBars`, `rangeLookbackMinutes`, `bufferTicks`, `cooldownBars`, `minRR`
+- Optional time fields: `sessionStart`, `sessionEnd` in `HH:MM` or `HH:MM:SS`
+
+Use the `*.example.json` files as templates and align keys with your actual strategy code.
+
+## Validation
+Run:
+
+
+pnpm config:check
+
+- Checks: types, numeric finiteness, non-negative durations/counts; accounts schema also rejects **unknown keys** and bad types.
+- Strategy validation is **generic** and safe: it enforces numeric/time types; for strict key lists, pass `allowedKeys` in your own loader or extend the schema.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "scan:dead": "node tools/depcheck.mjs || true",
     "scan:strays": "git ls-files | egrep -i '\\.(bak|backup|old)$|(^|/)=?[0-9]{2,3}%$|(^|/)server\\.backup\\.|(^|/)\\]$' > reports/strays.txt || true",
     "docker:build": "docker build -t prism-apex-api:latest .",
-    "docker:run": "docker run --rm -p 3000:3000 -e LOG_LEVEL=info -e TRUST_PROXY=true -v api-data:/data prism-apex-api:latest"
+    "docker:run": "docker run --rm -p 3000:3000 -e LOG_LEVEL=info -e TRUST_PROXY=true -v api-data:/data prism-apex-api:latest",
+    "config:check": "node scripts/config-check.js"
   },
   "engines": {
     "node": ">=20 <21"

--- a/packages/accounts/__tests__/schema.spec.ts
+++ b/packages/accounts/__tests__/schema.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { validateAccountsConfig } from '../src/schema';
+
+describe('accounts schema', () => {
+  it('accepts a valid config', () => {
+    const cfg = {
+      accounts: [
+        {
+          name: 'PA-1',
+          accountId: 123456,
+          accountSpec: 'PA123456',
+          mode: 'funded',
+          planMaxContracts: 10,
+          baseSize: 2,
+          multiplier: 1.0,
+          minQty: 1,
+        },
+      ],
+    };
+    const v = validateAccountsConfig(cfg);
+    expect(v.accounts[0].name).toBe('PA-1');
+  });
+
+  it('rejects unknown keys & bad types', () => {
+    expect(() => validateAccountsConfig({})).toThrow();
+    expect(() => validateAccountsConfig({ accounts: [] })).toThrow();
+    expect(() =>
+      validateAccountsConfig({
+        accounts: [
+          { name: 'X', accountId: 'oops', accountSpec: 'S', mode: 'funded', planMaxContracts: 10 },
+        ],
+      }),
+    ).toThrow(/accountId/);
+    expect(() =>
+      validateAccountsConfig({
+        accounts: [
+          {
+            name: 'X',
+            accountId: 1,
+            accountSpec: 'S',
+            mode: 'funded',
+            planMaxContracts: 10,
+            typo: true,
+          },
+        ],
+      }),
+    ).toThrow(/unknown key "typo"/);
+  });
+});

--- a/packages/accounts/src/schema.ts
+++ b/packages/accounts/src/schema.ts
@@ -1,0 +1,105 @@
+export type AccountMode = 'eval' | 'funded';
+
+export interface AccountRecord {
+  name: string;
+  accountId: number;
+  accountSpec: string;
+  mode: AccountMode;
+  planMaxContracts: number;
+  baseSize?: number;
+  multiplier?: number;
+  minQty?: number;
+}
+
+export interface AccountsFile {
+  accounts: AccountRecord[];
+}
+
+export function isPositiveInt(n: unknown): n is number {
+  return typeof n === 'number' && Number.isInteger(n) && n > 0;
+}
+export function isNonNegativeInt(n: unknown): n is number {
+  return typeof n === 'number' && Number.isInteger(n) && n >= 0;
+}
+export function isFiniteNum(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n);
+}
+
+const ALLOWED_KEYS = new Set([
+  'name',
+  'accountId',
+  'accountSpec',
+  'mode',
+  'planMaxContracts',
+  'baseSize',
+  'multiplier',
+  'minQty',
+]);
+
+export function validateAccountsConfig(obj: unknown): AccountsFile {
+  if (typeof obj !== 'object' || obj === null) throw new Error('accounts.json: not an object');
+  const root = obj as any;
+
+  if (!Array.isArray(root.accounts) || root.accounts.length < 1) {
+    throw new Error('accounts.json: "accounts" must be a non-empty array');
+  }
+
+  const out: AccountsFile = { accounts: [] };
+
+  for (let i = 0; i < root.accounts.length; i++) {
+    const a = root.accounts[i];
+    if (typeof a !== 'object' || a === null) {
+      throw new Error(`accounts[${i}]: must be an object`);
+    }
+    // unknown key check
+    for (const k of Object.keys(a)) {
+      if (!ALLOWED_KEYS.has(k)) throw new Error(`accounts[${i}]: unknown key "${k}"`);
+    }
+
+    const name = a.name;
+    const accountId = a.accountId;
+    const accountSpec = a.accountSpec;
+    const mode = a.mode;
+    const planMaxContracts = a.planMaxContracts;
+    const baseSize = a.baseSize ?? 1;
+    const multiplier = a.multiplier ?? 1;
+    const minQty = a.minQty ?? 1;
+
+    if (typeof name !== 'string' || name.trim() === '') {
+      throw new Error(`accounts[${i}].name must be a non-empty string`);
+    }
+    if (!isPositiveInt(accountId))
+      throw new Error(`accounts[${i}].accountId must be a positive integer`);
+    if (typeof accountSpec !== 'string' || accountSpec.trim() === '') {
+      throw new Error(`accounts[${i}].accountSpec must be a non-empty string`);
+    }
+    if (mode !== 'eval' && mode !== 'funded') {
+      throw new Error(`accounts[${i}].mode must be "eval" or "funded"`);
+    }
+    if (!isPositiveInt(planMaxContracts)) {
+      throw new Error(`accounts[${i}].planMaxContracts must be a positive integer`);
+    }
+    if (!isPositiveInt(baseSize)) {
+      throw new Error(`accounts[${i}].baseSize must be a positive integer`);
+    }
+    if (!isFiniteNum(multiplier) || multiplier <= 0) {
+      throw new Error(`accounts[${i}].multiplier must be a positive number`);
+    }
+    if (!isNonNegativeInt(minQty)) {
+      throw new Error(`accounts[${i}].minQty must be an integer >= 0`);
+    }
+
+    out.accounts.push({
+      name,
+      accountId,
+      accountSpec,
+      mode,
+      planMaxContracts,
+      baseSize,
+      multiplier,
+      minQty,
+    });
+  }
+
+  return out;
+}

--- a/packages/strategies/__tests__/strategy.schema.spec.ts
+++ b/packages/strategies/__tests__/strategy.schema.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { validateStrategyConfig } from '../src/config/schema';
+
+describe('strategy schema (generic)', () => {
+  it('accepts numeric params and time fields', () => {
+    const ok = validateStrategyConfig({
+      rangeLookbackMinutes: 30,
+      bufferTicks: 4,
+      cooldownBars: 3,
+      sessionStart: '09:30',
+      sessionEnd: '16:00',
+    });
+    expect(ok['bufferTicks']).toBe(4);
+  });
+
+  it('rejects negative lookbacks and unknown keys when allowed list given', () => {
+    expect(() => validateStrategyConfig({ lookbackBars: -1 })).toThrow(/>= 0/);
+    expect(() => validateStrategyConfig({ foo: 1 }, { allowedKeys: ['bar'] })).toThrow(
+      /unknown key/,
+    );
+  });
+
+  it('rejects non-numeric where numbers required', () => {
+    expect(() => validateStrategyConfig({ cooldownBars: '3' as any })).toThrow(
+      /must be a finite number/,
+    );
+  });
+});

--- a/packages/strategies/src/config/schema.ts
+++ b/packages/strategies/src/config/schema.ts
@@ -1,0 +1,49 @@
+/**
+ * Generic validator for per-strategy config objects.
+ * It does not assume exact key names; instead it enforces:
+ *  - keys are strings
+ *  - values are finite numbers (or ISO strings for obvious time fields)
+ *  - basic non-negative constraints for lookbacks/cooldowns/ticks/bars/minutes
+ *  - OPTIONAL: reject unknown keys vs a provided "allowed" list (when you pass it)
+ */
+export interface StrategyValidationOptions {
+  allowedKeys?: string[]; // when provided, keys must be subset of this list
+}
+
+export function validateStrategyConfig(
+  obj: unknown,
+  opts: StrategyValidationOptions = {},
+): Record<string, number | string> {
+  if (typeof obj !== 'object' || obj === null) throw new Error('strategy config: not an object');
+  const out: Record<string, number | string> = {};
+  const allowed = opts.allowedKeys ? new Set(opts.allowedKeys) : null;
+
+  for (const [k, v] of Object.entries(obj as any)) {
+    if (allowed && !allowed.has(k)) {
+      throw new Error(`strategy config: unknown key "${k}"`);
+    }
+    if (typeof v === 'number') {
+      if (!Number.isFinite(v)) throw new Error(`strategy config: "${k}" must be a finite number`);
+      // heuristic non-negative for durations/counts
+      if (/(bars?|minutes?|ticks?|lookback|cooldown|count|period|window)$/i.test(k) && v < 0) {
+        throw new Error(`strategy config: "${k}" must be >= 0`);
+      }
+      out[k] = v;
+      continue;
+    }
+    if (typeof v === 'string') {
+      // allow session/time strings e.g., "09:30" or "16:00"
+      if (/(time|start|end)$/i.test(k)) {
+        if (!/^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/.test(v)) {
+          throw new Error(`strategy config: "${k}" must be "HH:MM" or "HH:MM:SS"`);
+        }
+        out[k] = v;
+        continue;
+      }
+      // otherwise reject strings
+      throw new Error(`strategy config: "${k}" must be a finite number`);
+    }
+    throw new Error(`strategy config: "${k}" must be a finite number`);
+  }
+  return out;
+}

--- a/scripts/config-check.js
+++ b/scripts/config-check.js
@@ -1,0 +1,86 @@
+/* Zero-dep CLI to validate config files */
+const fs = require('node:fs');
+const path = require('node:path');
+
+function readJson(p) {
+  try {
+    const raw = fs.readFileSync(p, 'utf8');
+    return JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`Failed to read ${p}: ${e.message}`);
+  }
+}
+
+/* ---- Accounts strict validation (mirrors packages/accounts/src/schema.ts) ---- */
+function isPositiveInt(n){ return typeof n==='number' && Number.isInteger(n) && n>0 }
+function isNonNegativeInt(n){ return typeof n==='number' && Number.isInteger(n) && n>=0 }
+function isFiniteNum(n){ return typeof n==='number' && Number.isFinite(n) }
+const ACC_KEYS = new Set(['name','accountId','accountSpec','mode','planMaxContracts','baseSize','multiplier','minQty']);
+
+function validateAccountsConfig(obj){
+  if (!obj || typeof obj!=='object') throw new Error('accounts.json: not an object');
+  if (!Array.isArray(obj.accounts) || obj.accounts.length<1) throw new Error('"accounts" must be a non-empty array');
+  obj.accounts.forEach((a, i) => {
+    if (!a || typeof a!=='object') throw new Error(`accounts[${i}] must be an object`);
+    Object.keys(a).forEach(k => { if (!ACC_KEYS.has(k)) throw new Error(`accounts[${i}]: unknown key "${k}"`)});
+    if (typeof a.name!=='string' || !a.name.trim()) throw new Error(`accounts[${i}].name must be a non-empty string`);
+    if (!isPositiveInt(a.accountId)) throw new Error(`accounts[${i}].accountId must be a positive integer`);
+    if (typeof a.accountSpec!=='string' || !a.accountSpec.trim()) throw new Error(`accounts[${i}].accountSpec must be a non-empty string`);
+    if (a.mode!=='eval' && a.mode!=='funded') throw new Error(`accounts[${i}].mode must be "eval" or "funded"`);
+    if (!isPositiveInt(a.planMaxContracts)) throw new Error(`accounts[${i}].planMaxContracts must be a positive integer`);
+    const baseSize = a.baseSize ?? 1;
+    const multiplier = a.multiplier ?? 1;
+    const minQty = a.minQty ?? 1;
+    if (!isPositiveInt(baseSize)) throw new Error(`accounts[${i}].baseSize must be a positive integer`);
+    if (!isFiniteNum(multiplier) || multiplier<=0) throw new Error(`accounts[${i}].multiplier must be a positive number`);
+    if (!isNonNegativeInt(minQty)) throw new Error(`accounts[${i}].minQty must be an integer >= 0`);
+  });
+}
+
+/* ---- Strategy generic validation ---- */
+function validateStrategyConfig(obj, strategyFile){
+  if (!obj || typeof obj!=='object') throw new Error(`${strategyFile}: not an object`);
+  for (const [k,v] of Object.entries(obj)){
+    if (typeof v==='number'){
+      if (!Number.isFinite(v)) throw new Error(`${strategyFile}: "${k}" must be a finite number`);
+      if (/(bars?|minutes?|ticks?|lookback|cooldown|count|period|window)$/i.test(k) && v<0){
+        throw new Error(`${strategyFile}: "${k}" must be >= 0`);
+      }
+      continue;
+    }
+    if (typeof v==='string' && /(time|start|end)$/i.test(k)){
+      if (!/^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/.test(v)) {
+        throw new Error(`${strategyFile}: "${k}" must be "HH:MM" or "HH:MM:SS"`);
+      }
+      continue;
+    }
+    throw new Error(`${strategyFile}: "${k}" must be a number`);
+  }
+}
+
+/* ---- Runner ---- */
+(function main(){
+  const root = process.cwd();
+
+  // Accounts
+  const accPath = path.resolve(root, 'configs', 'accounts.json');
+  if (fs.existsSync(accPath)) {
+    validateAccountsConfig(readJson(accPath));
+  } else {
+    console.log('INFO: configs/accounts.json not found (skip)');
+  }
+
+  // Strategies
+  const stratDir = path.resolve(root, 'configs', 'strategies');
+  if (fs.existsSync(stratDir)) {
+    const files = fs.readdirSync(stratDir).filter(f => f.endsWith('.json') && !f.endsWith('.example.json'));
+    for (const f of files){
+      const p = path.join(stratDir, f);
+      validateStrategyConfig(readJson(p), `configs/strategies/${f}`);
+    }
+  } else {
+    console.log('INFO: configs/strategies/ not found (skip)');
+  }
+
+  console.log('All configs valid');
+})();


### PR DESCRIPTION
## Summary
- add strict accounts config schema and tests
- add generic strategy config schema and tests
- document and validate configs via `pnpm config:check`

## Testing
- `pnpm --filter @prism-apex-tool/accounts typecheck`
- `pnpm --filter @prism-apex-tool/accounts test`
- `pnpm --filter @prism-apex-tool/strategies test`
- `pnpm run config:check`


------
https://chatgpt.com/codex/tasks/task_b_68b05c575384832c9016bd0fc5df1391