### PR TITLE
chore: rename dashboard-lite compose override and add api dependency

### DIFF
--- a/apps/dashboard-lite/README.md
+++ b/apps/dashboard-lite/README.md
@@ -14,7 +14,7 @@ pnpm -w -C apps/dashboard-lite --silent exec vite --config web/vite.config.ts
 
 Build & Run (Docker)
 docker build -t prism-apex:dashboard-lite -f apps/dashboard-lite/Dockerfile .
-docker compose -f docker-compose.dashboard-lite.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.dashboard-lite.override.yml up -d
 # open http://localhost:5178
 
 API

--- a/docker-compose.dashboard-lite.override.yml
+++ b/docker-compose.dashboard-lite.override.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: apps/dashboard-lite/Dockerfile
+    depends_on:
+      - api
     image: prism-apex:dashboard-lite
     container_name: prism-apex-dashboard-lite
     environment:


### PR DESCRIPTION
## Summary
- rename dashboard lite compose file to override and add api dependency
- update docs to reference new compose override

## Testing
- `pnpm lint` *(fails: Unexpected console statement, unused imports, etc.)*
- `pnpm typecheck` *(fails: TS errors such as object possibly undefined)*
- `pnpm test` *(terminated: manual interrupt)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c68fd2f9c8832c82d0e97d8aa0f57c