### PR TITLE
Dashboards: add Lite (:5178) & Full (:8080) compose profiles

### DIFF
--- a/docker-compose.dashboard-full.yml
+++ b/docker-compose.dashboard-full.yml
@@ -1,0 +1,21 @@
+services:
+  dashboard-full:
+    build:
+      context: apps/dashboard
+    image: prism-apex/dashboard-full:local
+    container_name: prism-apex-dashboard-full
+    environment:
+      PORT: "8080"
+      APEX_TICKETS_DIR: "/data/tickets"
+      API_BASE_URL: "http://api:3000"
+    depends_on:
+      - api
+    ports:
+      - "8080:8080"
+    volumes:
+      - api-data:/data:ro
+    restart: unless-stopped
+
+volumes:
+  api-data:
+    external: false

--- a/docker-compose.dashboard-lite.yml
+++ b/docker-compose.dashboard-lite.yml
@@ -1,0 +1,21 @@
+services:
+  dashboard-lite:
+    build:
+      context: apps/dashboard-lite
+    image: prism-apex/dashboard-lite:local
+    container_name: prism-apex-dashboard-lite
+    environment:
+      DASHBOARD_LITE_PORT: "5178"
+      APEX_TICKETS_DIR: "/data/tickets"
+      API_BASE_URL: "http://api:3000"
+    depends_on:
+      - api
+    ports:
+      - "5178:5178"
+    volumes:
+      - api-data:/data:ro
+    restart: unless-stopped
+
+volumes:
+  api-data:
+    external: false


### PR DESCRIPTION
## Summary
- add docker-compose.dashboard-lite.yml for dashboard-lite on 5178
- add docker-compose.dashboard-full.yml for full dashboard on 8080
- optional profiles share read-only API tickets volume

## Testing
- `docker compose -f docker-compose.yml -f docker-compose.dashboard-lite.yml build` *(skipped: Docker CLI not found)*
- `docker compose -f docker-compose.yml -f docker-compose.dashboard-full.yml build` *(skipped: Docker CLI not found)*
- `pnpm lint` *(fails: see logs)*
- `pnpm typecheck` *(fails: see logs)*
- `pnpm test` *(fails: see logs)*

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [x] Contract/security/performance notes (N/A)
- [x] Rollback steps (revert PR)
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c6ad2a55e4832c9956fff48c425234