### PR TITLE
chore(debug): run pnpm install with frozen lockfile

### DIFF
--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -75,7 +75,7 @@ Updates / redeploy
 
 ```
 sudo -u prism -H bash -lc 'cd ~/prism-apex-tool && git fetch && git checkout Test && git pull'
-sudo -u prism -H bash -lc 'pnpm install && pnpm --filter ./apps/api build'
+sudo -u prism -H bash -lc 'pnpm install --prefer-offline --frozen-lockfile && pnpm --filter ./apps/api build'
 sudo systemctl restart prism-apex
 ```
 

--- a/infra/systemd/install-prism-apex.sh
+++ b/infra/systemd/install-prism-apex.sh
@@ -26,7 +26,7 @@ fi
 
 # 3) Build app
 cd "$REPO_DIR"
-sudo -u "$APP_USER" pnpm install
+sudo -u "$APP_USER" pnpm install --prefer-offline --frozen-lockfile
 sudo -u "$APP_USER" pnpm --filter ./apps/api build
 
 # 4) Seed env file if missing


### PR DESCRIPTION
## Summary
- ensure debug collector uses `pnpm install --prefer-offline --frozen-lockfile`
- document frozen offline install for systemd deployments

## Testing
- `pnpm install --prefer-offline --frozen-lockfile`
- `pnpm lint` *(fails: 8 errors, 91 warnings)*
- `pnpm typecheck` *(fails: TS errors)*
- `pnpm test` *(fails: multiple test failures)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c69a017e2c832cac0bb2022aac6888