### PR TITLE
fix(data-yahoo): instantiate Ajv directly

### DIFF
--- a/packages/data-yahoo/src/schema.ts
+++ b/packages/data-yahoo/src/schema.ts
@@ -13,5 +13,5 @@ export const barSchema = {
   additionalProperties: false,
 } as const;
 
-const ajv = new Ajv.default({ allErrors: true, removeAdditional: true });
+const ajv = new Ajv({ allErrors: true, removeAdditional: true });
 export const validateBar = ajv.compile(barSchema);

--- a/packages/data-yahoo/tsconfig.json
+++ b/packages/data-yahoo/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "declarationMap": false,
     "sourceMap": false,
-    "rootDir": "."
+    "rootDir": ".",
+    "esModuleInterop": true
   },
   "include": ["src/**/*", "test/**/*"]
 }


### PR DESCRIPTION
## Summary
- instantiate Ajv without `.default` in data-yahoo schema
- explicitly enable esModuleInterop for the package

## Testing
- `pnpm install --silent`
- `pnpm lint` *(warn: 69 warnings)*
- `pnpm typecheck` *(fail: 30 errors in apps/api)*
- `pnpm --filter @prism-apex/data-yahoo exec tsc -p tsconfig.json --noEmit` *(fail: Ajv not constructable)*
- `pnpm test` *(fail: strategies.orchestrator spec)*

## PR Checklist
- [ ] Scope limited as described
- [ ] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [ ] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c82b90ed90832c89b76cceeaf0f50e