### PR TITLE
chore(ci): add config-only validation and docker smoke for config PRs

### DIFF
--- a/.ci/docker-smoke.sh
+++ b/.ci/docker-smoke.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if ! docker info >/dev/null 2>&1; then
+  echo "⚠️  Docker daemon not available — skipping docker build smoke (non-blocking)."
+  exit 0
+fi
+echo "🐳 Docker daemon detected — building image…"
+docker build -t prism-apex:ci .
+echo "✅ Docker build completed."
+exit 0

--- a/.ci/validate-configs.js
+++ b/.ci/validate-configs.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const files = [
+  'config/products.json',
+  'config/sessions.json',
+  'config/roll.json'
+];
+try {
+  const parsed = files.map(p => [p, JSON.parse(fs.readFileSync(p, 'utf8'))]);
+  console.log('✅ JSON configs valid:');
+  for (const [p, obj] of parsed) {
+    const keys = Array.isArray(obj) ? obj.length + ' items' : Object.keys(obj).join(', ');
+    console.log(' -', p, '→', keys || '(ok)');
+  }
+  process.exit(0);
+} catch (e) {
+  console.error('❌ JSON config validation failed:', e && e.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add script to validate JSON config files
- add Docker smoke script that builds only when daemon is available

## Testing
- `node .ci/validate-configs.js`
- `.ci/docker-smoke.sh`

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [x] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c522a19a2c832caa27684b77360ead