### PR TITLE
build: inherit NodeNext module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
     "strict": true,
     "noImplicitAny": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## Summary
- remove CommonJS and Node module resolution overrides to inherit NodeNext defaults

## Testing
- `pnpm lint` (fails: warnings)
- `pnpm typecheck` (fails: missing module declarations)
- `pnpm test` (fails: runtime and import errors)

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c7f1607c00832cba9c29ab1f71ce41