### PR TITLE
fix: replace __dirname with fileURLToPath

### DIFF
--- a/packages/indicators/__tests__/atr.spec.ts
+++ b/packages/indicators/__tests__/atr.spec.ts
@@ -1,14 +1,17 @@
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { describe, it, expect } from 'vitest';
 import { atrWilderSeries, trueRange } from '../src/atr.js';
 import type { Bar1m } from '../src/types.js';
 
 function loadBars(symbol: string): Bar1m[] {
-  const lines = readFileSync(join(__dirname, 'golden', `${symbol}_1m_sample.csv`), 'utf-8')
-    .trim()
-    .split('\n')
-    .slice(1);
+  const filePath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'golden',
+    `${symbol}_1m_sample.csv`,
+  );
+  const lines = readFileSync(filePath, 'utf-8').trim().split('\n').slice(1);
   return lines.map((line) => {
     const [ts, open, high, low, close, volume] = line.split(',');
     return { ts, open: +open, high: +high, low: +low, close: +close, volume: +volume };

--- a/packages/indicators/__tests__/vwap.spec.ts
+++ b/packages/indicators/__tests__/vwap.spec.ts
@@ -1,14 +1,17 @@
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { describe, it, expect } from 'vitest';
 import { vwapSessionSeries, updateVwap, initialVwapState } from '../src/vwap.js';
 import type { Bar1m } from '../src/types.js';
 
 function loadBars(symbol: string): Bar1m[] {
-  const lines = readFileSync(join(__dirname, 'golden', `${symbol}_1m_sample.csv`), 'utf-8')
-    .trim()
-    .split('\n')
-    .slice(1);
+  const filePath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    'golden',
+    `${symbol}_1m_sample.csv`,
+  );
+  const lines = readFileSync(filePath, 'utf-8').trim().split('\n').slice(1);
   return lines.map((line) => {
     const [ts, open, high, low, close, volume] = line.split(',');
     return { ts, open: +open, high: +high, low: +low, close: +close, volume: +volume };

--- a/packages/strategies/src/config/strategy-config.js
+++ b/packages/strategies/src/config/strategy-config.js
@@ -1,10 +1,9 @@
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-const __dirname =
-  typeof __dirname !== 'undefined'
-    ? __dirname
-    : dirname(fileURLToPath(new URL('.', import.meta.url)));
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 export function loadStrategyConfig(key) {
   const filePath = join(__dirname, '../../../../configs/strategies', `${key}.json`);
   try {
@@ -14,6 +13,7 @@ export function loadStrategyConfig(key) {
     throw new Error(`Failed to load strategy config for ${key}: ${err.message}`);
   }
 }
+
 export function mergeParams(defaults, overrides) {
   return { ...defaults, ...(overrides ?? {}) };
 }


### PR DESCRIPTION
## Summary
- refactor strategy config to resolve paths from `import.meta.url`
- update ATR and VWAP tests to use `fileURLToPath` and `join`

## Testing
- `pnpm install`
- `pnpm lint` *(fails: 105 warnings)*
- `pnpm typecheck` *(fails: cannot find modules)*
- `pnpm test` *(fails: job already registered; undefined property)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (N/A)
- [x] Contract/security/performance notes (N/A)
- [x] Rollback steps (N/A)
- [x] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c7f76cc8f0832caf4fbc50087324cc