### PR TITLE
chore: clean up lint warnings

### DIFF
--- a/.ci/validate-configs.js
+++ b/.ci/validate-configs.js
@@ -6,10 +6,10 @@ const files = [
 ];
 try {
   const parsed = files.map(p => [p, JSON.parse(fs.readFileSync(p, 'utf8'))]);
-  console.log('✅ JSON configs valid:');
+  console.info('✅ JSON configs valid:');
   for (const [p, obj] of parsed) {
     const keys = Array.isArray(obj) ? obj.length + ' items' : Object.keys(obj).join(', ');
-    console.log(' -', p, '→', keys || '(ok)');
+    console.info(' -', p, '→', keys || '(ok)');
   }
   process.exit(0);
 } catch (e) {

--- a/apps/api/src/jobs/feed.ts
+++ b/apps/api/src/jobs/feed.ts
@@ -27,7 +27,7 @@ export async function factory(_ctx: Ctx) {
   // Construct absolute login URL from BASE_URL
 
   // The clients-tradovate lib likely accepts config; pass absolute url + creds
-  const client = await createTradovateDemoClient(clientEnv as any);
+  const _client = await createTradovateDemoClient(clientEnv as any);
 
   return {
     async start() {

--- a/apps/api/src/store/tickets.ts
+++ b/apps/api/src/store/tickets.ts
@@ -69,13 +69,13 @@ export function listTickets(
   nextCursor?: number;
 } {
   const day = days.get(date) ?? [];
-  const slice = day.slice(cursor, cursor + limit).map(({ hash, ...t }) => t);
+  const slice = day.slice(cursor, cursor + limit).map(({ hash: _hash, ...t }) => t);
   const nextCursor = cursor + limit < day.length ? cursor + limit : undefined;
   return { items: slice, nextCursor };
 }
 
 export function exportTickets(date: string): Ticket[] {
-  return (days.get(date) ?? []).map(({ hash, ...t }) => t);
+  return (days.get(date) ?? []).map(({ hash: _hash, ...t }) => t);
 }
 
 export function getRecentTicketSizes(accountId: string, n = 10): number[] {

--- a/packages/accounts/src/cli.ts
+++ b/packages/accounts/src/cli.ts
@@ -15,7 +15,7 @@ function parseArgs(argv: string[]): Record<string, string> {
 }
 
 function help(): void {
-  console.log(`Usage: prism-accounts <command> [options]
+  console.info(`Usage: prism-accounts <command> [options]
 
 Commands:
   list
@@ -40,7 +40,7 @@ async function main(): Promise<void> {
     switch (cmd) {
       case 'list': {
         const accounts = await listAccounts(dataDir);
-        console.log(JSON.stringify(accounts, null, 2));
+        console.info(JSON.stringify(accounts, null, 2));
         break;
       }
       case 'add': {
@@ -54,7 +54,7 @@ async function main(): Promise<void> {
           bufferCleared: cleared,
           notes: opts['notes'],
         });
-        console.log(JSON.stringify(acct, null, 2));
+        console.info(JSON.stringify(acct, null, 2));
         break;
       }
       case 'set': {
@@ -67,7 +67,7 @@ async function main(): Promise<void> {
           bufferCleared: cleared,
           notes: opts['notes'],
         });
-        console.log(JSON.stringify(acct, null, 2));
+        console.info(JSON.stringify(acct, null, 2));
         break;
       }
       case 'get': {
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
         if (!id) throw new Error('id required');
         const acct = await readAccount(dataDir, id);
         if (!acct) throw new Error('not found');
-        console.log(JSON.stringify(acct, null, 2));
+        console.info(JSON.stringify(acct, null, 2));
         break;
       }
       default:

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -2,17 +2,17 @@ export type AnalyticsProps = Record<string, unknown>;
 export type AnalyticsTags = Record<string, string | number | boolean>;
 
 /** No-op event tracker (placeholder) */
-export function trackEvent(name: string, props: AnalyticsProps = {}): void {
+export function trackEvent(name: string, _props: AnalyticsProps = {}): void {
   // intentionally empty (stub)
 }
 
 /** No-op error tracker (placeholder) */
-export function trackError(error: unknown, context: AnalyticsProps = {}): void {
+export function trackError(error: unknown, _context: AnalyticsProps = {}): void {
   // intentionally empty (stub)
 }
 
 /** No-op metric emitter (placeholder) */
-export function meter(name: string, value: number, tags: AnalyticsTags = {}): void {
+export function meter(name: string, value: number, _tags: AnalyticsTags = {}): void {
   // intentionally empty (stub)
 }
 

--- a/packages/data-yahoo/src/replay-yahoo-bars.ts
+++ b/packages/data-yahoo/src/replay-yahoo-bars.ts
@@ -26,6 +26,6 @@ for (const b of arr) {
   av = stepAVWAP(av, Number(b.high), Number(b.low), Number(b.close), Number(b.volume));
 }
 const v = valueAVWAP(av);
-console.log(
+console.info(
   JSON.stringify({ weeklyVWAP: Number.isFinite(v) ? Number(v.toFixed(4)) : null }, null, 2),
 );

--- a/packages/strategies/src/osbBreakout.ts
+++ b/packages/strategies/src/osbBreakout.ts
@@ -1,24 +1,3 @@
-/* type-only: strategy IO contracts */
-import type { ApexStrategyId } from '../../../types/global/apex-types.js';
-
-interface Bar {
-  time: number;
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-  volume: number;
-}
-interface Signal {
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  entry: number;
-  stop: number;
-  target: number;
-  rr?: number;
-  strategy: ApexStrategyId;
-}
-
 import { Candle, Suggestion } from './types.js';
 import { AtrSeries, TickSpec } from './inputs.js';
 import { clamp, pricePlusTicks, rMultiple, ticksBetween } from './util.js';

--- a/packages/strategies/src/vwapFirstTouch.ts
+++ b/packages/strategies/src/vwapFirstTouch.ts
@@ -1,24 +1,3 @@
-/* type-only: strategy IO contracts */
-import type { ApexStrategyId } from '../../../types/global/apex-types.js';
-
-interface Bar {
-  time: number;
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-  volume: number;
-}
-interface Signal {
-  symbol: string;
-  side: 'BUY' | 'SELL';
-  entry: number;
-  stop: number;
-  target: number;
-  rr?: number;
-  strategy: ApexStrategyId;
-}
-
 import { Candle, Suggestion } from './types.js';
 import { VwapSeries, AtrSeries, TickSpec } from './inputs.js';
 import { clamp, last, rMultiple, ticksBetween, pricePlusTicks } from './util.js';

--- a/packages/ticketizer/__tests__/fanout.spec.ts
+++ b/packages/ticketizer/__tests__/fanout.spec.ts
@@ -119,7 +119,6 @@ describe('cap by plan & minQty', () => {
 
 describe('error isolation', () => {
   it('continues after broker error', async () => {
-    const accounts = mockAccounts as AccountRecord[];
     guard.mockReset();
     guard.mockReturnValue({ allow: true, ticket: { qty: 2 } });
     const placeOrder = vi


### PR DESCRIPTION
## Summary
- replace disallowed console calls with `console.info`
- mark unused variables and drop dead type declarations
- remove unused test helpers

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find module '@prism-apex/sdk'...)*
- `pnpm test` *(fails: Job MISSING_BRACKETS already registered; Cannot read properties of undefined)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [x] Rollback steps (and DOWN scripts if migrations)
- [x] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c821cd4a18832cb00e651b2dd5b9fa