### PR TITLE
chore: align vite-tsconfig-paths version

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,7 +31,7 @@
     "typescript-eslint": "^8.7.0",
     "prettier": "^3.3.3",
     "vite": "latest",
-    "vite-tsconfig-paths": "latest",
+    "vite-tsconfig-paths": "4.3.2",
     "tsconfig-paths": "latest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.7.0",
     "vitest": "^2.0.0",
-    "vite-tsconfig-paths": "4.3.x",
+    "vite-tsconfig-paths": "4.3.2",
     "ts-prune": "latest"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         specifier: ^8.7.0
         version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
       vite-tsconfig-paths:
-        specifier: 4.3.x
+        specifier: 4.3.2
         version: 4.3.2(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.11)(lightningcss@1.30.1))
       vitest:
         specifier: ^2.0.0
@@ -187,8 +187,8 @@ importers:
         specifier: latest
         version: 7.1.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)
       vite-tsconfig-paths:
-        specifier: latest
-        version: 5.1.4(typescript@5.9.2)(vite@7.1.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1))
+        specifier: 4.3.2
+        version: 4.3.2(typescript@5.9.2)(vite@7.1.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1))
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
@@ -4505,14 +4505,6 @@ packages:
 
   vite-tsconfig-paths@4.3.2:
     resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
-
-  vite-tsconfig-paths@5.1.4:
-    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
       vite: '*'
     peerDependenciesMeta:
@@ -8855,7 +8847,7 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@7.1.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)):
+  vite-tsconfig-paths@4.3.2(typescript@5.9.2)(vite@7.1.5(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2


### PR DESCRIPTION
## Summary
- align vite-tsconfig-paths to 4.3.2 across workspace
- refresh lockfile via pnpm install

## Testing
- `pnpm install`
- `pnpm lint` (fails: unused imports and lint errors)
- `pnpm typecheck` (fails: TS errors in api and packages)
- `pnpm test` (fails: ReferenceError in strategies config)

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (N/A)
- [ ] Contract/security/performance notes (N/A)
- [ ] Rollback steps (and DOWN scripts if migrations) (N/A)
- [ ] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c7d1e36c4c832c8c223ad2907ea6ad