### PR TITLE
feat(test): add tsconfig paths plugin to vitest local config

### DIFF
--- a/vitest.local.config.ts
+++ b/vitest.local.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig, defineProject, configDefaults } from 'vitest/config';
-import path from 'node:path';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   projects: [
     // Dashboard / web UI tests (DOM needed)
     defineProject({
+      plugins: [tsconfigPaths()],
       test: {
         name: 'web',
         environment: 'jsdom',
@@ -26,11 +27,11 @@ export default defineConfig({
         minThreads: 1,
         testTimeout: 12000,
         hookTimeout: 12000,
-        alias: { '@': path.resolve(__dirname, './') },
       },
     }),
     // Everything else (packages, services): Node
     defineProject({
+      plugins: [tsconfigPaths()],
       test: {
         name: 'node',
         environment: 'node',
@@ -53,7 +54,6 @@ export default defineConfig({
         minThreads: 1,
         testTimeout: 10000,
         hookTimeout: 10000,
-        alias: { '@': path.resolve(__dirname, './') },
       },
     }),
   ],


### PR DESCRIPTION
## Summary
- use vite-tsconfig-paths to resolve @prism-apex/* aliases in local Vitest config

## Testing
- `pnpm install`
- `pnpm lint` *(fails: Unexpected console statements and unused imports)*
- `pnpm typecheck` *(fails: many TS errors in apps/api)*
- `pnpm test:unit` *(terminated early; began running tests within node_modules)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c7e15f4f50832c909872ad6b40704b