### PR TITLE
DX: add compose runners & dead-code scan script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bootstrap": "corepack enable && pnpm install",
     "validate": "pnpm -w run typecheck && pnpm -w run lint",
     "versions": "node -v && pnpm -v",
-    "scan:dead": "node tools/depcheck.mjs || true",
+    "scan:dead": "depcheck || true",
     "scan:strays": "git ls-files | egrep -i '\\.(bak|backup|old)$|(^|/)=?[0-9]{2,3}%$|(^|/)server\\.backup\\.|(^|/)\\]$' > reports/strays.txt || true",
     "docker:build": "docker build -t prism-apex-api:latest .",
     "docker:run": "docker run --rm -p 3000:3000 -e LOG_LEVEL=info -e TRUST_PROXY=true -v api-data:/data prism-apex-api:latest",
@@ -31,7 +31,9 @@
     "test:unit": "vitest --config ./vitest.local.config.ts --run",
     "test:e2e": "playwright test",
     "test:ci": "pnpm -w run test:unit && pnpm -w run test:e2e",
-    "test:unit:ws": "vitest --config vitest.workspace.ts --run"
+    "test:unit:ws": "vitest --config vitest.workspace.ts --run",
+    "compose:lite": "docker compose -f docker-compose.yml -f docker-compose.dashboard-lite.yml up -d --build",
+    "compose:full": "docker compose -f docker-compose.yml -f docker-compose.dashboard-full.yml up -d --build"
   },
   "engines": {
     "node": ">=20 <21"


### PR DESCRIPTION
Adds compose:up/lite/full and scan:dead (depcheck) to streamline local ops. No app code touched.

## Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c6ea37a600832cb1dfa176ffb1c2f1