### PR TITLE
test: unit stabilization (Round 1 — setup & helpers, no runtime changes)

### DIFF
--- a/__tests__/helpers/marketDataMock.ts
+++ b/__tests__/helpers/marketDataMock.ts
@@ -1,0 +1,52 @@
+/**
+ * Deterministic market-data utilities for unit tests.
+ * - Generates synthetic OHLC bars and a simple VWAP series
+ * - No timers/IO; purely synchronous for predictable tests
+ */
+
+export interface Bar {
+  time: number;  // epoch ms
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+export function genBars(count: number, startPrice = 100, startTime = Date.UTC(2025, 0, 1, 0, 0, 0)): Bar[] {
+  const bars: Bar[] = [];
+  let price = startPrice;
+  for (let i = 0; i < count; i++) {
+    const open = price;
+    const drift = Math.sin(i / 5) * 0.5;
+    const noise = ((i * 9301 + 49297) % 233280) / 233280 - 0.5; // pseudo-rand [-0.5, 0.5)
+    const move = drift + noise * 0.25;
+    const close = +(open + move).toFixed(2);
+    const high = Math.max(open, close) + 0.2;
+    const low = Math.min(open, close) - 0.2;
+    const volume = 100 + (i % 20);
+    bars.push({
+      time: startTime + i * 60_000,
+      open: +open.toFixed(2),
+      high: +high.toFixed(2),
+      low: +low.toFixed(2),
+      close,
+      volume,
+    });
+    price = close;
+  }
+  return bars;
+}
+
+export function genVWAP(bars: Bar[]): number[] {
+  const vwap: number[] = [];
+  let cumPV = 0;
+  let cumV = 0;
+  for (const b of bars) {
+    const typical = (b.high + b.low + b.close) / 3;
+    cumPV += typical * b.volume;
+    cumV += b.volume;
+    vwap.push(+(cumPV / cumV).toFixed(4));
+  }
+  return vwap;
+}

--- a/__tests__/helpers/ticketFixtures.ts
+++ b/__tests__/helpers/ticketFixtures.ts
@@ -1,0 +1,52 @@
+/**
+ * Canonical ticket fixtures matching docs and operator flow.
+ * Keeps tests consistent with the tickets-only contract.
+ */
+
+export type StrategyId = 'vwap-first-touch' | 'osb-breakout' | (string & {});
+export type Side = 'BUY' | 'SELL';
+
+export interface TicketMeta {
+  strategy: StrategyId;
+  rr?: number;
+  guardrails?: string[];
+  sizingHint?: 'half-size' | 'normal' | 'reduced' | (string & {});
+  consistencyNotes?: string;
+}
+
+export interface Ticket {
+  symbol: string;
+  side: Side;
+  entry: number;
+  stop: number;
+  target: number;
+  qty: number;
+  accountId: string;
+  timestampUtc: string;
+  meta?: TicketMeta;
+  accepted: boolean;
+  reasons?: string[];
+}
+
+export const ticketFactory = (overrides: Partial<Ticket> = {}): Ticket => {
+  const base: Ticket = {
+    symbol: 'MESZ5',
+    side: 'BUY',
+    entry: 5550.25,
+    stop: 5544.25,
+    target: 5560.25,
+    qty: 1,
+    accountId: 'APEX-TEST',
+    timestampUtc: new Date(Date.UTC(2025, 0, 1, 12, 0, 0)).toISOString(),
+    meta: {
+      strategy: 'vwap-first-touch',
+      rr: 1.5,
+      guardrails: ['stopSideOk', 'rrInRange'],
+      sizingHint: 'normal',
+      consistencyNotes: 'fixture',
+    },
+    accepted: true,
+    reasons: [],
+  };
+  return { ...base, ...overrides };
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "docker:run": "docker run --rm -p 3000:3000 -e LOG_LEVEL=info -e TRUST_PROXY=true -v api-data:/data prism-apex-api:latest",
     "config:check": "node scripts/config-check.js",
     "build:api": "pnpm -C apps/api build",
-    "services:start": "echo \"Use: docker compose up -d (API at http://localhost:3000). This script is a no-op for CI.\""
+    "services:start": "echo \"Use: docker compose up -d (API at http://localhost:3000). This script is a no-op for CI.\"",
+    "test:unit:local": "vitest --config vitest.local.config.ts --run"
   },
   "engines": {
     "node": ">=20 <21"

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -1,0 +1,44 @@
+/**
+ * Global Vitest setup (unit-focused)
+ * - Force UTC timezone for deterministic date behavior
+ * - Reset modules/timers between tests
+ * - Provide safe default envs used by the app
+ * - Reduce console noise (keep warn/error)
+ */
+
+import { beforeAll, beforeEach, afterEach, vi } from 'vitest';
+
+beforeAll(() => {
+  // UTC by default
+  process.env.TZ = 'UTC';
+
+  // Safe default envs (non-secret; optional)
+  process.env.NODE_ENV ??= 'test';
+  process.env.LOG_LEVEL ??= 'error';
+
+  // Avoid noisy console in unit runs; preserve warnings/errors
+  const allow = new Set(['warn', 'error']);
+  for (const k of ['log','info','debug','trace'] as const) {
+    if (!(k in console)) continue;
+    // @ts-expect-error intentional override for tests
+    console[k] = (...args: unknown[]) => {
+      if (allow.has(k)) return (console as any)[k](...args);
+      // swallow noise
+    };
+  }
+});
+
+beforeEach(() => {
+  // Fresh fake timers OFF by default; enable per-test when needed
+  vi.useRealTimers();
+  vi.resetAllMocks();
+  vi.clearAllTimers();
+  vi.clearAllMocks();
+  vi.resetModules(); // isolate module state
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.resetAllMocks();
+  vi.clearAllTimers();
+});

--- a/vitest.local.config.ts
+++ b/vitest.local.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+import path from 'node:path';
+
+// Extend project defaults in a local-only config.
+// CI remains on the default 'vitest.config.ts'.
+export default defineConfig({
+  test: {
+    setupFiles: ['tests/setup/vitest.setup.ts'],
+    include: ['**/__tests__/**/*.test.{ts,tsx,js,jsx}'],
+    exclude: [
+      ...configDefaults.exclude,
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.git/**',
+    ],
+    // Single-threaded to reduce flakiness from shared state
+    maxThreads: 1,
+    minThreads: 1,
+    testTimeout: 10000,
+    hookTimeout: 10000,
+    // Resolve aliases if your project uses them (safe defaults)
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
+});


### PR DESCRIPTION
Adds Vitest setup + deterministic helpers and a local test config to stabilize unit tests without touching runtime code.
- tests/setup/vitest.setup.ts
- __tests__/helpers/ticketFixtures.ts
- __tests__/helpers/marketDataMock.ts
- vitest.local.config.ts (extends defaults for local/unit usage)
- package.json: adds `test:unit:local` script

CI remains unchanged (existing `pnpm test` untouched).
Non-negotiables preserved: tickets-only; no API orders.

### PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c02c2760f8832cbc208f45b3989ff7