### PR TITLE
test: reset job registries in API scheduler tests

### DIFF
--- a/apps/api/src/tests/helpers/jobs.ts
+++ b/apps/api/src/tests/helpers/jobs.ts
@@ -1,13 +1,17 @@
-import { startJobs, stopAllJobs } from '../../jobs/jobManager.js';
+import { startJobs, stopAllJobs, jobManager, resetJobsForTests } from '../../jobs/jobManager.js';
 
 export function withJobs() {
-  import('vitest').then(({ beforeAll, afterAll }) => {
-    beforeAll(async () => {
+  import('vitest').then(({ beforeEach, afterEach }) => {
+    beforeEach(async () => {
+      jobManager.resetForTests();
+      resetJobsForTests();
       process.env.DISABLE_JOBS = '0';
       await startJobs();
     });
-    afterAll(async () => {
+    afterEach(async () => {
       await stopAllJobs();
+      resetJobsForTests();
+      jobManager.resetForTests();
       process.env.DISABLE_JOBS = '1';
     });
   });

--- a/apps/api/src/tests/report.consistency.spec.ts
+++ b/apps/api/src/tests/report.consistency.spec.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { jobManager, resetJobsForTests } from '../jobs/jobManager.js';
 
 let buildServer: typeof import('../server.js').buildServer;
 
 beforeEach(async () => {
+  jobManager.resetForTests();
+  resetJobsForTests();
   ({ buildServer } = await import('../server.js'));
+});
+
+afterEach(() => {
+  resetJobsForTests();
+  jobManager.resetForTests();
 });
 
 describe('report consistency API', () => {

--- a/apps/api/src/tests/tickets.store.spec.ts
+++ b/apps/api/src/tests/tickets.store.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { jobManager, resetJobsForTests } from '../jobs/jobManager.js';
 import type { Ticket } from '../store.js';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -8,10 +9,17 @@ let buildServer: typeof import('../server.js').buildServer;
 let store: typeof import('../store/tickets.js');
 
 beforeEach(async () => {
+  jobManager.resetForTests();
+  resetJobsForTests();
   process.env.DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'tickets-'));
   ({ buildServer } = await import('../server.js'));
   store = await import('../store/tickets.js');
   store._clear();
+});
+
+afterEach(() => {
+  resetJobsForTests();
+  jobManager.resetForTests();
 });
 
 describe('ticket store', () => {


### PR DESCRIPTION
## Summary
- clear scheduler and job manager registries around API tests that start the job scheduler

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Module '@prism-apex/...' not found, etc.)*
- `pnpm test` *(fails: TypeError in strategies.orchestrator.spec.ts)*
- `pnpm -F @prism-apex/api test src/tests/report.consistency.spec.ts`

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c8257791c4832cbd00dbbcf79a0638