### PR TITLE
chore: add preflight script

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -1,5 +1,13 @@
 # Local Development & Production Parity
 
+## Preflight
+
+Check git, Node, pnpm, Docker, and API port:
+
+```bash
+bash scripts/preflight.sh
+```
+
 ## Dev (two terminals)
 
 - **API** (Terminal A):

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== git =="
+git --version
+
+echo "== node =="
+node --version
+
+echo "== pnpm =="
+pnpm --version
+
+echo "== docker =="
+if command -v docker >/dev/null 2>&1; then
+  docker --version
+  docker ps >/dev/null || echo "docker ps failed"
+else
+  echo "docker not found"
+fi
+
+PORT=${PORT:-3000}
+ENDPOINT=${ENDPOINT:-http://localhost:${PORT}/health}
+
+echo "== port ${PORT} =="
+if command -v ss >/dev/null 2>&1; then
+  if ss -ltn | grep -q ":${PORT} "; then
+    echo "Port ${PORT} is in use"
+  else
+    echo "Port ${PORT} is free"
+  fi
+else
+  echo "ss command not found; skipping port check"
+fi
+
+echo "== endpoint ${ENDPOINT} =="
+code=$(curl -sS -o /tmp/_preflight.body -w '%{http_code}' "${ENDPOINT}" || echo 000)
+echo "${ENDPOINT} -> ${code}"
+if [ "${code}" = "200" ]; then
+  head -n 20 /tmp/_preflight.body
+fi


### PR DESCRIPTION
## Summary
- add preflight script with git, Node, pnpm, Docker, port, and endpoint checks
- document preflight usage in README-dev

## Testing
- `pnpm install`
- `pnpm lint` *(fails: eslint errors)*
- `pnpm typecheck` *(fails: TS errors)*
- `pnpm test` *(fails: see logs)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (N/A)
- [ ] Rollback steps (and DOWN scripts if migrations) (N/A)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c6945bfd28832cae375262428533ec