### PR TITLE
style(eslint): merge overrides without touching base config

### DIFF
--- a/.eslint/flat-merge.mjs
+++ b/.eslint/flat-merge.mjs
@@ -1,0 +1,11 @@
+// Compose base flat config with our targeted overrides (no mutation).
+import baseConfig from '../eslint.config.mjs';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+// Our overrides are CommonJS exports from .eslint-overrides/ts-tests-overrides.cjs
+const overridesMod = require('../.eslint-overrides/ts-tests-overrides.cjs');
+const overrides = Array.isArray(overridesMod?.overrides) ? overridesMod.overrides : [];
+
+const base = Array.isArray(baseConfig) ? baseConfig : (baseConfig ? [baseConfig] : []);
+export default [...base, ...overrides];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,14 +72,3 @@ export default [
     },
   },
 ];
-
-// Added by lint-autofix-round2 (safe, additive):
-import overridesTsTests from './.eslint-overrides/ts-tests-overrides.cjs';
-const __appliedTsTestsOverrides = Array.isArray(overridesTsTests?.overrides)
-  ? overridesTsTests.overrides
-  : [];
-export default Array.isArray(globalThis.__mergedEslintConfig)
-  ? [...globalThis.__mergedEslintConfig, ...__appliedTsTestsOverrides]
-  : (Array.isArray(exports.default)
-      ? [...exports.default, ...__appliedTsTestsOverrides]
-      : (__appliedTsTestsOverrides));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Prism Apex Tool monorepo",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint -c .eslint/flat-merge.mjs .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Fixes ESLint SyntaxError by restoring base eslint.config.mjs and using a separate merge config.
- Restore: eslint.config.mjs from base
- New: .eslint/flat-merge.mjs composes base + .eslint-overrides/ts-tests-overrides.cjs
- Update: package.json `lint` to `-c .eslint/flat-merge.mjs`
- Run: eslint --fix; capture results to reports/lint/round2_1/.../lint.out

No runtime code changes; tickets-only rule preserved.

PR Checklist:
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [x] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c05a588f14832c87ba246c62ae56e6