### PR TITLE
test: vitest fixup — jsdom for dashboard, node for rest (globals on)

### DIFF
--- a/vitest.local.config.ts
+++ b/vitest.local.config.ts
@@ -1,26 +1,56 @@
-import { defineConfig, configDefaults } from 'vitest/config';
+import { defineConfig, defineProject, configDefaults } from 'vitest/config';
 import path from 'node:path';
 
-// Extend project defaults in a local-only config.
-// CI remains on the default 'vitest.config.ts'.
 export default defineConfig({
-  test: {
-    setupFiles: ['tests/setup/vitest.setup.ts'],
-    include: ['**/__tests__/**/*.test.{ts,tsx,js,jsx}'],
-    exclude: [
-      ...configDefaults.exclude,
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/.git/**',
-    ],
-    // Single-threaded to reduce flakiness from shared state
-    maxThreads: 1,
-    minThreads: 1,
-    testTimeout: 10000,
-    hookTimeout: 10000,
-    // Resolve aliases if your project uses them (safe defaults)
-    alias: {
-      '@': path.resolve(__dirname, './'),
-    },
-  },
+  projects: [
+    // Dashboard / web UI tests (DOM needed)
+    defineProject({
+      test: {
+        name: 'web',
+        environment: 'jsdom',
+        globals: true,
+        setupFiles: ['tests/setup/vitest.setup.ts'],
+        include: [
+          'apps/**/__tests__/**/*.test.{ts,tsx,js,jsx}',
+          'apps/**/?(*.)+(spec|test).{ts,tsx,js,jsx}',
+        ],
+        exclude: [
+          ...configDefaults.exclude,
+          '**/node_modules/**',
+          '**/dist/**',
+          '**/.git/**',
+        ],
+        maxThreads: 1,
+        minThreads: 1,
+        testTimeout: 12000,
+        hookTimeout: 12000,
+        alias: { '@': path.resolve(__dirname, './') },
+      },
+    }),
+    // Everything else (packages, services): Node
+    defineProject({
+      test: {
+        name: 'node',
+        environment: 'node',
+        globals: true,
+        setupFiles: ['tests/setup/vitest.setup.ts'],
+        include: [
+          '**/__tests__/**/*.test.{ts,tsx,js,jsx}',
+          '?(*.)+(spec|test).{ts,tsx,js,jsx}',
+        ],
+        exclude: [
+          ...configDefaults.exclude,
+          'apps/**', // handled by web project
+          '**/node_modules/**',
+          '**/dist/**',
+          '**/.git/**',
+        ],
+        maxThreads: 1,
+        minThreads: 1,
+        testTimeout: 10000,
+        hookTimeout: 10000,
+        alias: { '@': path.resolve(__dirname, './') },
+      },
+    }),
+  ],
 });


### PR DESCRIPTION
Fixes `expect is not defined` by switching dashboard tests to jsdom + globals, rest to node + globals.
- Adds dev dep: jsdom
- Replaces local config with multi-project setup
- No runtime code touched

Non-negotiables preserved: tickets-only; no API orders.

### PR Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c030511308832ca9f748a48f3b558b