### PR TITLE
test: use fileURLToPath for ESM tests

### DIFF
--- a/packages/data-yahoo/test/io.test.ts
+++ b/packages/data-yahoo/test/io.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { barsFile, appendJSONL } from '../src/io.js';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 describe('file I/O helpers', () => {
   it('builds a sanitized bars file path and ensures directory', () => {
-    const base = mkdtempSync(join(tmpdir(), 'bars-'));
+    const base = mkdtempSync(join(dirname(fileURLToPath(import.meta.url)), 'bars-'));
     const file = barsFile(base, 'BRK.B', '2024-01-01');
     expect(file).toContain('BRK_B');
     expect(file.endsWith('2024-01-01.jsonl')).toBe(true);
@@ -15,7 +15,7 @@ describe('file I/O helpers', () => {
   });
 
   it('appends objects as JSON lines', () => {
-    const base = mkdtempSync(join(tmpdir(), 'bars-'));
+    const base = mkdtempSync(join(dirname(fileURLToPath(import.meta.url)), 'bars-'));
     const file = join(base, 'sample.jsonl');
     appendJSONL(file, { a: 1 });
     appendJSONL(file, { b: 2 });

--- a/packages/indicators/__tests__/atr.spec.ts
+++ b/packages/indicators/__tests__/atr.spec.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import { atrWilderSeries, trueRange } from '../src/atr.js';
 import type { Bar1m } from '../src/types.js';

--- a/packages/indicators/__tests__/vwap.spec.ts
+++ b/packages/indicators/__tests__/vwap.spec.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import { vwapSessionSeries, updateVwap, initialVwapState } from '../src/vwap.js';
 import type { Bar1m } from '../src/types.js';


### PR DESCRIPTION
## Summary
- use fileURLToPath-based joins in data-yahoo tests
- normalize indicator tests to node: builtins

## Testing
- `pnpm --filter @prism-apex/data-yahoo test`
- `pnpm --filter @prism-apex/indicators test` *(fails: No test files found)*
- `pnpm test` *(fails: Job MISSING_BRACKETS already registered)*


------
https://chatgpt.com/codex/tasks/task_b_68c80000ec5c832cb3c6fcd31f1493f5