### PR TITLE
docs: clarify path alias config

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -34,9 +34,9 @@ Absolute rule
 The codebase must never introduce broker order placement (tickets-only). CI enforces this at PR time.
 
 ### API-focused commands
-- `pnpm build:api` — build only the API workspace and its deps  
-- `pnpm typecheck:api` — typecheck API scope  
-- `pnpm test:api` — run API tests only  
+- `pnpm build:api` — build only the API workspace and its deps
+- `pnpm typecheck:api` — typecheck API scope
+- `pnpm test:api` — run API tests only
 
 ### API bundling
 - Runtime artifact is **CommonJS**: `apps/api/dist/server.cjs` (bundled by **tsup**).
@@ -44,6 +44,7 @@ The codebase must never introduce broker order placement (tickets-only). CI enfo
 - If your entry file is not `src/server.ts`, update `apps/api/tsup.config.ts`.
 
 ### Path aliases
-- TS path aliases are defined in `tsconfig.base.json` (e.g. `@api/*` → `apps/api/src/*`).
-- Vitest honors these via `vite-tsconfig-paths` and `tsconfig-paths/register` (`apps/api/test.setup.ts`).
+- TS path aliases are maintained in `tsconfig.paths.json`, which is extended by `tsconfig.base.json`.
+  Example: `@prism-apex/app-api/*` → `apps/api/src/*`.
+- Vitest uses `vite-tsconfig-paths` and `tsconfig-paths/register` to resolve these aliases (`apps/api/test.setup.ts`).
 - If you change folder layout, update the `paths` map accordingly.


### PR DESCRIPTION
## Summary
- document path alias locations and vitest resolution
- update alias example to `@prism-apex/app-api/*`

## Testing
- `pnpm install --silent`
- `pnpm lint` *(fails: 8 errors, 107 warnings)*
- `pnpm typecheck` *(fails: 82 errors in 35 files)*
- `pnpm test` *(fails: 7 failed, 1 passed, 2 skipped)*

## Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c7d3e06a28832cb1d4cc227d3afda0