### PR TITLE
fix(api): resolve path without __dirname in strategy test

### DIFF
--- a/apps/api/src/tests/strategies.orchestrator.spec.ts
+++ b/apps/api/src/tests/strategies.orchestrator.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { publish, subscribe } from '../lib/bus.js';
 import {
@@ -72,11 +72,12 @@ vi.mock('@prism-apex/strategies', () => ({
   },
 }));
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const fixturesDir = fileURLToPath(new URL('../../fixtures', import.meta.url));
 
 function loadCsv(name: string): BarMessage[] {
   const lines = fs
-    .readFileSync(join(__dirname, '../../fixtures', name), 'utf8')
+    .readFileSync(join(fixturesDir, name), 'utf8')
     .trim()
     .split(/\n/)
     .slice(1);


### PR DESCRIPTION
## Summary
- avoid `__dirname` in `strategies.orchestrator.spec`

## Testing
- `pnpm lint` (warnings)
- `pnpm typecheck` (fails: Cannot find module '@prism-apex/rules-apex' and others)
- `pnpm test` (fails: ReferenceError: Cannot access `__dirname` before initialization)

## PR Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c7f314f3f4832c8ff2a312bd12dda6