### PR TITLE
feat(strategy-apx-ddb01): add long-only selector for APX-DDB-01

### DIFF
--- a/packages/strategy-apx-ddb01/package.json
+++ b/packages/strategy-apx-ddb01/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@prism-apex/strategy-apx-ddb01",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest -c vitest.config.ts"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/strategy-apx-ddb01/src/index.ts
+++ b/packages/strategy-apx-ddb01/src/index.ts
@@ -1,0 +1,1 @@
+export * from './selector.js';

--- a/packages/strategy-apx-ddb01/src/selector.ts
+++ b/packages/strategy-apx-ddb01/src/selector.ts
@@ -1,0 +1,41 @@
+export type LongOnlyPlan = {
+  side: 'Buy';
+  entry: number;
+  stopTicks: number;
+  rr: number;
+  notes: string;
+};
+
+export function planLongOnlyRetest(args: {
+  tickSize: number; // e.g., 0.25 (MES)
+  currentPrice: number; // latest price (delayed OK)
+  weeklyVwap: number; // weekly anchored VWAP value
+  priorHigh: number; // yesterday's RTH High
+  bufferTicks: number; // small cushion (e.g., 2)
+  minStopTicks: number; // product floor (e.g., MES 12)
+  rr: number; // requested RR (min 2)
+}): LongOnlyPlan | null {
+  const { tickSize, currentPrice, weeklyVwap, priorHigh, bufferTicks, minStopTicks } = args;
+  const rr = Math.max(2, args.rr ?? 2);
+
+  // Bias: long-only when price >= weekly VWAP, else no trade
+  if (!(currentPrice >= weeklyVwap)) return null;
+
+  // Entry = retest of priorHigh minus buffer
+  const entry = roundToTick(priorHigh - bufferTicks * tickSize, tickSize);
+
+  // Stop: at least minStopTicks below entry
+  const stopTicks = Math.max(minStopTicks, bufferTicks);
+
+  return {
+    side: 'Buy',
+    entry,
+    stopTicks,
+    rr,
+    notes: 'APX-DDB-01 long-only: prior RTH High retest with weekly VWAP bias up',
+  };
+}
+
+function roundToTick(price: number, tick: number): number {
+  return Number((Math.round(price / tick) * tick).toFixed(10));
+}

--- a/packages/strategy-apx-ddb01/test/selector.test.ts
+++ b/packages/strategy-apx-ddb01/test/selector.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { planLongOnlyRetest } from '../src/selector';
+
+describe('APX-DDB-01 long-only selector', () => {
+  const tick = 0.25;
+  it('returns a plan when price >= weekly VWAP', () => {
+    const p = planLongOnlyRetest({
+      tickSize: tick,
+      currentPrice: 5332.0,
+      weeklyVwap: 5320.0,
+      priorHigh: 5334.75,
+      bufferTicks: 2,
+      minStopTicks: 12,
+      rr: 2,
+    });
+    expect(p).not.toBeNull();
+    expect(p!.side).toBe('Buy');
+    expect(p!.stopTicks).toBeGreaterThanOrEqual(12);
+    expect(p!.entry).toBeCloseTo(5334.25, 5);
+  });
+
+  it('returns null when price < weekly VWAP', () => {
+    const p = planLongOnlyRetest({
+      tickSize: tick,
+      currentPrice: 5318.0,
+      weeklyVwap: 5320.0,
+      priorHigh: 5334.75,
+      bufferTicks: 2,
+      minStopTicks: 12,
+      rr: 2,
+    });
+    expect(p).toBeNull();
+  });
+
+  it('enforces rr >= 2 and rounds to tick', () => {
+    const p = planLongOnlyRetest({
+      tickSize: tick,
+      currentPrice: 5400.01,
+      weeklyVwap: 5300.0,
+      priorHigh: 5400.13,
+      bufferTicks: 1,
+      minStopTicks: 12,
+      rr: 1.2,
+    });
+    expect(p).not.toBeNull();
+    expect(p!.rr).toBeGreaterThanOrEqual(2);
+    expect(Number.isInteger(p!.entry / tick)).toBe(true);
+  });
+});

--- a/packages/strategy-apx-ddb01/tsconfig.json
+++ b/packages/strategy-apx-ddb01/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "strict": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/strategy-apx-ddb01/vitest.config.ts
+++ b/packages/strategy-apx-ddb01/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { include: ['test/**/*.test.ts'], watch: false, passWithNoTests: false },
+});


### PR DESCRIPTION
## Summary
- add `@prism-apex/strategy-apx-ddb01` package with VWAP-biased long-only selector
- include unit tests for VWAP bias, stop enforcement, and tick rounding

## Testing
- `pnpm install --silent`
- `pnpm lint` *(fails: Unexpected console statement, unused vars, extraneous deps)*
- `pnpm typecheck` *(fails: TS errors in unrelated packages)*
- `pnpm test` *(fails: various API and Playwright tests)*
- `pnpm --filter @prism-apex/strategy-apx-ddb01 build`
- `pnpm --filter @prism-apex/strategy-apx-ddb01 test`
- `.ci/docker-smoke.sh` *(skipped: Docker daemon not available)*

## PR Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c53dfbd020832c9bd1c6570396acc7