### PR TITLE
feat(types): ambient contracts R1 — typings + tsconfig include (no runtime changes)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,18 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "outDir": "dist",
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist", "build", "**/*.test-d.ts"]
+  "include": [
+    "**/*.ts",
+    "types/**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "build",
+    "**/*.test-d.ts"
+  ]
 }

--- a/types/global/contracts.d.ts
+++ b/types/global/contracts.d.ts
@@ -1,0 +1,45 @@
+/**
+ * Ambient canonical contracts for Prism-Apex (tickets-only architecture).
+ * Non-breaking typings merged globally; no runtime changes.
+ */
+declare namespace PrismApex {
+  type StrategyId = 'vwap-first-touch' | 'osb-breakout' | (string & {});
+  type Side = 'BUY' | 'SELL';
+  type GuardrailReason =
+    | 'STOP_REQUIRED'
+    | 'STOP_SIDE_INVALID'
+    | 'RR_OUT_OF_RANGE'
+    | 'SIZE_CLAMPED'
+    | 'TRAILING_DRAWDOWN'
+    | 'EOD_WINDOW'
+    | 'OUT_OF_HOURS'
+    | 'CONFIG_DISABLED'
+    | 'DUPLICATE_SIGNAL'
+    | 'SYMBOL_INVALID'
+    | (string & {});
+  interface TicketMeta {
+    strategy: StrategyId;
+    rr?: number;
+    guardrails?: string[];
+    sizingHint?: 'half-size' | 'normal' | 'reduced' | (string & {});
+    consistencyNotes?: string;
+  }
+  interface Ticket {
+    symbol: string;
+    side: Side;
+    entry: number;
+    stop: number;
+    target: number;
+    qty: number;
+    accountId: string;
+    timestampUtc: string; // ISO8601
+    meta?: TicketMeta;
+    accepted: boolean;
+    reasons?: GuardrailReason[] | string[];
+  }
+}
+// Convenience aliases (optional)
+type ApexTicket = PrismApex.Ticket;
+type ApexTicketMeta = PrismApex.TicketMeta;
+type ApexStrategyId = PrismApex.StrategyId;
+type ApexGuardrailReason = PrismApex.GuardrailReason;

--- a/types/global/env.d.ts
+++ b/types/global/env.d.ts
@@ -1,0 +1,11 @@
+declare namespace NodeJS {
+  interface ProcessEnv {
+    readonly NODE_ENV?: 'development' | 'test' | 'production';
+    readonly PORT?: string;
+    readonly CORS_ALLOWLIST?: string;       // comma-separated
+    readonly LOG_LEVEL?: 'debug' | 'info' | 'warn' | 'error';
+    readonly TV_API_BASE_URL?: string;      // Tradovate REST (read-only)
+    readonly TV_API_KEY?: string;
+    readonly TV_API_SECRET?: string;
+  }
+}

--- a/types/global/json.d.ts
+++ b/types/global/json.d.ts
@@ -1,0 +1,4 @@
+declare module '*.json' {
+  const value: unknown;
+  export default value;
+}

--- a/types/global/vitest.d.ts
+++ b/types/global/vitest.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vitest" />
+export {};


### PR DESCRIPTION
Ambient typings + tsconfig include to reduce TS errors without touching runtime code:
- types/global/contracts.d.ts (Ticket, TicketMeta, GuardrailReason, StrategyId)
- types/global/env.d.ts (ProcessEnv narrows; optional keys)
- types/global/json.d.ts (allow JSON imports)
- types/global/vitest.d.ts (Vitest globals)
- tsconfig.json: ensure `types/**/*.d.ts` is included

Tickets-only rule preserved; no API orders.

Typecheck snapshot after this change (grep): ~190 TS error hits remaining.

PR CHECKLIST
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c03c63a640832ca3a6865efc06fc16