### PR TITLE
docs: add smoke deploy instructions

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -56,11 +56,25 @@ Tear down
 docker compose down -v
 ```
 
+Dashboard Lite smoke deploy
+
+Use the compose override to run the API and dashboard-lite together:
+
+```bash
+./scripts/smoke_deploy.sh
+# or manually:
+docker compose -f docker-compose.yml -f docker-compose.dashboard-lite.override.yml up -d
+# Dashboard Lite: http://localhost:5178
+# API: http://localhost:3000
+# tear down
+docker compose down
+```
+
 Notes / Gotchas
 
 API build uses tsup (CJS output). Dev continues to use tsx.
 
-Dashboard is static and served by nginx. nginx.conf should proxy /api/\* to http://api:8000 (container hostname).
+Dashboard is static and served by nginx. nginx.conf should proxy /api/* to http://api:8000 (container hostname).
 
 If you change ports, also update:
 

--- a/apps/dashboard-lite/README.md
+++ b/apps/dashboard-lite/README.md
@@ -15,7 +15,12 @@ pnpm -w -C apps/dashboard-lite --silent exec vite --config web/vite.config.ts
 Build & Run (Docker)
 docker build -t prism-apex:dashboard-lite -f apps/dashboard-lite/Dockerfile .
 docker compose -f docker-compose.yml -f docker-compose.dashboard-lite.override.yml up -d
-# open http://localhost:5178
+# Dashboard Lite: http://localhost:5178
+# API: http://localhost:3000
+# or use helper script
+./scripts/smoke_deploy.sh
+# tear down
+docker compose down
 
 API
 


### PR DESCRIPTION
## Summary
- document smoke deploy steps with compose override and helper script

## Testing
- `pnpm install`
- `pnpm lint` (fails: React is defined but never used)
- `pnpm typecheck` (fails: Cannot find module '@prism-apex-tool/runtime/health')
- `pnpm test` (fails: Playwright Test did not expect test() to be called here)

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c6975bcfb8832caf0d46a8d0b979d2