### PR TITLE
fix: resolve lint errors

### DIFF
--- a/apps/dashboard-lite/web/test/app.test.tsx
+++ b/apps/dashboard-lite/web/test/app.test.tsx
@@ -1,5 +1,4 @@
 import { describe, it, expect } from "vitest";
-import React from "react";
 
 describe("dashboard-lite ui", () => {
   it("placeholder", () => {

--- a/apps/ingress-yahoo-dev/src/server.ts
+++ b/apps/ingress-yahoo-dev/src/server.ts
@@ -3,7 +3,7 @@ import morgan from 'morgan';
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { barsFile, appendJSONL } from '@prism-apex/data-yahoo';
-import { initAVWAP, stepAVWAP, valueAVWAP } from '@prism-apex/data-yahoo';
+import { stepAVWAP, valueAVWAP } from '@prism-apex/data-yahoo';
 import { planLongOnlyRetest } from '@prism-apex/strategy-apx-ddb01';
 import { canAfford, addRisk, resetIfNewDay } from '@prism-apex/risk-state';
 

--- a/scripts/fix-api.mjs
+++ b/scripts/fix-api.mjs
@@ -103,7 +103,7 @@ async function patchServer(){
 
   // Remove any prior injected guard blobs / stray line
   s = s.replace(/\/\/\s*---\s*jobs guard[\s\S]*?(?=^\S|$)/gm, '');
-  s = s.replace(/^[ \t]*app\.\-zshRoute\);\r?\n?/m, '');
+  s = s.replace(/^[ \t]*app.-zshRoute\);\r?\n?/m, '');
 
   // 6) switch any dynamic app.register(import('./jobs/boot.js')) to static jobsBoot
   s = s.replace(/app\.register\(\s*import\('\.\/jobs\/boot\.js'\)\s*\)\s*;?/g, '');

--- a/scripts/fix-feed-final.mjs
+++ b/scripts/fix-feed-final.mjs
@@ -39,7 +39,7 @@ if (!/\bconst\s+cfg\s*=\s*getConfig\(\)/.test(s)) {
 
 // 4) Delete ALL hasAuth/clientEnv blocks; we’ll insert fresh ones (idempotent)
 s = s.replace(/^\s*const\s+hasAuth\s*=\s*Boolean\([\s\S]*?\)\s*;?\s*$/mg, '');
-s = s.replace(/^\s*const\s+clientEnv\s*[:\w\s<>\[\],]*=\s*\{\s*[\s\S]*?\}\s*;?\s*$/mg, '');
+s = s.replace(/^\s*const\s+clientEnv\s*[^=]*=\s*\{\s*[\s\S]*?\}\s*;?\s*$/mg, '');
 
 // 5) Insert fresh hasAuth + clientEnv immediately after cfg (once)
 s = s.replace(

--- a/scripts/fix-feed-solid.mjs
+++ b/scripts/fix-feed-solid.mjs
@@ -39,7 +39,7 @@ s = s.replace(/^\s*const\s+loginUrl\s*=\s*tvUrl\([^)]*\)\s*;\s*$/mg, '');
 //    b) remove ALL 'const hasAuth = ...' lines (we'll insert a clean one)
 s = s.replace(/^\s*const\s+hasAuth\s*=\s*.*;\s*$/mg, '');
 //    c) remove ALL 'const clientEnv ... = { ... }' blocks (we'll insert a clean one)
-s = s.replace(/^\s*const\s+clientEnv\s*[:\w\s<>\[\],]*=\s*\{\s*[\s\S]*?\}\s*;\s*$/mg, '');
+s = s.replace(/^\s*const\s+clientEnv\s*[^=]*=\s*\{\s*[\s\S]*?\}\s*;\s*$/mg, '');
 
 // 4) Ensure there is one cfg declaration. If missing, insert just after imports.
 if (!/\bconst\s+cfg\s*=\s*getConfig\(\)/.test(s)) {

--- a/scripts/fix-jobs-guard.mjs
+++ b/scripts/fix-jobs-guard.mjs
@@ -68,7 +68,7 @@ await (async () => {
     t = t.replace(/\/\/\s*---\s*jobs guard \(auto-injected\)[\s\S]*?(?=^\S|$\n?)/gm, '');
 
     // Remove the stray broken line if present
-    t = t.replace(/^[ \t]*app\.\-zshRoute\);\r?\n?/m, '');
+    t = t.replace(/^[ \t]*app.-zshRoute\);\r?\n?/m, '');
 
     // Idempotently append the onReady guard if missing
     if (!/app\.addHook\(\s*'onReady'/.test(t)) {

--- a/scripts/fix-server.mjs
+++ b/scripts/fix-server.mjs
@@ -63,7 +63,7 @@ if (!/app\.register\(\s*jobsBoot\s*\)/.test(s)) {
 
 // I) Remove previously injected “jobs guard” and any stray bogus line
 s = s.replace(/\/\/\s*---\s*jobs guard[\s\S]*?(?=^\S|$)/gm, '');
-s = s.replace(/^[ \t]*app\.\-zshRoute\);\r?\n?/m, '');
+s = s.replace(/^[ \t]*app.-zshRoute\);\r?\n?/m, '');
 
 // J) Final sanity trim of accidental duplicated cfg lines (rare)
 s = s.replace(/const\s+cfg\s*=\s*getConfig\(\);\s*const\s+cfg\s*=\s*getConfig\(\);/g, 'const cfg = getConfig();');

--- a/scripts/repair-feed.mjs
+++ b/scripts/repair-feed.mjs
@@ -21,7 +21,7 @@ s = s.replace(/^\s*const\s+loginUrl\s*=\s*tvUrl\([^)]*\)\s*;\s*$/m, '');
 // (3) Drop any duplicate cfg/hasAuth/clientEnv so we can reinsert cleanly
 s = s.replace(/^\s*const\s+cfg\s*=\s*getConfig\(\)\s*;\s*$/mg, '');
 s = s.replace(/^\s*const\s+hasAuth\s*=\s*.*;\s*$/mg, '');
-s = s.replace(/^\s*const\s+clientEnv\s*[:\w\s<>\[\],]*=\s*\{\s*[\s\S]*?\}\s*;\s*$/mg, '');
+s = s.replace(/^\s*const\s+clientEnv\s*[^=]*=\s*\{\s*[\s\S]*?\}\s*;\s*$/mg, '');
 
 // (4) Ensure exactly one cfg after imports
 if (!/\bconst\s+cfg\s*=\s*getConfig\(\)/.test(s)) {


### PR DESCRIPTION
## Summary
- remove unused imports
- drop unnecessary regex escapes in scripts

## Testing
- `pnpm lint`
- `pnpm typecheck` (fails: Relative import paths need explicit file extensions; Cannot find module '@prism-apex/rules-apex')
- `pnpm test` (fails: Cannot access '__dirname' before initialization)

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c7e6aaf250832c9e4f558153fbbd2f