### PR TITLE
fix(data-yahoo): use Ajv 2020 CJS build

### DIFF
--- a/packages/data-yahoo/src/schema.ts
+++ b/packages/data-yahoo/src/schema.ts
@@ -1,4 +1,5 @@
-import Ajv from 'ajv';
+import Ajv from 'ajv/dist/2020.js';
+
 export const barSchema = {
   type: 'object',
   properties: {

--- a/packages/data-yahoo/src/types/ajv-dist-2020.d.ts
+++ b/packages/data-yahoo/src/types/ajv-dist-2020.d.ts
@@ -1,0 +1,6 @@
+declare module 'ajv/dist/2020.js' {
+  import Ajv2020 from 'ajv/dist/2020';
+
+  export default Ajv2020;
+  export * from 'ajv/dist/2020';
+}


### PR DESCRIPTION
## Summary
- import Ajv from `ajv/dist/2020.js` to instantiate the validator with CJS-compatible typings
- add a local module declaration so TypeScript recognizes the default export when targeting NodeNext

## Testing
- pnpm --filter @prism-apex/data-yahoo exec tsc -p tsconfig.json --noEmit

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c83f639eb8832c9b1fc99ffe45a3f3