### PR TITLE
feat: add Yahoo delayed bar ingress microservice

### DIFF
--- a/apps/ingress-yahoo-dev/Dockerfile
+++ b/apps/ingress-yahoo-dev/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* ./
+RUN npm i -g pnpm@9 && pnpm fetch || true
+
+FROM node:20-alpine AS build
+WORKDIR /app
+RUN npm i -g pnpm@9
+COPY . .
+RUN pnpm -w -C packages/data-yahoo build && \
+    pnpm -w -C packages/risk-state build && \
+    pnpm -w -C packages/strategy-apx-ddb01 build && \
+    pnpm -w -C apps/ingress-yahoo-dev build
+
+FROM node:20-alpine
+WORKDIR /app
+RUN npm i -g pnpm@9
+COPY --from=build /app .
+ENV PORT=8080
+EXPOSE 8080
+CMD ["pnpm","-C","apps/ingress-yahoo-dev","start"]

--- a/apps/ingress-yahoo-dev/package.json
+++ b/apps/ingress-yahoo-dev/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@prism-apex/ingress-yahoo-dev",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/server.js",
+  "module": "dist/server.js",
+  "types": "dist/server.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "test": "vitest -c vitest.config.ts"
+  },
+  "dependencies": {
+    "@prism-apex/data-yahoo": "workspace:*",
+    "@prism-apex/risk-state": "workspace:*",
+    "@prism-apex/strategy-apx-ddb01": "workspace:*",
+    "express": "^4.19.2",
+    "morgan": "^1.10.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "supertest": "^7.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/apps/ingress-yahoo-dev/src/server.ts
+++ b/apps/ingress-yahoo-dev/src/server.ts
@@ -1,0 +1,242 @@
+import express, { Request, Response } from 'express';
+import morgan from 'morgan';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { barsFile, appendJSONL } from '@prism-apex/data-yahoo';
+import { initAVWAP, stepAVWAP, valueAVWAP } from '@prism-apex/data-yahoo';
+import { planLongOnlyRetest } from '@prism-apex/strategy-apx-ddb01';
+import { canAfford, addRisk, resetIfNewDay } from '@prism-apex/risk-state';
+
+const app: express.Express = express();
+app.use(express.json({ limit: '256kb' }));
+app.use(morgan('tiny'));
+
+// Feature flag (default off)
+const ENABLE = (process.env.APEX_ENABLE_YAHOO_INGRESS || 'false').toLowerCase() === 'true';
+const SECRET = process.env.APEX_YAHOO_SHARED_SECRET || '';
+const OUTDIR = process.env.APEX_TICKETS_OUTDIR || 'tickets';
+const ACCOUNT_RISK = Number(process.env.APEX_ACCOUNT_RISK_USD || '200');
+const MAX_DAILY_RISK = Number(process.env.APEX_MAX_DAILY_RISK_USD || '800');
+const MIN_RR = Number(process.env.APEX_MIN_RR || '2.0');
+const BUF_TICKS = Number(process.env.APEX_BUFFER_TICKS || '2');
+const LONG_ONLY = (process.env.APEX_LONG_ONLY || 'true').toLowerCase() === 'true';
+const DISABLE_NEWS = (process.env.APEX_NEWS_BLACKOUT || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+// Static configs
+const products = safeJson('config/products.json');
+const sessions = safeJson('config/sessions.json');
+const rollmap = safeJson('config/roll.json');
+
+function safeJson(p: string): any {
+  try {
+    return JSON.parse(readFileSync(p, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+app.post('/ingress/yahoo/v1/bar', async (req: Request, res: Response) => {
+  try {
+    if (!ENABLE) return res.status(403).json({ error: 'disabled' });
+    if (SECRET && req.headers['x-apex-secret'] !== SECRET)
+      return res.status(401).json({ error: 'unauthorized' });
+
+    const b = req.body || {};
+    const sym = String(b.symbol || '');
+    const ts = String(b.ts || '');
+    const H = Number(b.high),
+      L = Number(b.low),
+      C = Number(b.close),
+      V = Number(b.volume);
+
+    if (
+      !sym ||
+      !ts ||
+      !Number.isFinite(H) ||
+      !Number.isFinite(L) ||
+      !Number.isFinite(C) ||
+      !Number.isFinite(V)
+    )
+      return res.status(400).json({ error: 'bad payload' });
+    if (!(V > 0)) return res.json({ ok: true, skipped: 'no-volume' });
+
+    // Daily risk reset
+    const ymd = ts.slice(0, 10);
+    resetIfNewDay(ymd);
+
+    // Cache bar (append-only)
+    const pathBars = barsFile('.cache/bars', sym, ymd);
+    appendJSONL(pathBars, { symbol: sym, ts, high: H, low: L, close: C, volume: V });
+
+    // Weekly AVWAP state (by week key)
+    const wkKey = ymd.replace(/-/g, '').slice(0, 8);
+    const avDir = '.cache/avwap';
+    mkdirSync(avDir, { recursive: true });
+    const avFile = join(avDir, `${sym}.${wkKey}.json`);
+    let av = existsSync(avFile)
+      ? JSON.parse(readFileSync(avFile, 'utf8'))
+      : { tpv: 0, vol: 0, anchorISO: ts };
+    av = stepAVWAP(av, H, L, C, V);
+    writeFileSync(avFile, JSON.stringify(av));
+    const weeklyVwap = valueAVWAP(av);
+    if (!Number.isFinite(weeklyVwap)) return res.json({ ok: true, skipped: 'no-vwap' });
+
+    // Prior RTH High: naive (aggregate yesterday's bars). In production, slice RTH window from sessions.
+    const prev = new Date(ts);
+    prev.setUTCDate(prev.getUTCDate() - 1);
+    const prevYmd = prev.toISOString().slice(0, 10);
+    const prevFile = barsFile('.cache/bars', sym, prevYmd);
+    if (!existsSync(prevFile)) return res.json({ ok: true, skipped: 'no-prior' });
+    const lines = readFileSync(prevFile, 'utf8').trim().split('\n').filter(Boolean);
+    let priorHigh = -Infinity;
+    for (const ln of lines) {
+      const x = JSON.parse(ln);
+      if (typeof x.high === 'number' && x.high > priorHigh) priorHigh = x.high;
+    }
+    if (!(priorHigh > 0)) return res.json({ ok: true, skipped: 'bad-prior' });
+
+    // Root map (Yahoo continuous -> our root)
+    const root = mapRoot(sym);
+    if (!root) return res.json({ ok: true, skipped: 'root-map' });
+    if (!LONG_ONLY) return res.json({ ok: true, skipped: 'not-long-only' });
+
+    const tickSize = products[root]?.tickSize ?? 0.25;
+    const tickValue = products[root]?.tickValue ?? 1.25;
+    const minStop = { MES: 12, MNQ: 20, GC: 15, CL: 15 }[root] ?? 12;
+
+    // News blackout (simple time-key match placeholder)
+    if (isNewsBlackout(ts)) return res.json({ ok: true, skipped: 'news-blackout' });
+
+    // Plan (long-only)
+    const plan = planLongOnlyRetest({
+      tickSize,
+      currentPrice: C,
+      weeklyVwap,
+      priorHigh,
+      bufferTicks: BUF_TICKS,
+      minStopTicks: minStop,
+      rr: MIN_RR,
+    });
+    if (!plan) return res.json({ ok: true, skipped: 'no-plan' });
+
+    // Sizing & guardrails
+    const stopTicks = plan.stopTicks;
+    const riskPerContract = stopTicks * tickValue;
+    const qtyRaw = Math.floor(ACCOUNT_RISK / riskPerContract);
+    const maxContracts = 10; // configurable per root if desired
+    const qty = Math.max(1, Math.min(qtyRaw, maxContracts));
+    const worstCase = qty * riskPerContract;
+
+    if (!canAfford(worstCase, MAX_DAILY_RISK)) return res.json({ ok: true, skipped: 'daily-cap' });
+
+    // Targets & prices
+    const targetTicks = Math.round(plan.rr * stopTicks);
+    const entry = round(plan.entry, tickSize);
+    const stopPx = round(entry - stopTicks * tickSize, tickSize);
+    const tgtPx = round(entry + targetTicks * tickSize, tickSize);
+
+    // Resolve month for operator note
+    const month = rollmap[root]?.month || 'Z5';
+    const symbolForTicket = `${root}${month}`;
+
+    // Enforce no-overnight via expiry (set a safe cut-off; UI/operator still flattens manually)
+    const expiryISO = computeExpiry(ts, root);
+
+    const ticket = {
+      id: genId(),
+      ts,
+      symbol: symbolForTicket,
+      root,
+      side: 'Buy',
+      strategy: 'APX-DDB-01',
+      qty,
+      entry: { type: 'limit', price: entry },
+      stop: { type: 'stopMarket', price: stopPx, ticks: stopTicks },
+      targets: [{ type: 'limit', price: tgtPx, ticks: targetTicks, qty }],
+      rr: plan.rr,
+      tickSize,
+      tickValue,
+      expiry: expiryISO,
+      notes: `${plan.notes}; levels from ${sym}; month=${month}`,
+      meta: {
+        source: 'delayed-bias',
+        rulesApplied: {
+          accountRisk: ACCOUNT_RISK,
+          maxDailyRisk: MAX_DAILY_RISK,
+          minStopTicks: minStop,
+          rrMin: MIN_RR,
+        },
+        calc: { weeklyVwap, priorHigh, bufferTicks: BUF_TICKS },
+      },
+    };
+
+    // Persist ticket (append-only file)
+    const dayDir = join(OUTDIR, ymd);
+    mkdirSync(dayDir, { recursive: true });
+    const tPath = join(dayDir, `${symbolForTicket}.${ticket.id}.json`);
+    writeFileSyncAtomic(tPath, JSON.stringify(ticket, null, 2) + '\n');
+
+    // Book risk after successful write
+    addRisk(worstCase);
+
+    return res.json({ ok: true, ticket });
+  } catch (e: any) {
+    // JSON log error
+    console.error(
+      JSON.stringify({ level: 'error', msg: e?.message || 'internal', stack: e?.stack }),
+    );
+    return res.status(500).json({ error: 'internal' });
+  }
+});
+
+function mapRoot(y: string): 'MES' | 'MNQ' | 'GC' | 'CL' | null {
+  if (y === 'ES=F') return 'MES';
+  if (y === 'NQ=F') return 'MNQ';
+  if (y === 'GC=F') return 'GC';
+  if (y === 'CL=F') return 'CL';
+  return null;
+}
+function round(p: number, t: number) {
+  return Number((Math.round(p / t) * t).toFixed(10));
+}
+function genId() {
+  return Math.random().toString(36).slice(2, 10) + Date.now().toString(36).slice(-6);
+}
+function writeFileSyncAtomic(path: string, data: string) {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = path + '.tmp';
+  writeFileSync(tmp, data, 'utf8');
+  appendFileSync(path, ''); // ensure file handle state ok on some FS
+  // rename is atomic on POSIX; on some FS this is safe-enough for our JSON files
+  require('node:fs').renameSync(tmp, path);
+}
+function isNewsBlackout(_iso: string): boolean {
+  // Simple stub: if env contains any tokens, always skip (operator-defined calendar could be added)
+  return DISABLE_NEWS.length > 0;
+}
+function computeExpiry(iso: string, root: string): string {
+  try {
+    const tz = sessions?.tz || 'America/Chicago';
+    const r = sessions?.roots?.[root];
+    const flatBy = r?.flat_by || '15:00:00';
+    // Naive computation: same day flat_by; operator SOP still enforces manual flat
+    const day = iso.slice(0, 10);
+    return new Date(`${day}T${flatBy}Z`).toISOString();
+  } catch {
+    return new Date(Date.now() + 6 * 3600e3).toISOString();
+  }
+}
+
+const port = Number(process.env.PORT || 8080);
+app.get('/health', (_, _res) => _res.json({ ok: true, service: 'ingress-yahoo-dev' }));
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(
+      JSON.stringify({ level: 'info', msg: `ingress listening on ${port}`, enable: ENABLE }),
+    );
+  });
+}
+export default app;

--- a/apps/ingress-yahoo-dev/src/shims.d.ts
+++ b/apps/ingress-yahoo-dev/src/shims.d.ts
@@ -1,0 +1,4 @@
+declare module 'morgan';
+declare module '@prism-apex/data-yahoo';
+declare module '@prism-apex/strategy-apx-ddb01';
+declare module '@prism-apex/risk-state';

--- a/apps/ingress-yahoo-dev/test/ingress.test.ts
+++ b/apps/ingress-yahoo-dev/test/ingress.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { join, dirname } from 'node:path';
+import { mkdirSync, appendFileSync } from 'node:fs';
+import request from 'supertest';
+
+vi.mock('@prism-apex/data-yahoo', () => ({
+  barsFile: (base: string, sym: string, day: string) => join(base, `${sym}.${day}.jsonl`),
+  appendJSONL: (path: string, obj: any) => {
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, JSON.stringify(obj) + '\n');
+  },
+  stepAVWAP: (s: any, h: number, l: number, c: number, v: number) => {
+    const price = (h + l + c) / 3;
+    return { tpv: (s.tpv ?? 0) + price * v, vol: (s.vol ?? 0) + v, anchorISO: s.anchorISO ?? '' };
+  },
+  valueAVWAP: (s: any) => (s.vol ? s.tpv / s.vol : NaN),
+}));
+vi.mock('@prism-apex/strategy-apx-ddb01', () => ({
+  planLongOnlyRetest: (opts: any) => ({
+    entry: opts.currentPrice,
+    stopTicks: opts.minStopTicks,
+    rr: opts.rr,
+    notes: 'mock',
+  }),
+}));
+vi.mock('@prism-apex/risk-state', () => ({
+  canAfford: () => true,
+  addRisk: () => {},
+  resetIfNewDay: () => {},
+}));
+
+process.env.APEX_ENABLE_YAHOO_INGRESS = 'true';
+process.env.APEX_YAHOO_SHARED_SECRET = 's3cr3t';
+
+let app: any;
+beforeAll(async () => {
+  app = (await import('../src/server')).default;
+});
+
+describe('ingress/yahoo', () => {
+  it('rejects without secret', async () => {
+    const r = await request(app).post('/ingress/yahoo/v1/bar').send({});
+    expect(r.status).toBe(401);
+  });
+
+  it('skips zero volume', async () => {
+    const r = await request(app)
+      .post('/ingress/yahoo/v1/bar')
+      .set('x-apex-secret', 's3cr3t')
+      .send({
+        symbol: 'ES=F',
+        ts: '2025-09-12T14:31:00Z',
+        high: 10,
+        low: 9,
+        close: 9.5,
+        volume: 0,
+      });
+    expect(r.status).toBe(200);
+    expect(r.body.skipped || r.body?.skipped).toBeDefined();
+  });
+
+  it('accepts a plausible bar payload', async () => {
+    await request(app)
+      .post('/ingress/yahoo/v1/bar')
+      .set('x-apex-secret', 's3cr3t')
+      .send({
+        symbol: 'ES=F',
+        ts: '2025-09-11T14:31:00Z',
+        high: 5334.75,
+        low: 5330.25,
+        close: 5332.0,
+        volume: 1000,
+      });
+    const r = await request(app)
+      .post('/ingress/yahoo/v1/bar')
+      .set('x-apex-secret', 's3cr3t')
+      .send({
+        symbol: 'ES=F',
+        ts: '2025-09-12T14:31:00Z',
+        high: 5335.0,
+        low: 5331.0,
+        close: 5333.0,
+        volume: 1200,
+      });
+    expect(r.status).toBe(200);
+    expect(r.body.ok).toBe(true);
+    if (r.body.ticket) {
+      expect(r.body.ticket.symbol).toMatch(/^MES/);
+      expect(r.body.ticket.side).toBe('Buy');
+      expect(r.body.ticket.entry.price).toBeDefined();
+    }
+  });
+});

--- a/apps/ingress-yahoo-dev/tsconfig.json
+++ b/apps/ingress-yahoo-dev/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/ingress-yahoo-dev/vitest.config.ts
+++ b/apps/ingress-yahoo-dev/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+    watch: false,
+    passWithNoTests: false,
+  },
+});


### PR DESCRIPTION
## Summary
- add isolated ingress service for delayed Yahoo bars with feature flag and secret gate
- compute weekly AVWAP and prior RTH high to emit long-only APX-DDB-01 tickets with risk guardrails
- include Dockerfile and isolated tests

## Testing
- `pnpm --filter @prism-apex/ingress-yahoo-dev build`
- `pnpm --filter @prism-apex/ingress-yahoo-dev test`

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable
- [ ] Contract/security/performance notes
- [x] Rollback steps (revert PR; deletes only apps/ingress-yahoo-dev/)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c5423058c8832cb29d4b3a159ac187