### PR TITLE
chore(dashboard-lite): scoped typecheck + lint cleanup (no runtime changes)

### DIFF
--- a/.eslint/flat-merge.mjs
+++ b/.eslint/flat-merge.mjs
@@ -12,3 +12,7 @@ const base = Array.isArray(baseConfig) ? baseConfig : (baseConfig ? [baseConfig]
 // include dashboard-lite overrides
 import dl from '../.eslint-overrides/dashboard-lite.cjs';
 export default [...base, ...overrides, ...dl.overrides];
+
+// include dashboard-lite local app config
+import dl_app from '../apps/dashboard-lite/.eslint.app.cjs'
+export default [...base, ...cjs.overrides, ...(dl?.overrides||[]), ...(dl_app?.overrides||[])]

--- a/apps/dashboard-lite/.eslint.app.cjs
+++ b/apps/dashboard-lite/.eslint.app.cjs
@@ -1,0 +1,20 @@
+// Local app-only lint knobs (extends workspace flat config via merge)
+module.exports = {
+  overrides: [
+    {
+      files: ['**/*.{ts,tsx,js,jsx}'],
+      rules: {
+        // keep console relaxed here (warn), prod apps stay strict via workspace config
+        'no-console': ['warn', { allow: ['info', 'warn', 'error'] }],
+        // underscore-prefixed are intentional
+        '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      }
+    },
+    {
+      files: ['src/__tests__/**/*.{ts,tsx,js,jsx}','**/*.spec.*','**/*.test.*'],
+      rules: {
+        'import/no-extraneous-dependencies': 'off'
+      }
+    }
+  ]
+}

--- a/apps/dashboard-lite/.eslintignore
+++ b/apps/dashboard-lite/.eslintignore
@@ -1,0 +1,5 @@
+dist
+node_modules
+coverage
+*.log
+reports

--- a/apps/dashboard-lite/package.json
+++ b/apps/dashboard-lite/package.json
@@ -8,7 +8,10 @@
     "build": "tsc -b && vite build",
     "start": "NODE_ENV=production node dist-server/index.js",
     "test": "vitest --run",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
+    "lint": "eslint .",
+    "lintfix": "eslint . --fix"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.23
+      '@types/morgan':
+        specifier: 1.9.x
+        version: 1.9.10
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.11
@@ -1594,6 +1597,9 @@ packages:
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
+  '@types/morgan@1.9.10':
+    resolution: {integrity: sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==}
 
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
@@ -5496,6 +5502,10 @@ snapshots:
   '@types/minimatch@3.0.5': {}
 
   '@types/minimist@1.2.5': {}
+
+  '@types/morgan@1.9.10':
+    dependencies:
+      '@types/node': 20.19.11
 
   '@types/node@20.19.11':
     dependencies:


### PR DESCRIPTION
Adds package-local typecheck script (tsc -p tsconfig.typecheck.json --noEmit), app-level eslint ignores/overrides, and runs autofix. No runtime behavior changes; tickets-only preserved.

## PR Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c67f7fc0c0832caede56790d1adb86