### PR TITLE
chore: run typecheck across packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint -c .eslint/flat-merge.mjs .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "pnpm run typecheck:api",
+    "typecheck": "pnpm --filter \"./packages/**\" typecheck",
     "test": "pnpm run test:api",
     "test:watch": "vitest",
     "test:api": "pnpm -r --filter @prism-apex/api test",


### PR DESCRIPTION
## Summary
- run package typechecks using workspace filter

## Testing
- `pnpm --filter "./packages/**" build` *(fails: TypeScript error in packages/data-yahoo)*
- `pnpm lint`
- `pnpm typecheck` *(fails: tsc error in packages/audit)*
- `pnpm test` *(fails: 1 failing test and recursive run error)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI) — N/A
- [x] Contract/security/performance notes (if relevant) — N/A
- [x] Rollback steps (and DOWN scripts if migrations) — revert commit
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c830025624832c955a771e0e16196c