### PR TITLE
chore(paths): TS aliases + Vitest resolution (R9; no runtime changes)

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -11,5 +11,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"]
+  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/apps/dashboard-lite/tsconfig.json
+++ b/apps/dashboard-lite/tsconfig.json
@@ -9,5 +9,10 @@
     "baseUrl": "./web/src",
     "paths": {}
   },
-  "include": ["web/src/**/*", "web/test/**/*"]
+  "include": ["web/src/**/*", "web/test/**/*"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -20,5 +20,10 @@
     "vite.config.ts",
     "vitest.config.ts"
   ],
-  "exclude": ["src/__tests__"]
+  "exclude": ["src/__tests__"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/apps/ingress-yahoo-dev/tsconfig.json
+++ b/apps/ingress-yahoo-dev/tsconfig.json
@@ -11,5 +11,10 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:unit:local": "vitest --config vitest.local.config.ts --run",
     "test:unit": "vitest --config ./vitest.local.config.ts --run",
     "test:e2e": "playwright test",
-    "test:ci": "pnpm -w run test:unit && pnpm -w run test:e2e"
+    "test:ci": "pnpm -w run test:unit && pnpm -w run test:e2e",
+    "test:unit:ws": "vitest --config vitest.workspace.ts --run"
   },
   "engines": {
     "node": ">=20 <21"
@@ -65,7 +66,8 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.7.0",
-    "vitest": "^2.0.0"
+    "vitest": "^2.0.0",
+    "vite-tsconfig-paths": "4.3.x"
   },
   "lint-staged": {
     "**/*.{ts,js,json,md,yml,yaml}": "prettier -w",

--- a/packages/accounts/tsconfig.json
+++ b/packages/accounts/tsconfig.json
@@ -13,5 +13,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"]
+  "include": ["src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -8,5 +8,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "src/**/*.d.ts", "src/**/*.ts", "types/**/*.d.ts"]
+  "include": ["src", "src/**/*.d.ts", "src/**/*.ts", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/audit/tsconfig.json
+++ b/packages/audit/tsconfig.json
@@ -9,5 +9,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"]
+  "include": ["src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/clients-tradovate/tsconfig.json
+++ b/packages/clients-tradovate/tsconfig.json
@@ -10,5 +10,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"]
+  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -12,5 +12,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"]
+  "include": ["src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/consistency/tsconfig.json
+++ b/packages/consistency/tsconfig.json
@@ -12,5 +12,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"]
+  "include": ["src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/data-yahoo/tsconfig.json
+++ b/packages/data-yahoo/tsconfig.json
@@ -11,5 +11,10 @@
     "strict": true,
     "rootDir": "."
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*", "test/**/*"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/indicators/tsconfig.json
+++ b/packages/indicators/tsconfig.json
@@ -12,5 +12,10 @@
     "moduleResolution": "node"
   },
   "include": ["src/**/*", "types/**/*.d.ts"],
-  "exclude": ["dist", "__tests__"]
+  "exclude": ["dist", "__tests__"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/metrics/tsconfig.json
+++ b/packages/metrics/tsconfig.json
@@ -12,5 +12,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"]
+  "include": ["src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/reporting/tsconfig.json
+++ b/packages/reporting/tsconfig.json
@@ -10,5 +10,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"]
+  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/risk-state/tsconfig.json
+++ b/packages/risk-state/tsconfig.json
@@ -11,5 +11,10 @@
     "strict": true,
     "rootDir": "."
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*", "test/**/*"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/rules-apex/tsconfig.json
+++ b/packages/rules-apex/tsconfig.json
@@ -12,5 +12,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"]
+  "include": ["src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/rules/tsconfig.json
+++ b/packages/rules/tsconfig.json
@@ -8,5 +8,10 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["__tests__", "src", "types/**/*.d.ts"]
+  "include": ["__tests__", "src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -7,5 +7,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["__tests__", "src", "types/**/*.d.ts"]
+  "include": ["__tests__", "src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -10,5 +10,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"]
+  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/signals/tsconfig.json
+++ b/packages/signals/tsconfig.json
@@ -10,5 +10,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"]
+  "include": ["src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/strategies/tsconfig.json
+++ b/packages/strategies/tsconfig.json
@@ -8,5 +8,10 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"]
+  "include": ["src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/strategy-apx-ddb01/tsconfig.json
+++ b/packages/strategy-apx-ddb01/tsconfig.json
@@ -11,5 +11,10 @@
     "strict": true,
     "rootDir": "."
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*", "test/**/*"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/packages/ticketizer/tsconfig.json
+++ b/packages/ticketizer/tsconfig.json
@@ -13,5 +13,10 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["src", "types/**/*.d.ts"]
+  "include": ["src", "types/**/*.d.ts"],
+  "references": [
+    {
+      "path": "../../tsconfig.paths.json"
+    }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       typescript-eslint:
         specifier: ^8.7.0
         version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+      vite-tsconfig-paths:
+        specifier: 4.3.x
+        version: 4.3.2(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.11)(lightningcss@1.30.1))
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
@@ -2771,6 +2774,9 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -4309,6 +4315,16 @@ packages:
       '@swc/wasm':
         optional: true
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -4437,6 +4453,14 @@ packages:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-tsconfig-paths@4.3.2:
+    resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@5.4.19:
     resolution: {integrity: sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==}
@@ -6976,6 +7000,8 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  globrex@0.1.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -8498,6 +8524,10 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  tsconfck@3.1.6(typescript@5.9.2):
+    optionalDependencies:
+      typescript: 5.9.2
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -8674,6 +8704,17 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.11)(lightningcss@1.30.1)):
+    dependencies:
+      debug: 4.4.1
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.2)
+    optionalDependencies:
+      vite: 5.4.19(@types/node@20.19.11)(lightningcss@1.30.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@5.4.19(@types/node@20.19.11)(lightningcss@1.30.1):
     dependencies:

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@prism-apex/accounts/*": ["packages/accounts/src/*"],
+      "@prism-apex/analytics/*": ["packages/analytics/src/*"],
+      "@prism-apex/audit/*": ["packages/audit/src/*"],
+      "@prism-apex/clients-tradovate/*": ["packages/clients-tradovate/src/*"],
+      "@prism-apex/config/*": ["packages/config/src/*"],
+      "@prism-apex/consistency/*": ["packages/consistency/src/*"],
+      "@prism-apex/indicators/*": ["packages/indicators/src/*"],
+      "@prism-apex/metrics/*": ["packages/metrics/src/*"],
+      "@prism-apex/reporting/*": ["packages/reporting/src/*"],
+      "@prism-apex/rules-apex/*": ["packages/rules-apex/src/*"],
+      "@prism-apex/rules/*": ["packages/rules/src/*"],
+      "@prism-apex/runtime/*": ["packages/runtime/src/*"],
+      "@prism-apex/sdk/*": ["packages/sdk/src/*"],
+      "@prism-apex/signals/*": ["packages/signals/src/*"],
+      "@prism-apex/strategies/*": ["packages/strategies/src/*"],
+      "@prism-apex/ticketizer/*": ["packages/ticketizer/src/*"],
+
+      "@prism-apex/app-api/*": ["apps/api/src/*"],
+      "@prism-apex/app-dashboard/*": ["apps/dashboard/src/*"],
+      "@prism-apex/app-dashboard-lite/*": ["apps/dashboard-lite/src/*"]
+    }
+  }
+}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,31 @@
+import { defineWorkspace } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+// Two projects: node (libs/api), jsdom (UIs)
+// Each project picks up tsconfig path aliases via plugin.
+export default defineWorkspace([
+  {
+    test: {
+      name: 'node',
+      environment: 'node',
+      include: [
+        'packages/**/?(*.)+(test|spec).{ts,tsx}',
+        'apps/api/**/?(*.)+(test|spec).{ts,tsx}'
+      ],
+      globals: true
+    },
+    plugins: [tsconfigPaths()]
+  },
+  {
+    test: {
+      name: 'jsdom',
+      environment: 'jsdom',
+      include: [
+        'apps/dashboard/**/?(*.)+(test|spec).{ts,tsx}',
+        'apps/dashboard-lite/**/?(*.)+(test|spec).{ts,tsx}'
+      ],
+      globals: true
+    },
+    plugins: [tsconfigPaths()]
+  }
+])


### PR DESCRIPTION
Adds central tsconfig.paths.json and Vitest workspace with vite-tsconfig-paths so tests resolve monorepo imports consistently. No runtime behavior changes.

## PR Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c6853110e4832cac45cfac808b1d53