### PR TITLE
style(eslint): scope console for tests/scripts + autofix (no runtime changes)

### DIFF
--- a/.eslint-overrides/ts-tests-overrides.cjs
+++ b/.eslint-overrides/ts-tests-overrides.cjs
@@ -63,3 +63,20 @@ module.exports = {
     },
   ],
 };
+
+// L4: scope console usage to warn in test + scripts only
+module.exports.overrides = [
+  ...(module.exports.overrides || []),
+  {
+    files: [
+      '**/__tests__/**',
+      '**/*.test.*',
+      '**/*.spec.*',
+      'scripts/**',
+      'tools/**'
+    ],
+    rules: {
+      'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
+    },
+  },
+];

--- a/__tests__/helpers/assert.ts
+++ b/__tests__/helpers/assert.ts
@@ -3,7 +3,7 @@
  * Keeps TS happy when values may be undefined/null in fixtures.
  */
 export function ensureDefined<T>(value: T, msg = 'Expected value to be defined'): asserts value is NonNullable<T> {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+   
   if (value === undefined || value === null) {
     throw new Error(msg);
   }

--- a/apps/dashboard/tests/e2e/compliance-strip.spec.ts
+++ b/apps/dashboard/tests/e2e/compliance-strip.spec.ts
@@ -1,5 +1,3 @@
-import { ensureDefined } from '../../../../__tests__/helpers/assert';
-import { describe as _describe, it as _it, expect as _expect } from 'vitest';
 import { test, expect } from '@playwright/test';
 
 test('Compliance strip shows badges and EOD OK', async ({ page }) => {

--- a/apps/dashboard/tests/e2e/eod-block.spec.ts
+++ b/apps/dashboard/tests/e2e/eod-block.spec.ts
@@ -1,5 +1,3 @@
-import { ensureDefined } from '../../../../__tests__/helpers/assert';
-import { describe as _describe, it as _it, expect as _expect } from 'vitest';
 import { test, expect } from '@playwright/test';
 
 test.describe('EOD block modal & copy disabling', () => {

--- a/packages/indicators/__tests__/atr.spec.ts
+++ b/packages/indicators/__tests__/atr.spec.ts
@@ -1,4 +1,3 @@
-import { ensureDefined } from '../../__tests__/helpers/assert';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { describe, it, expect } from 'vitest';

--- a/packages/indicators/__tests__/swings.spec.ts
+++ b/packages/indicators/__tests__/swings.spec.ts
@@ -1,4 +1,3 @@
-import { ensureDefined } from '../../__tests__/helpers/assert';
 import { describe, it, expect } from 'vitest';
 import { swings, SwingPoint } from '../src/swings.js';
 import type { Bar1m } from '../src/types.js';

--- a/packages/indicators/__tests__/vwap.spec.ts
+++ b/packages/indicators/__tests__/vwap.spec.ts
@@ -1,4 +1,3 @@
-import { ensureDefined } from '../../__tests__/helpers/assert';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { describe, it, expect } from 'vitest';


### PR DESCRIPTION
Scopes `no-console` to warn in tests/scripts (keeps error elsewhere), preserves devDep/test overrides, runs autofix.
No runtime changes; tickets-only preserved.

- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c0a2a3f468832cba3117d03c9fef2e