### PR TITLE
fix: reference apex type aliases

### DIFF
--- a/packages/rules-apex/src/applyGuards.ts
+++ b/packages/rules-apex/src/applyGuards.ts
@@ -1,4 +1,6 @@
 /* type-only: guardrails decisions */
+import type { ApexGuardrailReason } from '../../../types/global/apex-types.js';
+
 type GuardrailDecision = {
   accepted: boolean;
   reasons: ApexGuardrailReason[];
@@ -27,7 +29,7 @@ export function applyGuardWithSizing(
 
   const policy = getPhasePolicy(ctx.phase);
 
-  const guardrails = [`phase:${ctx.phase}`] as const;
+  const guardrails = [`phase:${ctx.phase}`];
   guardrails.push(policy.requireStop ? 'stop-required' : 'stop-optional');
   guardrails.push('rr-clamp');
   if (policy.halfSizeUntilBuffer) guardrails.push('half-size-until-buffer');

--- a/packages/rules-apex/tsconfig.json
+++ b/packages/rules-apex/tsconfig.json
@@ -6,7 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": false,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "../../types/global"]
   },
   "include": ["src", "types/**/*.d.ts"]
 }

--- a/packages/strategies/src/osbBreakout.ts
+++ b/packages/strategies/src/osbBreakout.ts
@@ -1,4 +1,6 @@
 /* type-only: strategy IO contracts */
+import type { ApexStrategyId } from '../../../types/global/apex-types.js';
+
 interface Bar {
   time: number;
   open: number;
@@ -9,11 +11,12 @@ interface Bar {
 }
 interface Signal {
   symbol: string;
-  side: ApexStrategyId extends never ? 'BUY' | 'SELL' : 'BUY' | 'SELL';
+  side: 'BUY' | 'SELL';
   entry: number;
   stop: number;
   target: number;
   rr?: number;
+  strategy: ApexStrategyId;
 }
 
 import { Candle, Suggestion } from './types.js';

--- a/packages/strategies/src/vwapFirstTouch.ts
+++ b/packages/strategies/src/vwapFirstTouch.ts
@@ -1,4 +1,6 @@
 /* type-only: strategy IO contracts */
+import type { ApexStrategyId } from '../../../types/global/apex-types.js';
+
 interface Bar {
   time: number;
   open: number;
@@ -9,11 +11,12 @@ interface Bar {
 }
 interface Signal {
   symbol: string;
-  side: ApexStrategyId extends never ? 'BUY' | 'SELL' : 'BUY' | 'SELL';
+  side: 'BUY' | 'SELL';
   entry: number;
   stop: number;
   target: number;
   rr?: number;
+  strategy: ApexStrategyId;
 }
 
 import { Candle, Suggestion } from './types.js';

--- a/packages/strategies/tsconfig.json
+++ b/packages/strategies/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "../../types/global"]
   },
   "include": ["src", "types/**/*.d.ts"]
 }

--- a/types/global/apex-types.d.ts
+++ b/types/global/apex-types.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="./contracts.d.ts" />
+export type ApexStrategyId = PrismApex.StrategyId;
+export type ApexGuardrailReason = PrismApex.GuardrailReason;

--- a/types/global/index.d.ts
+++ b/types/global/index.d.ts
@@ -1,0 +1,4 @@
+/// <reference path="./contracts.d.ts" />
+/// <reference path="./env.d.ts" />
+/// <reference path="./json.d.ts" />
+/// <reference path="./vitest.d.ts" />


### PR DESCRIPTION
## Summary
- include shared global types in strategies and rules-apex builds
- replace ambient Apex types with explicit imports

## Testing
- `pnpm --filter @prism-apex/strategies build`
- `pnpm --filter @prism-apex/rules-apex build`
- `pnpm lint` *(warnings)*
- `pnpm typecheck` *(fails: Cannot find module '@prism-apex/config'...)*
- `pnpm test` *(fails: Job MISSING_BRACKETS already registered)*

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c8167e3370832c851e1af33f3f375d