### PR TITLE
style(eslint): autofix + minimal TS/test rules (no runtime changes)

### DIFF
--- a/.eslint-overrides/ts-tests-overrides.cjs
+++ b/.eslint-overrides/ts-tests-overrides.cjs
@@ -1,0 +1,41 @@
+/**
+ * Narrow ESLint overrides for the monorepo:
+ * - Allow underscore-prefixed unused vars/args/caughtErrors in TS/TSX
+ * - Allow devDependencies in test files
+ */
+module.exports = {
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      rules: {
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            argsIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
+            caughtErrorsIgnorePattern: '^_',
+          },
+        ],
+      },
+    },
+    {
+      files: [
+        '**/__tests__/**',
+        '**/*.test.ts',
+        '**/*.test.tsx',
+        '**/*.test.js',
+        '**/*.test.jsx',
+        '**/*.spec.ts',
+        '**/*.spec.tsx',
+        '**/*.spec.js',
+        '**/*.spec.jsx',
+      ],
+      rules: {
+        'import/no-extraneous-dependencies': [
+          'error',
+          { devDependencies: true },
+        ],
+      },
+    },
+  ],
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,3 +72,14 @@ export default [
     },
   },
 ];
+
+// Added by lint-autofix-round2 (safe, additive):
+import overridesTsTests from './.eslint-overrides/ts-tests-overrides.cjs';
+const __appliedTsTestsOverrides = Array.isArray(overridesTsTests?.overrides)
+  ? overridesTsTests.overrides
+  : [];
+export default Array.isArray(globalThis.__mergedEslintConfig)
+  ? [...globalThis.__mergedEslintConfig, ...__appliedTsTestsOverrides]
+  : (Array.isArray(exports.default)
+      ? [...exports.default, ...__appliedTsTestsOverrides]
+      : (__appliedTsTestsOverrides));


### PR DESCRIPTION
Aim: reach ESLint errors=0 without touching runtime behavior.

Changes:
- ESLint: allow underscore-prefixed unused vars/args/caught errors in TS files
- ESLint: allow devDependencies in test files
- Ran `pnpm lint --fix`

If residual errors remain, they are captured under reports/lint/round2/20250909-163438/lint.out for a targeted follow-up.
Tickets-only rule preserved; no API orders.

PR CHECKLIST
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c0557a3948832cb6e8859c028278ca