### PR TITLE
fix: add .js extension to relative imports

### DIFF
--- a/apps/api/__tests__/consistency.route.spec.ts
+++ b/apps/api/__tests__/consistency.route.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import Fastify from 'fastify';
-import consistencyRoute from '../src/routes/consistency';
+import consistencyRoute from '../src/routes/consistency.js';
 
 const VAR_DIR = path.resolve(process.cwd(), 'var', 'pnl');
 const FILE = path.join(VAR_DIR, 'daily.json');

--- a/apps/api/__tests__/ready.spec.ts
+++ b/apps/api/__tests__/ready.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import Fastify from 'fastify';
-import readyRoute from '../src/routes/ready';
+import readyRoute from '../src/routes/ready.js';
 import { setJobBeat } from '@prism-apex/runtime/health';
 
 describe('GET /ready', () => {

--- a/apps/api/test/rules/engine.test.ts
+++ b/apps/api/test/rules/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { checkCompliance, AccountState } from '../../src/services/rules/engine';
+import { checkCompliance, AccountState } from '../../src/services/rules/engine.js';
 
 describe('Compliance Rule Engine', () => {
   const base: AccountState = {

--- a/apps/dashboard-lite/src/main.tsx
+++ b/apps/dashboard-lite/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import { App } from './ui/App'
+import { App } from './ui/App.js'
 
 const el = document.getElementById('root')!
 createRoot(el).render(<App />)

--- a/apps/dashboard-lite/web/src/main.tsx
+++ b/apps/dashboard-lite/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
-import App from "./pages/App";
+import App from "./pages/App.js";
 
 const root = createRoot(document.getElementById("root")!);
 root.render(<App />);

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,10 +1,10 @@
 import { BrowserRouter, Routes, Route, Navigate, Link } from 'react-router-dom';
-import TicketsPage from './pages/Tickets';
-import PositionsPage from './pages/Positions';
-import { AlertsPanel } from './components/AlertsPanel';
-import { AccountStatus } from './components/AccountStatus';
-import { ReportsView } from './components/ReportsView';
-import { SystemStatus } from './components/SystemStatus';
+import TicketsPage from './pages/Tickets.js';
+import PositionsPage from './pages/Positions.js';
+import { AlertsPanel } from './components/AlertsPanel.js';
+import { AccountStatus } from './components/AccountStatus.js';
+import { ReportsView } from './components/ReportsView.js';
+import { SystemStatus } from './components/SystemStatus.js';
 
 export default function App() {
   return (

--- a/apps/dashboard/src/__tests__/App.test.tsx
+++ b/apps/dashboard/src/__tests__/App.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
  
-import App from '../App';
+import App from '../App.js';
 
 describe('App', () => {
   it('renders dashboard title', () => {

--- a/apps/dashboard/src/__tests__/Positions.test.tsx
+++ b/apps/dashboard/src/__tests__/Positions.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import PositionsPage from '../pages/Positions';
+import PositionsPage from '../pages/Positions.js';
 
 const positions = [{ contract: 'ESZ4', symbolRoot: 'ES', qty: 1, avgPrice: 100, unrealizedPnL: 2 }];
 

--- a/apps/dashboard/src/__tests__/Tickets.test.tsx
+++ b/apps/dashboard/src/__tests__/Tickets.test.tsx
@@ -36,7 +36,7 @@ const fetchMock = vi.fn().mockResolvedValue({
 });
 vi.stubGlobal('fetch', fetchMock);
 
-import TicketsPage from '../pages/Tickets';
+import TicketsPage from '../pages/Tickets.js';
 
 describe('TicketsPage', () => {
   it('toggles accepted/rejected filters', async () => {

--- a/apps/dashboard/src/components/AccountStatus.tsx
+++ b/apps/dashboard/src/components/AccountStatus.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { api } from '../lib/api';
+import { api } from '../lib/api.js';
 
 interface Status {
   balance: number;

--- a/apps/dashboard/src/components/AlertsPanel.tsx
+++ b/apps/dashboard/src/components/AlertsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { api } from '../lib/api';
+import { api } from '../lib/api.js';
 
 interface Alert {
   message: string;

--- a/apps/dashboard/src/components/ComplianceStrip.tsx
+++ b/apps/dashboard/src/components/ComplianceStrip.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComplianceSnapshot } from '../lib/api';
+import type { ComplianceSnapshot } from '../lib/api.js';
 
 export function ComplianceStrip({ data }: { data: ComplianceSnapshot | null }) {
   const Badge = ({ ok, label }: { ok: boolean; label: string }) => (

--- a/apps/dashboard/src/components/FiltersBar.tsx
+++ b/apps/dashboard/src/components/FiltersBar.tsx
@@ -1,4 +1,4 @@
-import { SYMBOLS, STRATEGIES } from '../constants';
+import { SYMBOLS, STRATEGIES } from '../constants.js';
 
 interface Props {
   date: string;

--- a/apps/dashboard/src/components/NextTicket.tsx
+++ b/apps/dashboard/src/components/NextTicket.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Ticket } from '../lib/api';
+import type { Ticket } from '../lib/api.js';
 
 function toText(t: Ticket) {
   return `${t.symbol} ${t.contract} ${t.side} x${t.qty} @ ${t.order.entry} | SL ${t.order.stop} | TP ${t.order.targets.join(', ')} | TIF ${t.order.tif}`;

--- a/apps/dashboard/src/components/PositionsOrders.tsx
+++ b/apps/dashboard/src/components/PositionsOrders.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Market, type Position, type Order } from '../lib/api';
+import { Market, type Position, type Order } from '../lib/api.js';
 
 export function PositionsOrders() {
   const [positions, setPositions] = useState<Position[]>([]);

--- a/apps/dashboard/src/components/ReportsView.tsx
+++ b/apps/dashboard/src/components/ReportsView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { api } from '../lib/api';
+import { api } from '../lib/api.js';
 
 interface Report {
   win_rate: number;

--- a/apps/dashboard/src/components/SystemStatus.tsx
+++ b/apps/dashboard/src/components/SystemStatus.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { api } from '../lib/api';
+import { api } from '../lib/api.js';
 
 export function SystemStatus() {
   const [status, setStatus] = useState<any>(null);

--- a/apps/dashboard/src/components/TicketsTable.tsx
+++ b/apps/dashboard/src/components/TicketsTable.tsx
@@ -1,4 +1,4 @@
-import { copyText } from '../lib/copy';
+import { copyText } from '../lib/copy.js';
 
 export interface Ticket {
   symbol: string;

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import App from './App';
+import App from './App.js';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/apps/dashboard/src/pages/Positions.tsx
+++ b/apps/dashboard/src/pages/Positions.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import PositionsTable from '../components/PositionsTable';
-import { fetchPositions, fetchAccount } from '../lib/telemetry';
+import PositionsTable from '../components/PositionsTable.js';
+import { fetchPositions, fetchAccount } from '../lib/telemetry.js';
 
 export default function PositionsPage() {
   const accountId = 'A1';

--- a/apps/dashboard/src/pages/Tickets.tsx
+++ b/apps/dashboard/src/pages/Tickets.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { FiltersBar } from '../components/FiltersBar';
-import { TicketsTable, Ticket } from '../components/TicketsTable';
-import { api } from '../lib/api';
+import { FiltersBar } from '../components/FiltersBar.js';
+import { TicketsTable, Ticket } from '../components/TicketsTable.js';
+import { api } from '../lib/api.js';
 
 export default function TicketsPage() {
   const today = new Date().toISOString().slice(0, 10);

--- a/docs/compliance/rule-engine.md
+++ b/docs/compliance/rule-engine.md
@@ -14,7 +14,7 @@ Codify Apex Trader Funding rules into machine-enforceable checks.
 ## Example
 
 ```ts
-import { checkCompliance, AccountState } from '../../apps/api/src/services/rules/engine';
+import { checkCompliance, AccountState } from '../../apps/api/src/services/rules/engine.js';
 
 const state: AccountState = {
   phase: 'evaluation',

--- a/packages/accounts/__tests__/schema.spec.ts
+++ b/packages/accounts/__tests__/schema.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateAccountsConfig } from '../src/schema';
+import { validateAccountsConfig } from '../src/schema.js';
 
 describe('accounts schema', () => {
   it('accepts a valid config', () => {

--- a/packages/accounts/src/index.d.ts
+++ b/packages/accounts/src/index.d.ts
@@ -1,2 +1,2 @@
-export * from './registry';
+export * from './registry.js';
 //# sourceMappingURL=index.d.ts.map

--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -1,2 +1,2 @@
 // Re-export the registry and types so consumers can `import { getAccounts } from '@prism-apex/accounts'`
-export * from './registry';
+export * from './registry.js';

--- a/packages/analytics/__tests__/index.spec.ts
+++ b/packages/analytics/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { trackEvent, trackError, meter, createAnalyticsScope } from '../src';
+import { trackEvent, trackError, meter, createAnalyticsScope } from '../src/index.js';
 
 describe('@prism-apex/analytics stub', () => {
   it('exports no-op functions without throwing', () => {

--- a/packages/data-yahoo/test/io.test.ts
+++ b/packages/data-yahoo/test/io.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { barsFile, appendJSONL } from '../src/io';
+import { barsFile, appendJSONL } from '../src/io.js';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';

--- a/packages/data-yahoo/test/vwap.test.ts
+++ b/packages/data-yahoo/test/vwap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { initAVWAP, stepAVWAP, valueAVWAP } from '../src/vwap';
+import { initAVWAP, stepAVWAP, valueAVWAP } from '../src/vwap.js';
 
 describe('weekly anchored VWAP', () => {
   it('accumulates over positive volume bars', () => {

--- a/packages/metrics/__tests__/consistency.spec.ts
+++ b/packages/metrics/__tests__/consistency.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeConsistency, type DailyPnL } from '../src/consistency';
+import { computeConsistency, type DailyPnL } from '../src/consistency.js';
 
 describe('computeConsistency', () => {
   it('eligible when total>0, >=5 profit days, bestDayShare<=0.30', () => {

--- a/packages/risk-state/test/risk-state.test.ts
+++ b/packages/risk-state/test/risk-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { existsSync, rmSync } from 'node:fs';
-import { getState, resetIfNewDay, canAfford, addRisk } from '../src/index';
+import { getState, resetIfNewDay, canAfford, addRisk } from '../src/index.js';
 
 const FILE = '.state/daily-risk.json';
 

--- a/packages/rules/src/index.ts
+++ b/packages/rules/src/index.ts
@@ -1,2 +1,2 @@
-export * from './apex';
-export * from './config';
+export * from './apex.js';
+export * from './config.js';

--- a/packages/runtime/__tests__/heartbeat.spec.ts
+++ b/packages/runtime/__tests__/heartbeat.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createHeartbeat } from '../src/heartbeat';
+import { createHeartbeat } from '../src/heartbeat.js';
 
 describe('heartbeat + stale detection', () => {
   let now = 0;

--- a/packages/strategies/__tests__/strategy.schema.spec.ts
+++ b/packages/strategies/__tests__/strategy.schema.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateStrategyConfig } from '../src/config/schema';
+import { validateStrategyConfig } from '../src/config/schema.js';
 
 describe('strategy schema (generic)', () => {
   it('accepts numeric params and time fields', () => {

--- a/packages/strategy-apx-ddb01/test/planLongOnlyRetest.test.ts
+++ b/packages/strategy-apx-ddb01/test/planLongOnlyRetest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { planLongOnlyRetest } from '../src/selector';
+import { planLongOnlyRetest } from '../src/selector.js';
 
 describe('planLongOnlyRetest', () => {
   const tick = 0.25;


### PR DESCRIPTION
## Summary
- ensure relative imports include `.js` extension across apps, packages, and tests
- update compliance rule engine doc import for ESM

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find module '@prism-apex/sdk', etc.)*
- `pnpm test` *(fails: 4 failed tests)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (N/A)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c7fa15dd80832cb4f93c56a9f70ae8