### PR TITLE
test: cover planLongOnlyRetest and Yahoo helpers

### DIFF
--- a/packages/data-yahoo/test/io.test.ts
+++ b/packages/data-yahoo/test/io.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { barsFile, appendJSONL } from '../src/io';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+describe('file I/O helpers', () => {
+  it('builds a sanitized bars file path and ensures directory', () => {
+    const base = mkdtempSync(join(tmpdir(), 'bars-'));
+    const file = barsFile(base, 'BRK.B', '2024-01-01');
+    expect(file).toContain('BRK_B');
+    expect(file.endsWith('2024-01-01.jsonl')).toBe(true);
+    expect(existsSync(dirname(file))).toBe(true);
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('appends objects as JSON lines', () => {
+    const base = mkdtempSync(join(tmpdir(), 'bars-'));
+    const file = join(base, 'sample.jsonl');
+    appendJSONL(file, { a: 1 });
+    appendJSONL(file, { b: 2 });
+    const txt = readFileSync(file, 'utf8');
+    expect(txt.trim().split('\n')).toHaveLength(2);
+    rmSync(base, { recursive: true, force: true });
+  });
+});

--- a/packages/data-yahoo/test/vwap.test.ts
+++ b/packages/data-yahoo/test/vwap.test.ts
@@ -15,4 +15,11 @@ describe('weekly anchored VWAP', () => {
     const v = valueAVWAP(s);
     expect(Number.isFinite(v)).toBe(false);
   });
+
+  it('ignores non-positive volume', () => {
+    let s = initAVWAP('2025-09-08T13:30:00Z');
+    s = stepAVWAP(s, 10, 8, 9, -100);
+    const v = valueAVWAP(s);
+    expect(Number.isFinite(v)).toBe(false);
+  });
 });

--- a/packages/strategy-apx-ddb01/test/planLongOnlyRetest.test.ts
+++ b/packages/strategy-apx-ddb01/test/planLongOnlyRetest.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { planLongOnlyRetest } from '../src/selector';
 
-describe('APX-DDB-01 long-only selector', () => {
+describe('planLongOnlyRetest', () => {
   const tick = 0.25;
   it('returns a plan when price >= weekly VWAP', () => {
     const p = planLongOnlyRetest({
@@ -44,6 +44,7 @@ describe('APX-DDB-01 long-only selector', () => {
     });
     expect(p).not.toBeNull();
     expect(p!.rr).toBeGreaterThanOrEqual(2);
+    expect(p!.entry).toBe(5400);
     expect(Number.isInteger(p!.entry / tick)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add planLongOnlyRetest tests for valid, null, and tick-rounded scenarios
- add file I/O helper tests and extend VWAP coverage for Yahoo data

## Testing
- `pnpm --filter @prism-apex/strategy-apx-ddb01 test`
- `pnpm --filter @prism-apex/data-yahoo test`
- `pnpm lint` *(fails: Unexpected console statement; see logs)*
- `pnpm typecheck` *(fails: missing modules; see logs)*
- `pnpm test` *(fails: Cannot access '__dirname' before initialization)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [N/A] Contract/security/performance notes (if relevant)
- [N/A] Rollback steps (and DOWN scripts if migrations)
- [N/A] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c7e43daedc832cab8fb081602a9fd4