### PR TITLE
fix(api): append .js extensions to local imports

### DIFF
--- a/apps/api/src/__tests__._archived/jobs.spec.skip.ts
+++ b/apps/api/src/__tests__._archived/jobs.spec.skip.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildServer } from '../server';
+import { buildServer } from '../server.js';
 import { startJobs } from '../jobs/scheduler.js';
-import { store } from '../store';
+import { store } from '../store.js';
 
 describe('job scheduler', () => {
   let app: ReturnType<typeof buildServer>;

--- a/apps/api/src/__tests__._archived/webhooks.tradingview.spec.skip.ts
+++ b/apps/api/src/__tests__._archived/webhooks.tradingview.spec.skip.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { normalizeSymbol } from '../routes/webhooks.tradingview';
+import { normalizeSymbol } from '../routes/webhooks.tradingview.js';
 
 let buildServer: typeof import('../server.js').buildServer;
 let Accounts: typeof import('../lib/accounts.js').Accounts;

--- a/apps/api/src/jobs/consistency.ts
+++ b/apps/api/src/jobs/consistency.ts
@@ -1,5 +1,5 @@
-import type { JobFn } from './scheduler';
-import { store } from '../store';
+import type { JobFn } from './scheduler.js';
+import { store } from '../store.js';
 
 export const jobConsistency: JobFn = () => {
   const rc = store.getRiskContext();

--- a/apps/api/src/jobs/dailyLoss.ts
+++ b/apps/api/src/jobs/dailyLoss.ts
@@ -1,5 +1,5 @@
-import type { JobFn } from './scheduler';
-import { store } from '../store';
+import type { JobFn } from './scheduler.js';
+import { store } from '../store.js';
 
 export const jobDailyLoss: JobFn = () => {
   const rc = store.getRiskContext();

--- a/apps/api/src/jobs/eodFlat.ts
+++ b/apps/api/src/jobs/eodFlat.ts
@@ -1,4 +1,4 @@
-import type { JobFn } from './scheduler';
+import type { JobFn } from './scheduler.js';
 import { jobManager } from '../lib/jobManager.js';
 
 let lastRun: number | undefined;

--- a/apps/api/src/jobs/jobManager.ts
+++ b/apps/api/src/jobs/jobManager.ts
@@ -1,9 +1,9 @@
-import { jobManager } from '../lib/jobManager';
+import { jobManager } from '../lib/jobManager.js';
 import {
   startJobs as schedulerStartJobs,
   stopJobs as schedulerStopJobs,
   resetJobsForTests,
-} from './scheduler';
+} from './scheduler.js';
 
 export async function startJobs() {
   await jobManager.startAll();

--- a/apps/api/src/jobs/jobManagerTestHooks.ts
+++ b/apps/api/src/jobs/jobManagerTestHooks.ts
@@ -1,5 +1,5 @@
-import { jobManager } from '../lib/jobManager';
-export { stopAllJobs, resetJobsForTests } from './jobManager';
+import { jobManager } from '../lib/jobManager.js';
+export { stopAllJobs, resetJobsForTests } from './jobManager.js';
 export function getJobManagerForTests() {
   return jobManager;
 }

--- a/apps/api/src/jobs/manager.ts
+++ b/apps/api/src/jobs/manager.ts
@@ -1,4 +1,4 @@
-import { jobManager } from '../lib/jobManager';
+import { jobManager } from '../lib/jobManager.js';
 
 export class JobManager {
   private static inst = jobManager;

--- a/apps/api/src/jobs/missingBrackets.ts
+++ b/apps/api/src/jobs/missingBrackets.ts
@@ -1,5 +1,5 @@
-import type { JobFn } from './scheduler';
-import { store } from '../store';
+import type { JobFn } from './scheduler.js';
+import { store } from '../store.js';
 
 let missing = false;
 

--- a/apps/api/src/lib/guard.ts
+++ b/apps/api/src/lib/guard.ts
@@ -1,11 +1,11 @@
-import { getConfig } from '../config/env';
+import { getConfig } from '../config/env.js';
 import {
   evaluateTicket,
   withinSuppressionWindow,
   TicketInput,
   suggestPercent,
 } from '@prism-apex/rules-apex';
-import { Accounts } from './accounts';
+import { Accounts } from './accounts.js';
 
 export type GuardSizing = {
   allowed?: number;

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-import { store } from '../store';
+import { store } from '../store.js';
 import { z } from 'zod';
 
 export async function alertsRoutes(app: FastifyInstance) {

--- a/apps/api/src/routes/compat.ts
+++ b/apps/api/src/routes/compat.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-import { store } from '../store';
+import { store } from '../store.js';
 import { z } from 'zod';
 import { randomUUID } from 'node:crypto';
 

--- a/apps/api/src/routes/ingest.ts
+++ b/apps/api/src/routes/ingest.ts
@@ -1,8 +1,8 @@
 import { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
-import { applyGuardWithSizing } from '../lib/guard';
-import { store } from '../store';
-import { alertSchema } from '../schemas/alert';
+import { applyGuardWithSizing } from '../lib/guard.js';
+import { store } from '../store.js';
+import { alertSchema } from '../schemas/alert.js';
 import type { TicketInput } from '@prism-apex/rules-apex';
 
 const TicketInputSchema = z.object({

--- a/apps/api/src/routes/notify.ts
+++ b/apps/api/src/routes/notify.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
-import { store } from '../store';
-import { recipientsSchema } from '../schemas/recipients';
+import { store } from '../store.js';
+import { recipientsSchema } from '../schemas/recipients.js';
 
 export const notifyRoutes: FastifyPluginAsync = async (app) => {
   app.post('/notify/recipients', async (req, reply) => {

--- a/apps/api/src/routes/report.ts
+++ b/apps/api/src/routes/report.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
-import { store } from '../store';
+import { store } from '../store.js';
 
 export const reportRoutes: FastifyPluginAsync = async (app) => {
   app.get('/report/daily', async (req, reply) => {

--- a/apps/api/src/routes/rules.ts
+++ b/apps/api/src/routes/rules.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
-import { checkCompliance } from '../services/rules/engine';
-import { accountStateSchema } from '../schemas/accountState';
+import { checkCompliance } from '../services/rules/engine.js';
+import { accountStateSchema } from '../schemas/accountState.js';
 
 export const rulesRoutes: FastifyPluginAsync = async (app) => {
   app.post('/rules/check', async (req, reply) => {

--- a/apps/api/src/routes/signals.ts
+++ b/apps/api/src/routes/signals.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import { osbSuggest, vwapFirstTouchSuggest, type Bar } from '@prism-apex/signals';
-import { applyGuardrails } from '../lib/guard';
+import { applyGuardrails } from '../lib/guard.js';
 
 export async function signalRoutes(app: FastifyInstance) {
   const BarSchema = z.object({

--- a/apps/api/src/routes/webhooks.tradingview.ts
+++ b/apps/api/src/routes/webhooks.tradingview.ts
@@ -1,12 +1,12 @@
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
-import { getConfig } from '../config/env';
-import { applyGuardWithSizing } from '../lib/guard';
+import { getConfig } from '../config/env.js';
+import { applyGuardWithSizing } from '../lib/guard.js';
 import type { TicketInput } from '@prism-apex/rules-apex';
-import { store } from '../store';
-import { alertSchema } from '../schemas/alert';
-import type { ParseResult } from '../types';
-import { ctEqual } from '../lib/ctEqual';
+import { store } from '../store.js';
+import { alertSchema } from '../schemas/alert.js';
+import type { ParseResult } from '../types.js';
+import { ctEqual } from '../lib/ctEqual.js';
 
 export function normalizeSymbol(sym: string): string {
   return sym.replace(/\d+!$/, '');

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -26,7 +26,7 @@ import jobsBoot from './jobs/boot.js';
 const cfg = getConfig();
 
 import { telemetryRoutes } from './routes/telemetry.js';
-import openapi from './routes/openapi';
+import openapi from './routes/openapi.js';
 import { jobManager } from './lib/jobManager.js';
 
 import { registerStrategiesJob } from './jobs/strategies.js';
@@ -34,10 +34,10 @@ import { registerTicketizerJob } from './jobs/ticketizer.js';
 import { registerTelemetryJob } from './jobs/telemetry.js';
 import { registerEodFlatJob } from './jobs/eodFlat.js';
 
-import { registerJob, startJobs, stopJobs } from './jobs/scheduler';
-import { jobMissingBrackets } from './jobs/missingBrackets';
-import { jobDailyLoss } from './jobs/dailyLoss';
-import { jobConsistency } from './jobs/consistency';
+import { registerJob, startJobs, stopJobs } from './jobs/scheduler.js';
+import { jobMissingBrackets } from './jobs/missingBrackets.js';
+import { jobDailyLoss } from './jobs/dailyLoss.js';
+import { jobConsistency } from './jobs/consistency.js';
 
 const DISABLE = process.env.DISABLE_JOBS === '1' || process.env.NODE_ENV === 'test';
 

--- a/apps/api/src/server.ts.bak.1757284653
+++ b/apps/api/src/server.ts.bak.1757284653
@@ -34,10 +34,10 @@ import { registerTicketizerJob } from './jobs/ticketizer.js';
 import { registerTelemetryJob } from './jobs/telemetry.js';
 import { registerEodFlatJob } from './jobs/eodFlat.js';
 
-import { registerJob, startJobs, stopJobs } from './jobs/scheduler';
-import { jobMissingBrackets } from './jobs/missingBrackets';
-import { jobDailyLoss } from './jobs/dailyLoss';
-import { jobConsistency } from './jobs/consistency';
+import { registerJob, startJobs, stopJobs } from './jobs/scheduler.js';
+import { jobMissingBrackets } from './jobs/missingBrackets.js';
+import { jobDailyLoss } from './jobs/dailyLoss.js';
+import { jobConsistency } from './jobs/consistency.js';
 
 const DISABLE = process.env.DISABLE_JOBS === '1' || process.env.NODE_ENV === 'test';
 

--- a/apps/api/src/server.ts.bak.1757285094
+++ b/apps/api/src/server.ts.bak.1757285094
@@ -34,10 +34,10 @@ import { registerTicketizerJob } from './jobs/ticketizer.js';
 import { registerTelemetryJob } from './jobs/telemetry.js';
 import { registerEodFlatJob } from './jobs/eodFlat.js';
 
-import { registerJob, startJobs, stopJobs } from './jobs/scheduler';
-import { jobMissingBrackets } from './jobs/missingBrackets';
-import { jobDailyLoss } from './jobs/dailyLoss';
-import { jobConsistency } from './jobs/consistency';
+import { registerJob, startJobs, stopJobs } from './jobs/scheduler.js';
+import { jobMissingBrackets } from './jobs/missingBrackets.js';
+import { jobDailyLoss } from './jobs/dailyLoss.js';
+import { jobConsistency } from './jobs/consistency.js';
 
 const DISABLE = process.env.DISABLE_JOBS === '1' || process.env.NODE_ENV === 'test';
 

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
-import type { Ticket as StoreTicket, ParseResult } from './types';
+import type { Ticket as StoreTicket, ParseResult } from './types.js';
 export type { Ticket } from './store/tickets.js';
 export type TicketType = import('./store/tickets.js').Ticket;
 

--- a/apps/api/src/tests/helpers/jobs.ts
+++ b/apps/api/src/tests/helpers/jobs.ts
@@ -1,4 +1,4 @@
-import { startJobs, stopAllJobs } from '../../jobs/jobManager';
+import { startJobs, stopAllJobs } from '../../jobs/jobManager.js';
 
 export function withJobs() {
   import('vitest').then(({ beforeAll, afterAll }) => {

--- a/apps/api/src/tests/telemetry.api.spec.ts
+++ b/apps/api/src/tests/telemetry.api.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { withJobs } from './helpers/jobs';
+import { withJobs } from './helpers/jobs.js';
 import { setJobBeat } from '@prism-apex/runtime';
 
 process.env.ENABLE_TELEMETRY = 'true';

--- a/apps/api/src/tests/ticketizer.api.spec.ts
+++ b/apps/api/src/tests/ticketizer.api.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { setJobBeat } from '@prism-apex/runtime';
 import { buildServer } from '../server.js';
 import { _clear, saveTicket } from '../store/tickets.js';
-import { withJobs } from './helpers/jobs';
+import { withJobs } from './helpers/jobs.js';
 
 withJobs();
 

--- a/apps/api/src/tests/tickets.store.spec.ts
+++ b/apps/api/src/tests/tickets.store.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import type { Ticket } from '../store';
+import type { Ticket } from '../store.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';


### PR DESCRIPTION
## Summary
- add `.js` extensions to local imports across API source and tests to satisfy ESM resolver

## Testing
- `pnpm install --silent`
- `pnpm lint` (warnings only)
- `pnpm typecheck` (fails: missing @prism-apex modules and declarations)
- `pnpm test` (fails: ReferenceError: Cannot access '__dirname' before initialization)

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI) N/A
- [ ] Contract/security/performance notes (if relevant) N/A
- [ ] Rollback steps (and DOWN scripts if migrations) N/A
- [ ] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c7eb8d01c0832c9fe58ad27bba4337