### PR TITLE
chore(config): add APX-DDB-01 base maps (long-only)

### DIFF
--- a/config/products.json
+++ b/config/products.json
@@ -1,0 +1,9 @@
+{
+  "ES":  { "tickSize": 0.25, "tickValue": 12.5 },
+  "MES": { "tickSize": 0.25, "tickValue": 1.25 },
+  "NQ":  { "tickSize": 0.25, "tickValue": 5 },
+  "MNQ": { "tickSize": 0.25, "tickValue": 0.5 },
+  "GC":  { "tickSize": 0.10, "tickValue": 10 },
+  "MGC": { "tickSize": 0.10, "tickValue": 1 },
+  "CL":  { "tickSize": 0.01, "tickValue": 10 }
+}

--- a/config/roll.json
+++ b/config/roll.json
@@ -1,0 +1,6 @@
+{
+  "MES": { "month": "Z5", "note": "Resolve levels from ES=F; operator verifies month in Tradovate" },
+  "MNQ": { "month": "Z5", "note": "Resolve from NQ=F; operator verifies" },
+  "GC":  { "month": "Z5", "note": "Resolve from GC=F; operator verifies" },
+  "CL":  { "month": "Z5", "note": "Resolve from CL=F; operator verifies" }
+}

--- a/config/sessions.json
+++ b/config/sessions.json
@@ -1,0 +1,29 @@
+{
+  "tz": "America/Chicago",
+  "roots": {
+    "MES": {
+      "rth_start": "08:30:00",
+      "rth_end":   "15:00:00",
+      "no_new_after": "14:30:00",
+      "flat_by":      "15:00:00"
+    },
+    "MNQ": {
+      "rth_start": "08:30:00",
+      "rth_end":   "15:00:00",
+      "no_new_after": "14:30:00",
+      "flat_by":      "15:00:00"
+    },
+    "GC": {
+      "rth_start": "07:20:00",
+      "rth_end":   "12:30:00",
+      "no_new_after": "12:10:00",
+      "flat_by":      "12:30:00"
+    },
+    "CL": {
+      "rth_start": "08:00:00",
+      "rth_end":   "13:30:00",
+      "no_new_after": "13:10:00",
+      "flat_by":      "13:30:00"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add product tick specs, trading sessions, and roll hints for APX-DDB-01 (long-only, no-overnight)

## Testing
- `node -e 'const fs=require("fs"); ["config/products.json","config/sessions.json","config/roll.json"].forEach(p=>JSON.parse(fs.readFileSync(p,"utf8"))); console.log("JSON configs valid")'`
- `pnpm install`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `docker build -t prism-apex:ci .`

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable
- [ ] Contract/security/performance notes (if relevant)
- [x] Rollback steps (revert commit)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c517998cc0832c8294a2f721c5e608