### PR TITLE
test: make readiness deterministic

### DIFF
--- a/apps/api/src/routes/ready.ts
+++ b/apps/api/src/routes/ready.ts
@@ -8,7 +8,7 @@ const plugin: FastifyPluginCallback = (app: FastifyInstance, _opts, done) => {
   const mgr = new Set(['FEED','STRATEGIES','TICKETIZER','TELEMETRY','EOD_FLAT']);
   let jobs = health.jobs;
   if (DISABLE) {
-    const filtered: typeof health.jobs = {};
+    const filtered: Record<string, { lastBeatIso: string; healthy: boolean }> = {};
     for (const [name, st] of Object.entries(jobs)) {
       if (!mgr.has(name)) filtered[name] = st;
     }

--- a/apps/api/src/tests/hardening.spec.ts
+++ b/apps/api/src/tests/hardening.spec.ts
@@ -1,18 +1,22 @@
-import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest';
 
 let buildServer: typeof import('../server.js').buildServer;
 let setJobBeat: typeof import('@prism-apex-tool/runtime').setJobBeat;
 let __resetHealth: typeof import('@prism-apex-tool/runtime').__resetHealth;
 
 beforeEach(async () => {
-  vi.resetModules(); // avoid double registration/state
+  vi.resetModules();
   vi.useFakeTimers();
+  vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
   process.env.RATE_LIMIT_MAX = '2';
   process.env.RATE_LIMIT_WINDOW_MS = '60000';
   process.env.RATE_LIMIT_MAX_BUCKETS = '10';
-  delete process.env.BEARER_TOKEN; // ensure auth is OFF for these tests
+  delete process.env.BEARER_TOKEN;
+
   ({ buildServer } = await import('../server.js'));
   ({ setJobBeat, __resetHealth } = await import('@prism-apex-tool/runtime'));
+
   __resetHealth();
 });
 
@@ -24,22 +28,19 @@ describe('Hardening', () => {
   it('returns readiness', async () => {
     const app = buildServer();
 
-    // Set all jobs to healthy
-    setJobBeat('alpha');
-    setJobBeat('beta');
-    setJobBeat('marketFeed');
-
-    // No real sleeping; the health uses Date.now, so it's instant
+    setJobBeat('alpha', Date.now());
+    setJobBeat('beta', Date.now());
+    setJobBeat('marketFeed', Date.now());
 
     const res = await app.inject({ method: 'GET', url: '/ready' });
     expect(res.statusCode).toBe(200);
     const body = res.json();
 
-    // Ensure job is healthy and overall is healthy
-    expect(body.jobs.alpha?.healthy).toBe(true);
-    expect(body.jobs.beta?.healthy).toBe(true);
-    expect(body.jobs.marketFeed?.healthy).toBe(true);
-    expect(body.overall).toBe('healthy'); // Expect overall to be healthy
+    expect(body.jobs.alpha.healthy).toBe(true);
+    expect(body.jobs.beta.healthy).toBe(true);
+    expect(body.jobs.marketFeed.healthy).toBe(true);
+    expect(body.overall).toBe('healthy');
+
     await app.close();
   });
 

--- a/apps/api/src/tests/ready.spec.ts
+++ b/apps/api/src/tests/ready.spec.ts
@@ -1,40 +1,39 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { buildServer } from '../server.js';
 import { setJobBeat, __resetHealth } from '@prism-apex-tool/runtime';
 
-import { buildServer } from '../server.js';
-
-beforeEach(() => {
-  vi.useFakeTimers();
-  __resetHealth();
-});
-
-afterEach(() => {
-  vi.useRealTimers();
-});
-
 describe('/ready', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    __resetHealth();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('reports job health', async () => {
     const app = buildServer();
 
-    // Set jobs as healthy
-    setJobBeat('alpha');
-    setJobBeat('beta');
+    setJobBeat('alpha', Date.now());
+    setJobBeat('beta', Date.now());
 
     let res = await app.inject({ method: 'GET', url: '/ready' });
     let body = res.json();
 
-    // Ensure both jobs are healthy
-    expect(body.jobs.alpha?.healthy).toBe(true);
-    expect(body.jobs.beta?.healthy).toBe(true);
-    expect(body.overall).toBe('healthy'); // Expect overall to be healthy
+    expect(body.jobs.alpha.healthy).toBe(true);
+    expect(body.jobs.beta.healthy).toBe(true);
+    expect(body.overall).toBe('healthy');
 
     await vi.advanceTimersByTimeAsync(11_000);
     res = await app.inject({ method: 'GET', url: '/ready' });
     body = res.json();
 
-    // After the timer, alpha should become unhealthy, and overall should be degraded
     expect(body.jobs.alpha.healthy).toBe(false);
+    expect(body.jobs.beta.healthy).toBe(false); // both stale by 11s
     expect(body.overall).toBe('degraded');
+
     await app.close();
   });
 });

--- a/apps/api/src/types/runtime.d.ts
+++ b/apps/api/src/types/runtime.d.ts
@@ -4,6 +4,6 @@ declare module '@prism-apex-tool/runtime' {
     jobs: Record<string, { lastBeatIso: string; healthy: boolean }>;
     overall: 'healthy' | 'degraded';
   };
-  // test-only: clears in-memory job beats
+  // test-only helper, safe to export
   export function __resetHealth(): void;
 }

--- a/packages/runtime/dist/health.js
+++ b/packages/runtime/dist/health.js
@@ -1,4 +1,7 @@
 const state = Object.create(null);
+export function __resetHealth() {
+  for (const k of Object.keys(state)) delete state[k];
+}
 export function setJobBeat(jobName, nowTs = Date.now()) {
   state[jobName] = nowTs;
 }
@@ -12,8 +15,4 @@ export function getHealth(nowTs = Date.now()) {
   const overall =
     entries.length > 0 && entries.every(([, ts]) => nowTs - ts < 10_000) ? 'healthy' : 'degraded';
   return { jobs, overall };
-}
-// test-only utility to avoid cross-test leakage of state
-export function __resetHealth() {
-  for (const k of Object.keys(state)) delete state[k];
 }

--- a/packages/runtime/src/health.ts
+++ b/packages/runtime/src/health.ts
@@ -2,6 +2,10 @@ type JobStatus = { lastBeatIso: string; healthy: boolean };
 
 const state: Record<string, number> = Object.create(null);
 
+export function __resetHealth(): void {
+  for (const k of Object.keys(state)) delete state[k];
+}
+
 export function setJobBeat(jobName: string, nowTs: number = Date.now()): void {
   state[jobName] = nowTs;
 }
@@ -19,9 +23,4 @@ export function getHealth(nowTs: number = Date.now()): {
   const overall: 'healthy' | 'degraded' =
     entries.length > 0 && entries.every(([, ts]) => nowTs - ts < 10_000) ? 'healthy' : 'degraded';
   return { jobs, overall };
-}
-
-// test-only utility to avoid cross-test leakage of state
-export function __resetHealth(): void {
-  for (const k of Object.keys(state)) delete (state as any)[k];
 }


### PR DESCRIPTION
## Summary
- add __resetHealth helper to runtime and expose in build
- declare runtime reset helper in API types
- use fake timers and reset health in readiness tests
- type filtered jobs in /ready route

## Testing
- `pnpm --filter @prism-apex-tool/runtime build`
- `pnpm --filter @prism-apex-tool/api exec vitest run src/tests/ready.spec.ts src/tests/hardening.spec.ts --config vitest.config.ts --reporter=verbose` *(fails: Failed to resolve entry for package "@prism-apex-tool/consistency".)*

------
https://chatgpt.com/codex/tasks/task_b_68b949d2fb9c832c9351dfe4b541a235