### PR TITLE
API: fix path aliases for typecheck/tests

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -42,3 +42,8 @@ The codebase must never introduce broker order placement (tickets-only). CI enfo
 - Runtime artifact is **CommonJS**: `apps/api/dist/server.cjs` (bundled by **tsup**).
 - Typechecking remains via `tsc --noEmit` using `tsconfig.build.json`.
 - If your entry file is not `src/server.ts`, update `apps/api/tsup.config.ts`.
+
+### Path aliases
+- TS path aliases are defined in `tsconfig.base.json` (e.g. `@api/*` → `apps/api/src/*`).
+- Vitest honors these via `vite-tsconfig-paths` and `tsconfig-paths/register` (`apps/api/test.setup.ts`).
+- If you change folder layout, update the `paths` map accordingly.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,7 +29,10 @@
     "eslint": "^9.10.0",
     "@eslint/js": "^9.10.0",
     "typescript-eslint": "^8.7.0",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "vite": "latest",
+    "vite-tsconfig-paths": "latest",
+    "tsconfig-paths": "latest"
   },
   "dependencies": {
     "@fastify/autoload": "6.3.1",

--- a/apps/api/test.setup.ts
+++ b/apps/api/test.setup.ts
@@ -1,0 +1,5 @@
+/**
+ * Ensure TS path aliases in tests work under Node by registering tsconfig paths.
+ * Vitest also receives vite-tsconfig-paths plugin for Vite-level resolution.
+ */
+import 'tsconfig-paths/register';

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,11 +1,16 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [
+    tsconfigPaths() // map TS path aliases for vitest/vite
+  ],
   test: {
     globals: true,
     environment: 'node',
     include: ['src/**/*.{test,spec}.ts'],
     exclude: ['node_modules', 'dist'],
+    setupFiles: ['test.setup.ts'],
     testTimeout: 20000,
     coverage: { reporter: ['text-summary', 'lcov'] }
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,12 @@
     "esModuleInterop": true,
     "isolatedModules": false,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": false
+    "noEmit": false,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"],
+      "@api/*": ["apps/api/src/*"],
+      "@pkg/*": ["packages/*/src"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add root `tsconfig.base.json` paths for common aliases
- Resolve aliases in API tests via `vite-tsconfig-paths` and `tsconfig-paths/register`
- Document alias setup for contributors

## Testing
- `pnpm lint` *(fails: eslint errors)*
- `pnpm typecheck` *(fails: missing workspace module types)*
- `pnpm test` *(fails: unresolved workspace packages)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c7361a0734832c91f6de89d34e1b29