### PR TITLE
chore: unify tsconfig path management

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -11,10 +11,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"]
 }

--- a/apps/dashboard-lite/tsconfig.json
+++ b/apps/dashboard-lite/tsconfig.json
@@ -9,10 +9,5 @@
     "baseUrl": "./web/src",
     "paths": {}
   },
-  "include": ["web/src/**/*", "web/test/**/*"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["web/src/**/*", "web/test/**/*"]
 }

--- a/apps/dashboard-lite/vitest.config.ts
+++ b/apps/dashboard-lite/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{ts,tsx}'],

--- a/apps/dashboard-lite/web/vitest.config.ts
+++ b/apps/dashboard-lite/web/vitest.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: { include: ['test/**/*.test.tsx'], watch: false, passWithNoTests: false },
 });

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -20,10 +20,5 @@
     "vite.config.ts",
     "vitest.config.ts"
   ],
-  "exclude": ["src/__tests__"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "exclude": ["src/__tests__"]
 }

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   test: {
     environment: 'jsdom',
     globals: true,

--- a/apps/ingress-yahoo-dev/tsconfig.json
+++ b/apps/ingress-yahoo-dev/tsconfig.json
@@ -11,10 +11,5 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src/**/*"]
 }

--- a/apps/ingress-yahoo-dev/vitest.config.ts
+++ b/apps/ingress-yahoo-dev/vitest.config.ts
@@ -1,25 +1,8 @@
 import { defineConfig } from 'vitest/config';
-import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      '@prism-apex/data-yahoo': resolve(__dirname, '..', '..', 'packages', 'data-yahoo', 'src'),
-      '@prism-apex/risk-state': resolve(__dirname, '..', '..', 'packages', 'risk-state', 'src'),
-      '@prism-apex/strategy-apx-ddb01': resolve(
-        __dirname,
-        '..',
-        '..',
-        'packages',
-        'strategy-apx-ddb01',
-        'src',
-      ),
-    },
-  },
+  plugins: [tsconfigPaths()],
   test: {
     include: ['test/**/*.test.ts'],
     environment: 'node',

--- a/packages/accounts/tsconfig.json
+++ b/packages/accounts/tsconfig.json
@@ -13,10 +13,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/accounts/vitest.config.ts
+++ b/packages/accounts/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
     globals: true,

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -8,10 +8,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "src/**/*.d.ts", "src/**/*.ts", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "src/**/*.d.ts", "src/**/*.ts", "types/**/*.d.ts"]
 }

--- a/packages/audit/tsconfig.json
+++ b/packages/audit/tsconfig.json
@@ -9,10 +9,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/audit/vitest.config.ts
+++ b/packages/audit/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
     globals: true,

--- a/packages/clients-tradovate/tsconfig.json
+++ b/packages/clients-tradovate/tsconfig.json
@@ -10,10 +10,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"]
 }

--- a/packages/clients-tradovate/vitest.config.ts
+++ b/packages/clients-tradovate/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
     globals: true,

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -12,10 +12,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/consistency/tsconfig.json
+++ b/packages/consistency/tsconfig.json
@@ -12,10 +12,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/data-yahoo/tsconfig.json
+++ b/packages/data-yahoo/tsconfig.json
@@ -11,10 +11,5 @@
     "strict": true,
     "rootDir": "."
   },
-  "include": ["src/**/*", "test/**/*"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/packages/data-yahoo/vitest.config.ts
+++ b/packages/data-yahoo/vitest.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     include: ['test/**/*.test.ts'],
     watch: false,

--- a/packages/indicators/tsconfig.json
+++ b/packages/indicators/tsconfig.json
@@ -12,10 +12,5 @@
     "moduleResolution": "node"
   },
   "include": ["src/**/*", "types/**/*.d.ts"],
-  "exclude": ["dist", "__tests__"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "exclude": ["dist", "__tests__"]
 }

--- a/packages/metrics/tsconfig.json
+++ b/packages/metrics/tsconfig.json
@@ -12,10 +12,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/reporting/tsconfig.json
+++ b/packages/reporting/tsconfig.json
@@ -10,10 +10,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"]
 }

--- a/packages/reporting/vitest.config.ts
+++ b/packages/reporting/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
     globals: true,

--- a/packages/risk-state/tsconfig.json
+++ b/packages/risk-state/tsconfig.json
@@ -11,10 +11,5 @@
     "strict": true,
     "rootDir": "."
   },
-  "include": ["src/**/*", "test/**/*"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/packages/risk-state/vitest.config.ts
+++ b/packages/risk-state/vitest.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: { include: ['test/**/*.test.ts'], watch: false, passWithNoTests: false },
 });

--- a/packages/rules-apex/tsconfig.json
+++ b/packages/rules-apex/tsconfig.json
@@ -12,10 +12,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/rules-apex/vitest.config.ts
+++ b/packages/rules-apex/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
     globals: true,

--- a/packages/rules/tsconfig.json
+++ b/packages/rules/tsconfig.json
@@ -8,10 +8,5 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["__tests__", "src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["__tests__", "src", "types/**/*.d.ts"]
 }

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -7,10 +7,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["__tests__", "src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["__tests__", "src", "types/**/*.d.ts"]
 }

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -10,10 +10,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts", "vitest.config.ts"]
 }

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,2 +1,7 @@
 import { defineConfig } from 'vitest/config';
-export default defineConfig({ test: { environment: 'node', globals: true } });
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: { environment: 'node', globals: true },
+});

--- a/packages/signals/tsconfig.json
+++ b/packages/signals/tsconfig.json
@@ -10,10 +10,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/signals/vitest.config.ts
+++ b/packages/signals/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
     globals: true,

--- a/packages/strategies/tsconfig.json
+++ b/packages/strategies/tsconfig.json
@@ -8,10 +8,5 @@
     "skipLibCheck": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/strategy-apx-ddb01/tsconfig.json
+++ b/packages/strategy-apx-ddb01/tsconfig.json
@@ -11,10 +11,5 @@
     "strict": true,
     "rootDir": "."
   },
-  "include": ["src/**/*", "test/**/*"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/packages/strategy-apx-ddb01/vitest.config.ts
+++ b/packages/strategy-apx-ddb01/vitest.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: { include: ['test/**/*.test.ts'], watch: false, passWithNoTests: false },
 });

--- a/packages/ticketizer/tsconfig.json
+++ b/packages/ticketizer/tsconfig.json
@@ -13,10 +13,5 @@
     "resolveJsonModule": true,
     "skipLibCheck": true
   },
-  "include": ["src", "types/**/*.d.ts"],
-  "references": [
-    {
-      "path": "../../tsconfig.paths.json"
-    }
-  ]
+  "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/ticketizer/vitest.config.ts
+++ b/packages/ticketizer/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
     globals: true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "NodeNext",
@@ -11,12 +12,6 @@
     "esModuleInterop": true,
     "isolatedModules": false,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": false,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["*"],
-      "@api/*": ["apps/api/src/*"],
-      "@pkg/*": ["packages/*/src"]
-    }
+    "noEmit": false
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
     globals: true,
     include: ['**/__tests__/**/*.spec.ts', '**/*.spec.ts'],


### PR DESCRIPTION
## Summary
- extend base tsconfig with centralized path mappings
- remove per-package path references
- enable vite-tsconfig-paths in vitest configs

## Testing
- `pnpm lint` *(fails: 8 errors, 107 warnings)*
- `pnpm typecheck` *(fails: Cannot find module '@prism-apex-tool/clients-tradovate/telemetry', ...)*
- `pnpm test` *(fails: Failed to resolve entry for package '@prism-apex-tool/signals')*

## PR Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c7b854ba88832c99a7a88a25feb2e0