### PR TITLE
chore(ci): triage logs + add services:start (no runtime changes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "docker:build": "docker build -t prism-apex-api:latest .",
     "docker:run": "docker run --rm -p 3000:3000 -e LOG_LEVEL=info -e TRUST_PROXY=true -v api-data:/data prism-apex-api:latest",
     "config:check": "node scripts/config-check.js",
-    "build:api": "pnpm -C apps/api build"
+    "build:api": "pnpm -C apps/api build",
+    "services:start": "echo \"Use: docker compose up -d (API at http://localhost:3000). This script is a no-op for CI.\""
   },
   "engines": {
     "node": ">=20 <21"

--- a/reports/ci/20250909-115721/lint.out
+++ b/reports/ci/20250909-115721/lint.out
@@ -1,0 +1,210 @@
+
+> prism-apex-tool@0.1.0 lint /workspace/prism-apex-tool
+> eslint .
+
+
+/workspace/prism-apex-tool/apps/api/eslint.config.mjs
+  4:1  warning  'globals' should be listed in the project's dependencies. Run 'npm i -S globals' to add it  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/apps/api/scripts/check-runtime.js
+  3:3  warning  Unexpected console statement  no-console
+  6:3  warning  Unexpected console statement  no-console
+  7:3  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/apps/api/scripts/postbuild.mjs
+  35:3  warning  Unexpected console statement  no-console
+  37:3  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/apps/api/scripts/seed.ts
+  100:3  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/apps/api/src/index.ts
+  27:3  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/apps/api/src/jobs/feed.ts
+  30:9  warning  'client' is assigned a value but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+
+/workspace/prism-apex-tool/apps/api/src/server.ts
+  14:8  warning  'openapiRoute' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+
+/workspace/prism-apex-tool/apps/api/src/store/tickets.ts
+  72:58  warning  'hash' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  78:40  warning  'hash' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+
+/workspace/prism-apex-tool/apps/api/test/rules/engine.test.ts
+  1:1  warning  'vitest' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/apps/dashboard/src/__tests__/App.test.tsx
+  1:1  warning  Unused eslint-disable directive (no problems were reported from 'simple-import-sort/imports')
+  4:1  warning  'vitest' should be listed in the project's dependencies. Run 'npm i -S vitest' to add it       import/no-extraneous-dependencies
+  6:1  warning  Unused eslint-disable directive (no problems were reported from 'import/no-unresolved')
+
+/workspace/prism-apex-tool/apps/dashboard/src/__tests__/Positions.test.tsx
+  3:1  warning  'vitest' should be listed in the project's dependencies. Run 'npm i -S vitest' to add it  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/apps/dashboard/src/__tests__/Tickets.test.tsx
+  3:1  warning  'vitest' should be listed in the project's dependencies. Run 'npm i -S vitest' to add it  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/apps/dashboard/src/lib/copy.ts
+  16:5  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/apps/dashboard/src/main.tsx
+  1:1  warning  Unused eslint-disable directive (no problems were reported from 'simple-import-sort/imports')
+
+/workspace/prism-apex-tool/apps/dashboard/src/pages/Tickets.tsx
+  37:7  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/apps/dashboard/vitest.config.ts
+  1:1  warning  Unused eslint-disable directive (no problems were reported from 'import/no-default-export')
+  2:1  warning  Unused eslint-disable directive (no problems were reported from 'import/no-unresolved')
+  3:1  warning  Unused eslint-disable directive (no problems were reported from 'simple-import-sort/imports')
+
+/workspace/prism-apex-tool/packages/accounts/src/cli.ts
+  18:3  warning  Unexpected console statement  no-console
+  43:9  warning  Unexpected console statement  no-console
+  57:9  warning  Unexpected console statement  no-console
+  70:9  warning  Unexpected console statement  no-console
+  78:9  warning  Unexpected console statement  no-console
+  86:5  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/packages/accounts/src/index.js
+   2:1   warning  Unexpected var, use let or const instead  no-var
+   7:9   warning  Unexpected var, use let or const instead  no-var
+  22:1   warning  Unexpected var, use let or const instead  no-var
+  25:10  warning  Unexpected var, use let or const instead  no-var
+
+/workspace/prism-apex-tool/packages/accounts/src/registry.js
+  2:1  warning  Unexpected var, use let or const instead  no-var
+
+/workspace/prism-apex-tool/packages/accounts/tests/fs.test.ts
+  4:1  warning  'vitest' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/packages/analytics/src/index.js
+   2:34  warning  'props' is assigned a value but never used. Allowed unused args must match /^_/u    @typescript-eslint/no-unused-vars
+   6:35  warning  'context' is assigned a value but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  10:36  warning  'tags' is assigned a value but never used. Allowed unused args must match /^_/u     @typescript-eslint/no-unused-vars
+
+/workspace/prism-apex-tool/packages/analytics/src/index.ts
+   5:42  warning  'props' is assigned a value but never used. Allowed unused args must match /^_/u    @typescript-eslint/no-unused-vars
+  10:44  warning  'context' is assigned a value but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  15:52  warning  'tags' is assigned a value but never used. Allowed unused args must match /^_/u     @typescript-eslint/no-unused-vars
+
+/workspace/prism-apex-tool/packages/audit/src/__tests__/readers.spec.ts
+  1:1  warning  'vitest' should be listed in the project's dependencies. Run 'npm i -S vitest' to add it  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/packages/clients-tradovate/vitest.config.ts
+  1:1  warning  Unused eslint-disable directive (no problems were reported from 'import/no-default-export')
+  2:1  warning  Unused eslint-disable directive (no problems were reported from 'import/no-unresolved')
+
+/workspace/prism-apex-tool/packages/rules-apex/src/applyGuards.ts
+  4:21  warning  'SizeContext' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+
+/workspace/prism-apex-tool/packages/rules/__tests__/apex.guard.spec.ts
+  1:1  warning  'vitest' should be listed in the project's dependencies. Run 'npm i -S vitest' to add it  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/packages/runtime/__tests__/heartbeat.spec.ts
+  1:1  warning  'vitest' should be listed in the project's dependencies. Run 'npm i -S vitest' to add it  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/packages/runtime/__tests__/ws.resilience.spec.ts
+  1:1  warning  'vitest' should be listed in the project's dependencies. Run 'npm i -S vitest' to add it  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/packages/sdk/src/index.spec.ts
+  1:1  warning  'vitest' should be listed in the project's dependencies. Run 'npm i -S vitest' to add it  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/packages/sdk/src/index.ts
+  2:3  warning  'Bar' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+
+/workspace/prism-apex-tool/packages/signals/src/__tests__/core.spec.ts
+  1:1  warning  'vitest' should be listed in the project's dependencies. Run 'npm i -S vitest' to add it  import/no-extraneous-dependencies
+
+/workspace/prism-apex-tool/scripts/build-openapi.js
+   6:11  warning  Unexpected console statement  no-console
+  24:15  warning  Unexpected console statement  no-console
+  27:3   warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/scripts/config-check.js
+  70:5  warning  Unexpected console statement  no-console
+  82:5  warning  Unexpected console statement  no-console
+  85:3  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/scripts/ensure-api-prodeps.mjs
+  53:3  warning  Unexpected console statement  no-console
+  57:3  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/scripts/ensure-openapi-dep.mjs
+  14:1  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/scripts/fix-api.mjs
+  106:30  error    Unnecessary escape character: \-                                     no-useless-escape
+  113:61  warning  'm' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
+  143:3   warning  Unexpected console statement                                         no-console
+  147:3   warning  Unexpected console statement                                         no-console
+
+/workspace/prism-apex-tool/scripts/fix-exports-auto.mjs
+  37:9   warning  'js' is assigned a value but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+  74:5   warning  Unexpected console statement                                                   no-console
+  78:22  warning  Unexpected console statement                                                   no-console
+
+/workspace/prism-apex-tool/scripts/fix-feed-final.mjs
+  42:48  error    Unnecessary escape character: \[  no-useless-escape
+  82:3   warning  Unexpected console statement      no-console
+  84:3   warning  Unexpected console statement      no-console
+
+/workspace/prism-apex-tool/scripts/fix-feed-solid.mjs
+  42:48  error    Unnecessary escape character: \[  no-useless-escape
+  95:3   warning  Unexpected console statement      no-console
+  97:3   warning  Unexpected console statement      no-console
+
+/workspace/prism-apex-tool/scripts/fix-feed.mjs
+   6:3  warning  Unexpected console statement                     no-console
+  10:5  warning  'orig' is never reassigned. Use 'const' instead  prefer-const
+  71:3  warning  Unexpected console statement                     no-console
+  73:3  warning  Unexpected console statement                     no-console
+
+/workspace/prism-apex-tool/scripts/fix-jobs-guard.mjs
+   2:8   warning  'path' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+   9:5   warning  Unexpected console statement                                            no-console
+  11:5   warning  Unexpected console statement                                            no-console
+  31:7   warning  Unexpected console statement                                            no-console
+  33:7   warning  Unexpected console statement                                            no-console
+  36:5   warning  Unexpected console statement                                            no-console
+  71:32  error    Unnecessary escape character: \-                                        no-useless-escape
+  98:1   warning  Unexpected console statement                                            no-console
+
+/workspace/prism-apex-tool/scripts/fix-package-exports.mjs
+  70:5  warning  Unexpected console statement  no-console
+  75:3  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/scripts/fix-server-final.mjs
+  23:3  warning  Unexpected console statement  no-console
+  25:3  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/scripts/fix-server.mjs
+   6:3   warning  Unexpected console statement                     no-console
+  11:5   warning  'orig' is never reassigned. Use 'const' instead  prefer-const
+  66:28  error    Unnecessary escape character: \-                 no-useless-escape
+  73:3   warning  Unexpected console statement                     no-console
+  75:3   warning  Unexpected console statement                     no-console
+
+/workspace/prism-apex-tool/scripts/repair-feed.mjs
+  24:48  error    Unnecessary escape character: \[  no-useless-escape
+  73:3   warning  Unexpected console statement      no-console
+  75:3   warning  Unexpected console statement      no-console
+
+/workspace/prism-apex-tool/scripts/repair-server.mjs
+  41:3  warning  Unexpected console statement  no-console
+  43:3  warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/scripts/verify-api.mjs
+   3:20  warning  Unexpected console statement  no-console
+  31:1   warning  Unexpected console statement  no-console
+
+/workspace/prism-apex-tool/scripts/verify-jobs-boot.mjs
+   8:3  warning  Unexpected console statement  no-console
+  12:3  warning  Unexpected console statement  no-console
+  15:1  warning  Unexpected console statement  no-console
+
+✖ 105 problems (6 errors, 99 warnings)
+  0 errors and 15 warnings potentially fixable with the `--fix` option.
+
+ ELIFECYCLE  Command failed with exit code 1.

--- a/reports/ci/20250909-115721/test.out
+++ b/reports/ci/20250909-115721/test.out
@@ -1,0 +1,157 @@
+
+> prism-apex-tool@0.1.0 test /workspace/prism-apex-tool
+> vitest run --reporter=verbose
+
+
+ RUN  v2.1.9 /workspace/prism-apex-tool
+
+ ✓ apps/api/node_modules/@prism-apex-tool/clients-tradovate/__tests__/telemetry.spec.ts > telemetry client > produces a shaped snapshot
+ ✓ apps/api/node_modules/@prism-apex-tool/clients-tradovate/__tests__/telemetry.spec.ts > telemetry client > flips bufferCleared when threshold crossed
+ ✓ apps/api/node_modules/@prism-apex-tool/clients-tradovate/__tests__/telemetry.spec.ts > telemetry client > handles empty data
+ ✓ packages/clients-tradovate/__tests__/telemetry.spec.ts > telemetry client > produces a shaped snapshot
+ ✓ packages/clients-tradovate/__tests__/telemetry.spec.ts > telemetry client > flips bufferCleared when threshold crossed
+ ✓ packages/clients-tradovate/__tests__/telemetry.spec.ts > telemetry client > handles empty data
+ × apps/api/src/tests/hardening.spec.ts > Hardening > returns readiness 481ms
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ × apps/api/src/tests/tickets.store.spec.ts > ticket store > deduplicates identical tickets 379ms
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ × apps/api/src/tests/tickets.store.spec.ts > ticket store > paginates results
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ × apps/api/src/tests/tickets.store.spec.ts > ticket store > exports CSV with strategy column
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ × apps/api/src/tests/hardening.spec.ts > Hardening > applies basic rate limit (429 after threshold) and sets Retry-After
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ × apps/api/src/tests/report.consistency.spec.ts > report consistency API > returns passing result 367ms
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ × apps/api/src/tests/report.consistency.spec.ts > report consistency API > flags topday>30% reason
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ × apps/api/src/tests/report.consistency.spec.ts > report consistency API > flags profitDays<5 reason
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ × apps/api/src/tests/hardening.spec.ts > Hardening > does not rate-limit CORS preflight (OPTIONS)
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ × apps/api/src/tests/hardening.spec.ts > Hardening > adds CORS header on responses
+   → Failed to resolve entry for package "@prism-apex-tool/signals". The package may have incorrect main/module/exports specified in its package.json.
+ ✓ apps/api/node_modules/@prism-apex-tool/runtime/__tests__/ws.resilience.spec.ts > ws resilience > reconnects on stale connections and re-subscribes
+ ✓ apps/api/node_modules/@prism-apex-tool/runtime/__tests__/ws.resilience.spec.ts > ws resilience > honors rate-limit penalties before retrying
+ ✓ apps/api/node_modules/@prism-apex-tool/runtime/__tests__/ws.resilience.spec.ts > ws resilience > backoff grows with attempts
+ ✓ packages/runtime/__tests__/ws.resilience.spec.ts > ws resilience > reconnects on stale connections and re-subscribes
+ ✓ packages/runtime/__tests__/ws.resilience.spec.ts > ws resilience > honors rate-limit penalties before retrying
+ ✓ packages/runtime/__tests__/ws.resilience.spec.ts > ws resilience > backoff grows with attempts
+ ✓ packages/consistency/__tests__/compute.spec.ts > computeConsistency > passes when top day share ≤30% and ≥5 profit days
+ ✓ packages/consistency/__tests__/compute.spec.ts > computeConsistency > fails when top day share >30%
+ ✓ packages/consistency/__tests__/compute.spec.ts > computeConsistency > fails when fewer than 8 days or <5 profit days
+ ✓ packages/consistency/__tests__/compute.spec.ts > computeConsistency > treats share as 0 when total ≤0
+ ✓ apps/api/node_modules/@prism-apex-tool/consistency/__tests__/compute.spec.ts > computeConsistency > passes when top day share ≤30% and ≥5 profit days
+ ✓ apps/api/node_modules/@prism-apex-tool/consistency/__tests__/compute.spec.ts > computeConsistency > fails when top day share >30%
+ ✓ apps/api/node_modules/@prism-apex-tool/consistency/__tests__/compute.spec.ts > computeConsistency > fails when fewer than 8 days or <5 profit days
+ ✓ apps/api/node_modules/@prism-apex-tool/consistency/__tests__/compute.spec.ts > computeConsistency > treats share as 0 when total ≤0
+ ✓ packages/ticketizer/node_modules/@prism-apex-tool/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > blocks when rr below min
+ ✓ packages/ticketizer/node_modules/@prism-apex-tool/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > allows when rr at min
+ ✓ packages/ticketizer/node_modules/@prism-apex-tool/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > blocks when rr above max
+ ✓ packages/ticketizer/node_modules/@prism-apex-tool/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > blocks when missing stop
+ ✓ packages/ticketizer/node_modules/@prism-apex-tool/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > blocks in EOD window
+ ✓ packages/ticketizer/node_modules/@prism-apex-tool/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > passes in evaluation mode without rr enforcement
+ ✓ packages/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > blocks when rr below min
+ ✓ packages/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > allows when rr at min
+ ✓ packages/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > blocks when rr above max
+ ✓ packages/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > blocks when missing stop
+ ✓ packages/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > blocks in EOD window
+ ✓ packages/rules/__tests__/apex.guard.spec.ts > guardApexFundingRules > passes in evaluation mode without rr enforcement
+ ✓ packages/indicators/__tests__/vwap.spec.ts > vwap > resets on session change
+ ✓ packages/indicators/__tests__/vwap.spec.ts > vwap > matches golden values
+ ✓ packages/indicators/__tests__/vwap.spec.ts > vwap > incremental matches batch
+ ✓ apps/api/node_modules/@prism-apex-tool/indicators/__tests__/vwap.spec.ts > vwap > resets on session change
+ ✓ apps/api/node_modules/@prism-apex-tool/indicators/__tests__/vwap.spec.ts > vwap > matches golden values
+ ✓ apps/api/node_modules/@prism-apex-tool/indicators/__tests__/vwap.spec.ts > vwap > incremental matches batch
+ ✓ packages/indicators/__tests__/atr.spec.ts > atr wilder > matches expected series
+ ✓ packages/indicators/__tests__/atr.spec.ts > atr wilder > converts to ticks
+ ✓ packages/indicators/__tests__/atr.spec.ts > atr wilder > computes true range
+ ✓ apps/api/node_modules/@prism-apex-tool/indicators/__tests__/atr.spec.ts > atr wilder > matches expected series
+ ✓ apps/api/node_modules/@prism-apex-tool/indicators/__tests__/atr.spec.ts > atr wilder > converts to ticks
+ ✓ apps/api/node_modules/@prism-apex-tool/indicators/__tests__/atr.spec.ts > atr wilder > computes true range
+ ✓ packages/metrics/__tests__/consistency.spec.ts > computeConsistency > eligible when total>0, >=5 profit days, bestDayShare<=0.30
+ ✓ packages/metrics/__tests__/consistency.spec.ts > computeConsistency > ineligible when total<=0
+ ✓ packages/metrics/__tests__/consistency.spec.ts > computeConsistency > ineligible when bestDayShare>0.30
+ ✓ apps/api/node_modules/@prism-apex-tool/metrics/__tests__/consistency.spec.ts > computeConsistency > eligible when total>0, >=5 profit days, bestDayShare<=0.30
+ ✓ apps/api/node_modules/@prism-apex-tool/metrics/__tests__/consistency.spec.ts > computeConsistency > ineligible when total<=0
+ ✓ apps/api/node_modules/@prism-apex-tool/metrics/__tests__/consistency.spec.ts > computeConsistency > ineligible when bestDayShare>0.30
+ ✓ packages/indicators/__tests__/swings.spec.ts > swings > detects pivot points for k=2
+ ✓ packages/indicators/__tests__/swings.spec.ts > swings > handles plateaus preferring earliest
+ ✓ packages/indicators/__tests__/swings.spec.ts > swings > returns empty when too few bars
+ ✓ apps/api/node_modules/@prism-apex-tool/indicators/__tests__/swings.spec.ts > swings > detects pivot points for k=2
+ ✓ apps/api/node_modules/@prism-apex-tool/indicators/__tests__/swings.spec.ts > swings > handles plateaus preferring earliest
+ ✓ apps/api/node_modules/@prism-apex-tool/indicators/__tests__/swings.spec.ts > swings > returns empty when too few bars
+ ✓ packages/clients-tradovate/src/__tests__/ws.spec.ts > MarketDataWS > sends heartbeats every 2.5s
+ ✓ packages/clients-tradovate/src/__tests__/ws.spec.ts > MarketDataWS > reconnects after close with backoff
+ ✓ apps/api/node_modules/@prism-apex-tool/clients-tradovate/src/__tests__/ws.spec.ts > MarketDataWS > sends heartbeats every 2.5s
+ ✓ apps/api/node_modules/@prism-apex-tool/clients-tradovate/src/__tests__/ws.spec.ts > MarketDataWS > reconnects after close with backoff
+ ✓ packages/runtime/__tests__/heartbeat.spec.ts > heartbeat + stale detection > sends heartbeats at interval
+ ✓ packages/runtime/__tests__/heartbeat.spec.ts > heartbeat + stale detection > calls onStale after no inbound for staleMs
+ ✓ apps/api/node_modules/@prism-apex-tool/runtime/__tests__/heartbeat.spec.ts > heartbeat + stale detection > sends heartbeats at interval
+ ✓ apps/api/node_modules/@prism-apex-tool/runtime/__tests__/heartbeat.spec.ts > heartbeat + stale detection > calls onStale after no inbound for staleMs
+ ✓ packages/signals/src/__tests__/core.spec.ts > signals core > computes VWAP
+ ✓ packages/signals/src/__tests__/core.spec.ts > signals core > suggests OSB breakout
+ ✓ packages/signals/src/__tests__/core.spec.ts > signals core > suggests VWAP first touch
+ ✓ apps/api/node_modules/@prism-apex-tool/signals/src/__tests__/core.spec.ts > signals core > computes VWAP
+ ✓ apps/api/node_modules/@prism-apex-tool/signals/src/__tests__/core.spec.ts > signals core > suggests OSB breakout
+ ✓ apps/api/node_modules/@prism-apex-tool/signals/src/__tests__/core.spec.ts > signals core > suggests VWAP first touch
+ ✓ packages/rules-apex/test/applyGuards.spec.ts > applyGuardWithSizing > half-size enforced when buffer not cleared
+ ✓ packages/rules-apex/test/applyGuards.spec.ts > applyGuardWithSizing > rejects missing stop in funded
+ ✓ packages/rules-apex/test/applyGuards.spec.ts > applyGuardWithSizing > accepts missing stop in eval with advisory
+ ✓ packages/rules-apex/test/applyGuards.spec.ts > applyGuardWithSizing > anti-windfall caps sudden jump
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/applyGuards.spec.ts > applyGuardWithSizing > half-size enforced when buffer not cleared
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/applyGuards.spec.ts > applyGuardWithSizing > rejects missing stop in funded
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/applyGuards.spec.ts > applyGuardWithSizing > accepts missing stop in eval with advisory
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/applyGuards.spec.ts > applyGuardWithSizing > anti-windfall caps sudden jump
+ ✓ packages/accounts/__tests__/schema.spec.ts > accounts schema > accepts a valid config
+ ✓ packages/accounts/__tests__/schema.spec.ts > accounts schema > rejects unknown keys & bad types
+ ✓ apps/api/node_modules/@prism-apex-tool/accounts/__tests__/schema.spec.ts > accounts schema > accepts a valid config
+ ✓ apps/api/node_modules/@prism-apex-tool/accounts/__tests__/schema.spec.ts > accounts schema > rejects unknown keys & bad types
+ ✓ packages/ticketizer/node_modules/@prism-apex-tool/accounts/__tests__/schema.spec.ts > accounts schema > accepts a valid config
+ ✓ packages/ticketizer/node_modules/@prism-apex-tool/accounts/__tests__/schema.spec.ts > accounts schema > rejects unknown keys & bad types
+ ✓ packages/rules-apex/test/size.spec.ts > size guard > half-size when buffer uncleared
+ ✓ packages/rules-apex/test/size.spec.ts > size guard > clamps to apex max
+ ✓ packages/rules-apex/test/size.spec.ts > size guard > rejects windfall size jumps
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/size.spec.ts > size guard > half-size when buffer uncleared
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/size.spec.ts > size guard > clamps to apex max
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/size.spec.ts > size guard > rejects windfall size jumps
+ ✓ apps/api/node_modules/@prism-apex-tool/reporting/src/__tests__/basic.spec.ts > reporting utils > formats CSV and noop email
+ ✓ packages/reporting/src/__tests__/basic.spec.ts > reporting utils > formats CSV and noop email
+ ✓ packages/strategies/__tests__/strategy.schema.spec.ts > strategy schema (generic) > accepts numeric params and time fields
+ ✓ packages/strategies/__tests__/strategy.schema.spec.ts > strategy schema (generic) > rejects negative lookbacks and unknown keys when allowed list given
+ ✓ packages/strategies/__tests__/strategy.schema.spec.ts > strategy schema (generic) > rejects non-numeric where numbers required
+ ✓ apps/api/node_modules/@prism-apex-tool/strategies/__tests__/strategy.schema.spec.ts > strategy schema (generic) > accepts numeric params and time fields
+ ✓ apps/api/node_modules/@prism-apex-tool/strategies/__tests__/strategy.schema.spec.ts > strategy schema (generic) > rejects negative lookbacks and unknown keys when allowed list given
+ ✓ apps/api/node_modules/@prism-apex-tool/strategies/__tests__/strategy.schema.spec.ts > strategy schema (generic) > rejects non-numeric where numbers required
+ ✓ packages/clients-tradovate/src/__tests__/bars.spec.ts > BarAggregator > rolls on minute boundary and publishes
+ ✓ apps/api/node_modules/@prism-apex-tool/clients-tradovate/src/__tests__/bars.spec.ts > BarAggregator > rolls on minute boundary and publishes
+ ✓ packages/rules-apex/test/stop.spec.ts > stop guard > requires stop in funded
+ ✓ packages/rules-apex/test/stop.spec.ts > stop guard > rejects bad stop side
+ ✓ packages/rules-apex/test/stop.spec.ts > stop guard > accepts good stop
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/stop.spec.ts > stop guard > requires stop in funded
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/stop.spec.ts > stop guard > rejects bad stop side
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/stop.spec.ts > stop guard > accepts good stop
+ ✓ packages/analytics/__tests__/index.spec.ts > @prism-apex-tool/analytics stub > exports no-op functions without throwing
+ ✓ apps/api/node_modules/@prism-apex-tool/analytics/__tests__/index.spec.ts > @prism-apex-tool/analytics stub > exports no-op functions without throwing
+ ✓ packages/clients-tradovate/src/__tests__/contracts.spec.ts > getContractMeta > parses metadata fields
+ ✓ apps/api/node_modules/@prism-apex-tool/clients-tradovate/src/__tests__/contracts.spec.ts > getContractMeta > parses metadata fields
+ ✓ packages/rules-apex/test/rr.spec.ts > rr guard > accepts rr within range
+ ✓ packages/rules-apex/test/rr.spec.ts > rr guard > rejects low rr
+ ✓ packages/rules-apex/test/rr.spec.ts > rr guard > rejects high rr
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/rr.spec.ts > rr guard > accepts rr within range
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/rr.spec.ts > rr guard > rejects low rr
+ ✓ apps/api/node_modules/@prism-apex-tool/rules-apex/test/rr.spec.ts > rr guard > rejects high rr
+ × packages/audit/src/__tests__/readers.spec.ts > audit readers > parses events from log lines
+   → readEventsFromLines is not a function
+ × apps/api/node_modules/@prism-apex-tool/audit/src/__tests__/readers.spec.ts > audit readers > parses events from log lines
+   → readEventsFromLines is not a function
+ ✓ packages/sdk/src/index.spec.ts > PrismApexClient > constructs
+ ✓ apps/api/node_modules/@prism-apex-tool/sdk/src/index.spec.ts > PrismApexClient > constructs
+ ✓ __tests__/smoke.spec.ts > smoke > sanity math works
+
+ Test Files  21 failed | 46 passed | 2 skipped (69)
+      Tests  12 failed | 119 passed | 6 skipped (137)
+   Start at  11:57:47
+   Duration  12.84s (transform 1.85s, setup 0ms, collect 2.43s, tests 1.94s, environment 22ms, prepare 11.34s)
+
+ ELIFECYCLE  Test failed. See above for more details.

--- a/reports/ci/20250909-115721/typecheck.out
+++ b/reports/ci/20250909-115721/typecheck.out
@@ -1,0 +1,225 @@
+
+> prism-apex-tool@0.1.0 typecheck /workspace/prism-apex-tool
+> tsc --noEmit
+
+apps/api/__tests__/ready.spec.ts(4,28): error TS2307: Cannot find module '@prism-apex-tool/runtime/health' or its corresponding type declarations.
+apps/api/src/__tests__._archived/api.spec.skip.ts(3,10): error TS2614: Module '"../routes/health.js"' has no exported member 'healthRoutes'. Did you mean to use 'import healthRoutes from "../routes/health.js"' instead?
+apps/api/src/__tests__._archived/export.spec.skip.ts(68,44): error TS2561: Object literal may only specify known properties, but 'maxContracts' does not exist in type 'Partial<AccountRecord> & { id: string; }'. Did you mean to write 'planMaxContracts'?
+apps/api/src/__tests__._archived/feed.health.spec.skip.ts(3,10): error TS2305: Module '"../jobs/feed.js"' has no exported member 'setClientFactory'.
+apps/api/src/__tests__._archived/ingest.spec.skip.ts(56,39): error TS2561: Object literal may only specify known properties, but 'maxContracts' does not exist in type 'Partial<AccountRecord> & { id: string; }'. Did you mean to write 'planMaxContracts'?
+apps/api/src/__tests__._archived/ingest.spec.skip.ts(77,39): error TS2561: Object literal may only specify known properties, but 'maxContracts' does not exist in type 'Partial<AccountRecord> & { id: string; }'. Did you mean to write 'planMaxContracts'?
+apps/api/src/__tests__._archived/webhooks.tradingview.spec.skip.ts(74,39): error TS2561: Object literal may only specify known properties, but 'maxContracts' does not exist in type 'Partial<AccountRecord> & { id: string; }'. Did you mean to write 'planMaxContracts'?
+apps/api/src/__tests__._archived/webhooks.tradingview.spec.skip.ts(99,39): error TS2561: Object literal may only specify known properties, but 'maxContracts' does not exist in type 'Partial<AccountRecord> & { id: string; }'. Did you mean to write 'planMaxContracts'?
+apps/api/src/jobs/strategies.ts(175,24): error TS2345: Argument of type '{ contract: string; meta: { vwap: number; atrTicks: number; strategy: "VWAP_FT" | "OSB"; rr: number; notes?: string; guardrails?: string[]; sizingHintPctOfMax?: number; }; symbol?: string | undefined; ... 5 more ...; timestampUtc?: string | undefined; }' is not assignable to parameter of type 'Suggestion'.
+  Type '{ contract: string; meta: { vwap: number; atrTicks: number; strategy: "VWAP_FT" | "OSB"; rr: number; notes?: string; guardrails?: string[]; sizingHintPctOfMax?: number; }; symbol?: string | undefined; ... 5 more ...; timestampUtc?: string | undefined; }' is not assignable to type 'Suggestion'.
+    Types of property 'symbol' are incompatible.
+      Type 'string | undefined' is not assignable to type 'string'.
+        Type 'undefined' is not assignable to type 'string'.
+apps/api/src/jobs/strategies.ts(178,22): error TS2532: Object is possibly 'undefined'.
+apps/api/src/jobs/strategies.ts(189,11): error TS18048: 's' is possibly 'undefined'.
+apps/api/src/jobs/strategies.ts(191,24): error TS2345: Argument of type '{ contract: string; meta: { atrTicks: number; orHigh: number; orLow: number; strategy: "VWAP_FT" | "OSB"; rr: number; notes?: string; guardrails?: string[]; sizingHintPctOfMax?: number; }; symbol?: string | undefined; ... 5 more ...; timestampUtc?: string | undefined; }' is not assignable to parameter of type 'Suggestion'.
+  Type '{ contract: string; meta: { atrTicks: number; orHigh: number; orLow: number; strategy: "VWAP_FT" | "OSB"; rr: number; notes?: string; guardrails?: string[]; sizingHintPctOfMax?: number; }; symbol?: string | undefined; ... 5 more ...; timestampUtc?: string | undefined; }' is not assignable to type 'Suggestion'.
+    Types of property 'symbol' are incompatible.
+      Type 'string | undefined' is not assignable to type 'string'.
+        Type 'undefined' is not assignable to type 'string'.
+apps/api/src/jobs/strategies.ts(194,22): error TS18048: 's' is possibly 'undefined'.
+apps/api/src/jobs/strategies.ts(196,18): error TS18048: 's' is possibly 'undefined'.
+apps/api/src/jobs/strategies.ts(198,24): error TS2345: Argument of type '{ contract: string; meta: { atrTicks: number; orHigh: number; orLow: number; strategy: "VWAP_FT" | "OSB"; rr: number; notes?: string; guardrails?: string[]; sizingHintPctOfMax?: number; }; symbol?: string | undefined; ... 5 more ...; timestampUtc?: string | undefined; }' is not assignable to parameter of type 'Suggestion'.
+  Type '{ contract: string; meta: { atrTicks: number; orHigh: number; orLow: number; strategy: "VWAP_FT" | "OSB"; rr: number; notes?: string; guardrails?: string[]; sizingHintPctOfMax?: number; }; symbol?: string | undefined; ... 5 more ...; timestampUtc?: string | undefined; }' is not assignable to type 'Suggestion'.
+    Types of property 'symbol' are incompatible.
+      Type 'string | undefined' is not assignable to type 'string'.
+        Type 'undefined' is not assignable to type 'string'.
+apps/api/src/jobs/strategies.ts(201,22): error TS18048: 's' is possibly 'undefined'.
+apps/api/src/jobs/ticketizer.ts(147,40): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/jobs/ticketizer.ts(149,16): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/jobs/ticketizer.ts(150,12): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/jobs/ticketizer.ts(151,19): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/jobs/ticketizer.ts(152,47): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/jobs/ticketizer.ts(153,39): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/lib/accounts.ts(41,11): error TS2322: Type 'AccountRecord | undefined' is not assignable to type 'AccountRecord'.
+  Type 'undefined' is not assignable to type 'AccountRecord'.
+apps/api/src/routes/consistency.ts(2,58): error TS2307: Cannot find module '@prism-apex-tool/metrics/consistency' or its corresponding type declarations.
+apps/api/src/routes/tickets.ts(71,20): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/routes/tickets.ts(72,16): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/routes/tickets.ts(73,23): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/routes/tickets.ts(74,24): error TS18048: 'acct' is possibly 'undefined'.
+apps/api/src/tests/strategies.orchestrator.spec.ts(13,1): error TS2304: Cannot find name 'vi'.
+apps/api/src/tests/strategies.orchestrator.spec.ts(82,3): error TS2322: Type '{ symbol: string | undefined; contract: string | undefined; ts: string | undefined; open: number; high: number; low: number; close: number; volume: number; session: "RTH" | "ETH"; }[]' is not assignable to type 'BarMessage[]'.
+  Type '{ symbol: string | undefined; contract: string | undefined; ts: string | undefined; open: number; high: number; low: number; close: number; volume: number; session: "RTH" | "ETH"; }' is not assignable to type 'BarMessage'.
+    Types of property 'symbol' are incompatible.
+      Type 'string | undefined' is not assignable to type 'string'.
+        Type 'undefined' is not assignable to type 'string'.
+apps/api/src/tests/telemetry.api.spec.ts(48,50): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(29,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(43,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(56,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(70,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(84,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(100,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(117,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(132,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(164,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(179,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(195,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(212,14): error TS2532: Object is possibly 'undefined'.
+apps/api/test/rules/engine.test.ts(227,14): error TS2532: Object is possibly 'undefined'.
+apps/api/vitest.config.ts(5,46): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
+apps/dashboard/vite.config.ts(3,19): error TS2307: Cannot find module '@vitejs/plugin-react' or its corresponding type declarations.
+  There are types at '/workspace/prism-apex-tool/apps/dashboard/node_modules/@vitejs/plugin-react/dist/index.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.
+apps/dashboard/vitest.config.ts(5,19): error TS2307: Cannot find module '@vitejs/plugin-react' or its corresponding type declarations.
+  There are types at '/workspace/prism-apex-tool/apps/dashboard/node_modules/@vitejs/plugin-react/dist/index.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.
+packages/accounts/__tests__/schema.spec.ts(21,12): error TS2532: Object is possibly 'undefined'.
+packages/accounts/src/cli.ts(8,9): error TS18048: 'arg' is possibly 'undefined'.
+packages/accounts/src/cli.ts(9,19): error TS18048: 'arg' is possibly 'undefined'.
+packages/accounts/src/cli.ts(10,37): error TS2532: Object is possibly 'undefined'.
+packages/accounts/src/cli.ts(11,7): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
+packages/audit/src/__tests__/readers.spec.ts(2,10): error TS2305: Module '"../index.js"' has no exported member 'readEventsFromLines'.
+packages/clients-tradovate/__tests__/telemetry.spec.ts(72,12): error TS18048: 's' is possibly 'undefined'.
+packages/clients-tradovate/__tests__/telemetry.spec.ts(72,12): error TS2532: Object is possibly 'undefined'.
+packages/clients-tradovate/__tests__/telemetry.spec.ts(73,12): error TS18048: 's' is possibly 'undefined'.
+packages/clients-tradovate/__tests__/telemetry.spec.ts(73,12): error TS2532: Object is possibly 'undefined'.
+packages/clients-tradovate/__tests__/telemetry.spec.ts(74,12): error TS18048: 's' is possibly 'undefined'.
+packages/clients-tradovate/__tests__/telemetry.spec.ts(74,12): error TS2532: Object is possibly 'undefined'.
+packages/clients-tradovate/__tests__/telemetry.spec.ts(98,18): error TS2339: Property 'bufferCleared' does not exist on type 'never'.
+packages/clients-tradovate/src/__tests__/ws.spec.ts(30,12): error TS18048: 'inst' is possibly 'undefined'.
+packages/clients-tradovate/src/__tests__/ws.spec.ts(31,12): error TS18048: 'inst' is possibly 'undefined'.
+packages/clients-tradovate/src/__tests__/ws.spec.ts(41,5): error TS18048: 'first' is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(12,3): error TS2322: Type '{ ts: string | undefined; open: number; high: number; low: number; close: number; volume: number; }[]' is not assignable to type 'Bar1m[]'.
+  Type '{ ts: string | undefined; open: number; high: number; low: number; close: number; volume: number; }' is not assignable to type 'Bar1m'.
+    Types of property 'ts' are incompatible.
+      Type 'string | undefined' is not assignable to type 'string'.
+        Type 'undefined' is not assignable to type 'string'.
+packages/indicators/__tests__/atr.spec.ts(14,25): error TS18048: 'open' is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(14,38): error TS18048: 'high' is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(14,50): error TS18048: 'low' is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(14,63): error TS18048: 'close' is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(14,79): error TS18048: 'volume' is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(59,26): error TS2345: Argument of type 'Bar1m | undefined' is not assignable to parameter of type 'Bar1m'.
+  Type 'undefined' is not assignable to type 'Bar1m'.
+packages/indicators/__tests__/atr.spec.ts(59,35): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(61,7): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(61,22): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(62,16): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(62,31): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(63,16): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/atr.spec.ts(63,30): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(21,76): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+packages/indicators/__tests__/swings.spec.ts(24,23): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(24,42): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(25,23): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(25,42): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(26,23): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(26,42): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(27,23): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(27,42): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(28,23): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(28,42): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(37,76): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+packages/indicators/__tests__/swings.spec.ts(39,42): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/swings.spec.ts(39,61): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/vwap.spec.ts(12,3): error TS2322: Type '{ ts: string | undefined; open: number; high: number; low: number; close: number; volume: number; }[]' is not assignable to type 'Bar1m[]'.
+  Type '{ ts: string | undefined; open: number; high: number; low: number; close: number; volume: number; }' is not assignable to type 'Bar1m'.
+    Types of property 'ts' are incompatible.
+      Type 'string | undefined' is not assignable to type 'string'.
+        Type 'undefined' is not assignable to type 'string'.
+packages/indicators/__tests__/vwap.spec.ts(14,25): error TS18048: 'open' is possibly 'undefined'.
+packages/indicators/__tests__/vwap.spec.ts(14,38): error TS18048: 'high' is possibly 'undefined'.
+packages/indicators/__tests__/vwap.spec.ts(14,50): error TS18048: 'low' is possibly 'undefined'.
+packages/indicators/__tests__/vwap.spec.ts(14,63): error TS18048: 'close' is possibly 'undefined'.
+packages/indicators/__tests__/vwap.spec.ts(14,79): error TS18048: 'volume' is possibly 'undefined'.
+packages/indicators/__tests__/vwap.spec.ts(27,17): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/vwap.spec.ts(27,33): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/vwap.spec.ts(27,48): error TS2532: Object is possibly 'undefined'.
+packages/indicators/__tests__/vwap.spec.ts(42,37): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+packages/indicators/src/swings.ts(19,9): error TS2532: Object is possibly 'undefined'.
+packages/indicators/src/swings.ts(20,32): error TS2532: Object is possibly 'undefined'.
+packages/indicators/src/swings.ts(20,51): error TS2532: Object is possibly 'undefined'.
+packages/indicators/src/swings.ts(22,9): error TS2532: Object is possibly 'undefined'.
+packages/indicators/src/swings.ts(23,32): error TS2532: Object is possibly 'undefined'.
+packages/indicators/src/swings.ts(23,51): error TS2532: Object is possibly 'undefined'.
+packages/rules-apex/test/applyGuards.spec.ts(4,1): error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/applyGuards.spec.ts(22,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/applyGuards.spec.ts(24,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/applyGuards.spec.ts(25,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/applyGuards.spec.ts(28,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/applyGuards.spec.ts(30,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/applyGuards.spec.ts(33,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/applyGuards.spec.ts(35,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/applyGuards.spec.ts(36,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/applyGuards.spec.ts(39,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/applyGuards.spec.ts(44,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/rr.spec.ts(3,1): error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/rr.spec.ts(4,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/rr.spec.ts(6,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/rr.spec.ts(9,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/rr.spec.ts(11,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/rr.spec.ts(14,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/rr.spec.ts(16,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/size.spec.ts(3,1): error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/size.spec.ts(4,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/size.spec.ts(15,7): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/size.spec.ts(16,7): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/size.spec.ts(22,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/size.spec.ts(33,7): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/size.spec.ts(34,7): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/size.spec.ts(40,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/size.spec.ts(50,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/stop.spec.ts(3,1): error TS2593: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/stop.spec.ts(4,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/stop.spec.ts(5,17): error TS2554: Expected 3 arguments, but got 2.
+packages/rules-apex/test/stop.spec.ts(9,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/stop.spec.ts(12,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/stop.spec.ts(13,17): error TS2554: Expected 3 arguments, but got 2.
+packages/rules-apex/test/stop.spec.ts(17,5): error TS2304: Cannot find name 'expect'.
+packages/rules-apex/test/stop.spec.ts(20,3): error TS2593: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha` and then add 'jest' or 'mocha' to the types field in your tsconfig.
+packages/rules-apex/test/stop.spec.ts(21,17): error TS2554: Expected 3 arguments, but got 2.
+packages/rules-apex/test/stop.spec.ts(25,5): error TS2304: Cannot find name 'expect'.
+packages/rules/src/apex.ts(38,21): error TS18048: 'h' is possibly 'undefined'.
+packages/rules/src/apex.ts(38,32): error TS18048: 'm' is possibly 'undefined'.
+packages/rules/src/apex.ts(38,41): error TS18048: 's' is possibly 'undefined'.
+packages/rules/src/config.ts(11,59): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
+packages/runtime/__tests__/ws.resilience.spec.ts(31,5): error TS18048: 'first' is possibly 'undefined'.
+packages/runtime/__tests__/ws.resilience.spec.ts(37,5): error TS18048: 'second' is possibly 'undefined'.
+packages/runtime/__tests__/ws.resilience.spec.ts(46,11): error TS2558: Expected 0-1 type arguments, but got 2.
+packages/runtime/__tests__/ws.resilience.spec.ts(49,49): error TS2345: Argument of type '[string | undefined]' is not assignable to parameter of type 'never'.
+packages/runtime/__tests__/ws.resilience.spec.ts(54,12): error TS2532: Object is possibly 'undefined'.
+packages/signals/src/__tests__/core.spec.ts(25,12): error TS18048: 's' is possibly 'undefined'.
+packages/signals/src/__tests__/core.spec.ts(26,12): error TS18048: 's' is possibly 'undefined'.
+packages/signals/src/__tests__/core.spec.ts(36,12): error TS2532: Object is possibly 'undefined'.
+packages/strategies/src/config/strategy-config.ts(35,41): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020', 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', or 'nodenext'.
+packages/strategies/src/osbBreakout.ts(39,19): error TS18048: 'lastBar' is possibly 'undefined'.
+packages/strategies/src/osbBreakout.ts(39,70): error TS18048: 'lastBar' is possibly 'undefined'.
+packages/strategies/src/osbBreakout.ts(40,21): error TS18048: 'lastBar' is possibly 'undefined'.
+packages/strategies/src/osbBreakout.ts(40,71): error TS18048: 'lastBar' is possibly 'undefined'.
+packages/strategies/src/vwapFirstTouch.ts(29,18): error TS2532: Object is possibly 'undefined'.
+packages/strategies/src/vwapFirstTouch.ts(29,41): error TS2532: Object is possibly 'undefined'.
+packages/strategies/src/vwapFirstTouch.ts(34,41): error TS2532: Object is possibly 'undefined'.
+packages/strategies/src/vwapFirstTouch.ts(38,21): error TS2532: Object is possibly 'undefined'.
+packages/strategies/src/vwapFirstTouch.ts(40,18): error TS18048: 'vnow' is possibly 'undefined'.
+packages/strategies/src/vwapFirstTouch.ts(40,60): error TS18048: 'vnow' is possibly 'undefined'.
+packages/strategies/src/vwapFirstTouch.ts(45,30): error TS18048: 'touchBar' is possibly 'undefined'.
+packages/strategies/src/vwapFirstTouch.ts(45,47): error TS18048: 'vnow' is possibly 'undefined'.
+packages/strategies/src/vwapFirstTouch.ts(51,24): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+packages/strategies/src/vwapFirstTouch.ts(52,24): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+packages/strategies/src/vwapFirstTouch.ts(56,24): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+packages/strategies/src/vwapFirstTouch.ts(57,24): error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
+  Type 'undefined' is not assignable to type 'number'.
+packages/strategies/tests/osbBreakout.spec.ts(38,12): error TS18048: 's' is possibly 'undefined'.
+packages/strategies/tests/osbBreakout.spec.ts(39,12): error TS18048: 's' is possibly 'undefined'.
+packages/strategies/tests/osbBreakout.spec.ts(40,12): error TS18048: 's' is possibly 'undefined'.
+packages/strategies/tests/osbBreakout.spec.ts(112,25): error TS18048: 's' is possibly 'undefined'.
+packages/strategies/tests/osbBreakout.spec.ts(112,34): error TS18048: 's' is possibly 'undefined'.
+packages/strategies/tests/vwapFirstTouch.spec.ts(36,12): error TS18048: 's' is possibly 'undefined'.
+packages/strategies/tests/vwapFirstTouch.spec.ts(37,12): error TS18048: 's' is possibly 'undefined'.
+packages/strategies/tests/vwapFirstTouch.spec.ts(38,25): error TS18048: 's' is possibly 'undefined'.
+packages/strategies/tests/vwapFirstTouch.spec.ts(38,34): error TS18048: 's' is possibly 'undefined'.
+packages/ticketizer/src/fanout.ts(48,12): error TS2339: Property 'maxContractsAllowed' does not exist on type '{}'.
+packages/ticketizer/src/fanout.ts(93,35): error TS2339: Property 'maxContractsAllowed' does not exist on type '{}'.
+ ELIFECYCLE  Command failed with exit code 2.


### PR DESCRIPTION
This PR:
- Captures current CI failures to `reports/ci/20250909-115721`.
- Opens tracking issues for lint/typecheck/test (labels: ci).
- Adds a non-invasive `services:start` script to stop workspace errors in tooling.
- No runtime logic changes.

Artifacts:
- `reports/ci/20250909-115721/lint.out`
- `reports/ci/20250909-115721/typecheck.out`
- `reports/ci/20250909-115721/test.out`

Intended follow-ups will fix issues in separate, small PRs.

---

- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [x] Contract/security/performance notes (if relevant)
- [x] Rollback steps (and DOWN scripts if migrations)
- [x] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c00e9f1280832cb6cd032ee28c57ba