### PR TITLE
fix: use ESM-safe __dirname in depcheck script

### DIFF
--- a/tools/depcheck.mjs
+++ b/tools/depcheck.mjs
@@ -1,17 +1,17 @@
 // Programmatic depcheck runner that respects .depcheckrc.json
 /* eslint-disable import/no-extraneous-dependencies, no-console */
 import fs from 'node:fs';
-import path from 'node:path';
+import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import depcheck from 'depcheck';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(__dirname, '..');
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
 
-const cfgPath = path.join(repoRoot, '.depcheckrc.json');
+const cfgPath = join(repoRoot, '.depcheckrc.json');
 // Output directory and file for depcheck results
-const outDir = path.join(repoRoot, 'reports');
-const outPath = path.join(outDir, 'depcheck.json');
+const outDir = join(repoRoot, 'reports');
+const outPath = join(outDir, 'depcheck.json');
 
 const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
 const options = {


### PR DESCRIPTION
## Summary
- ensure depcheck script derives __dirname via dirname(fileURLToPath(import.meta.url))

## Testing
- `pnpm lint`
- `pnpm typecheck` (fails: @prism-apex/audit@0.1.0 typecheck)
- `pnpm test`
- `node tools/depcheck.mjs`

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c8360e5c14832c9764d5ffe127a395