### PR TITLE
API baseline: NodeNext TS + API-only build/typecheck/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Tests (non-blocking)
         run: pnpm -r test || true
 
+      - name: Typecheck (API)
+        run: pnpm run typecheck:api || true
+
+      - name: Tests (API)
+        run: pnpm run test:api || true
+
       - name: Upload workspace diagnostics on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/README-dev.md
+++ b/README-dev.md
@@ -32,3 +32,8 @@ If Docker is not installed locally, compose builds will be skipped. Install Dock
 Absolute rule
 
 The codebase must never introduce broker order placement (tickets-only). CI enforces this at PR time.
+
+### API-focused commands
+- `pnpm build:api` — build only the API workspace and its deps  
+- `pnpm typecheck:api` — typecheck API scope  
+- `pnpm test:api` — run API tests only  

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,11 +7,10 @@
     "packages/*"
   ],
   "scripts": {
-    "pretest": "pnpm -r --filter @prism-apex-tool/rules-apex --filter @prism-apex-tool/accounts --filter @prism-apex-tool/config --filter @prism-apex-tool/signals --filter @prism-apex-tool/analytics --filter @prism-apex-tool/audit --filter @prism-apex-tool/reporting --filter @prism-apex-tool/consistency --filter @prism-apex-tool/metrics --filter @prism-apex-tool/indicators --filter @prism-apex-tool/strategies --filter @prism-apex-tool/clients-tradovate build",
     "test:api": "vitest run --config apps/api/vitest.config.ts --reporter=verbose --passWithNoTests",
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.build.json",
-    "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
     "start": "node dist/index.js",
     "test": "vitest run --reporter=verbose --passWithNoTests",
     "coverage": "vitest run --config apps/api/vitest.config.ts --coverage",
@@ -55,5 +54,7 @@
     "@prism-apex-tool/metrics": "workspace:*",
     "@prism-apex-tool/sdk": "workspace:*",
     "@asteasolutions/zod-to-openapi": "^7.1.0"
-  }
+  },
+  "type": "module",
+  "main": "dist/server.js"
 }

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,22 +1,20 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": "src",
-    "declaration": true,
-    "declarationMap": true,
-    "paths": {},
-    "types": ["vitest/globals"],
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "moduleResolution": "node"
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": false,
+    "sourceMap": true,
+    "composite": false
   },
-  "include": ["src", "types/**/*.d.ts"],
+  "include": ["src/**/*"],
   "exclude": [
-    "src/__tests__/**",
-    "src/tests/**",
+    "**/*.test.ts",
     "**/*.spec.ts",
+    "node_modules",
+    "dist",
     "src/__tests__._archived/**",
+    "src/tests/**",
     "src/jobs/jobManagerTestHooks.ts"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "lint": "eslint -c .eslint/flat-merge.mjs .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --noEmit",
-    "test": "vitest run --reporter=verbose",
+    "typecheck": "pnpm run typecheck:api",
+    "test": "pnpm run test:api",
     "test:watch": "vitest",
-    "test:api": "pnpm --filter @prism-apex-tool/runtime build && pnpm --filter @prism-apex-tool/consistency build && pnpm --filter @prism-apex-tool/api test",
+    "test:api": "pnpm -r --filter @prism-apex-tool/api test",
     "coverage": "pnpm --filter ./apps/api test -- --coverage",
-    "build": "pnpm -r build",
+    "build": "pnpm run build:api",
     "prepare": "husky install",
     "clean": "rimraf node_modules dist coverage",
     "compose:up": "docker compose up -d --build",
@@ -25,7 +25,7 @@
     "docker:build": "docker build -t prism-apex-api:latest .",
     "docker:run": "docker run --rm -p 3000:3000 -e LOG_LEVEL=info -e TRUST_PROXY=true -v api-data:/data prism-apex-api:latest",
     "config:check": "node scripts/config-check.js",
-    "build:api": "pnpm -C apps/api build",
+    "build:api": "pnpm -r --filter @prism-apex-tool/api build",
     "services:start": "echo \"Use: docker compose up -d (API at http://localhost:3000). This script is a no-op for CI.\"",
     "test:unit:local": "vitest --config vitest.local.config.ts --run",
     "test:unit": "vitest --config ./vitest.local.config.ts --run",
@@ -35,7 +35,8 @@
     "compose:lite": "docker compose -f docker-compose.yml -f docker-compose.dashboard-lite.yml up -d --build",
     "compose:full": "docker compose -f docker-compose.yml -f docker-compose.dashboard-full.yml up -d --build",
     "scan:dead:deps": "depcheck || true",
-    "scan:dead:symbols": "ts-prune -p tsconfig.json || ts-prune -p tsconfig.build.json || true"
+    "scan:dead:symbols": "ts-prune -p tsconfig.json || ts-prune -p tsconfig.build.json || true",
+    "typecheck:api": "pnpm -r --filter @prism-apex-tool/api typecheck"
   },
   "engines": {
     "node": ">=20 <21"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,79 +1,16 @@
 {
   "compilerOptions": {
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "target": "ES2022",
-    "baseUrl": ".",
-    "paths": {
-      "@prism-apex-tool/sdk": [
-        "packages/sdk/src"
-      ],
-      "@prism-apex-tool/analytics": [
-        "packages/analytics/src"
-      ],
-      "@prism-apex-tool/audit": [
-        "packages/audit/src"
-      ],
-      "@prism-apex-tool/reporting": [
-        "packages/reporting/src"
-      ],
-      "@prism-apex-tool/signals": [
-        "packages/signals/src"
-      ],
-      "@prism-apex-tool/rules-apex": [
-        "packages/rules-apex/src"
-      ],
-      "@prism-apex-tool/rules/*": [
-        "packages/rules/src/*"
-      ],
-      "@prism-apex-tool/accounts": [
-        "packages/accounts/src/index.ts"
-      ],
-      "@prism-apex-tool/config": [
-        "packages/config/src"
-      ],
-      "@prism-apex-tool/clients-tradovate": [
-        "packages/clients-tradovate/src"
-      ],
-      "@prism-apex-tool/clients-tradovate/telemetry": [
-        "packages/clients-tradovate/src/telemetry.ts"
-      ],
-      "@prism-apex-tool/indicators": [
-        "packages/indicators/src"
-      ],
-      "@prism-apex-tool/strategies": [
-        "packages/strategies/src"
-      ],
-      "@prism-apex-tool/consistency": [
-        "packages/consistency/src"
-      ],
-      "@prism-apex-tool/ticketizer": [
-        "packages/ticketizer/src"
-      ]
-    },
+    "lib": ["ES2022"],
+    "strict": true,
+    "skipLibCheck": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noImplicitAny": true,
+    "isolatedModules": false,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
-    "types": [
-      "node",
-      "vitest/globals"
-    ]
-  },
-  "include": [
-    "apps/*/src",
-    "packages/*/src",
-    "types/**/*.d.ts"
-  ],
-  "exclude": [
-    "apps/dashboard",
-    "apps/e2e",
-    "sdks",
-    "**/*.spec.ts",
-    "**/__tests__/**"
-  ]
+    "noEmit": false
+  }
 }


### PR DESCRIPTION
## Summary
- set NodeNext/ES2022 baseline config
- wire API tsconfig build and workspace scripts
- add API-only checks in CI and docs

## Testing
- `pnpm lint` *(fails: Unexpected console statement, TS issues)*
- `pnpm typecheck` *(fails: missing modules and ESM path issues)*
- `pnpm test` *(fails: package entry resolution errors)*
- `pnpm build` *(fails: ESM import resolution errors)*

## Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced
- [ ] Lint/type/tests considered
- [ ] Docs updated (README/dev/ADR/CHANGELOG)
- [ ] Contract/security/performance impact assessed
- [ ] Rollback steps documented
- [ ] Deprecations noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c7167fb6d4832c9265cf83db7eee36