### PR TITLE
feat: add audit JSONL reader

### DIFF
--- a/packages/audit/src/__tests__/readers.spec.ts
+++ b/packages/audit/src/__tests__/readers.spec.ts
@@ -8,7 +8,55 @@ describe('audit readers', () => {
       '{"event_type":"PANIC","details":{"reason":"test"}}',
     ];
     const events = readEventsFromLines(lines);
-    expect(events.length).toBe(2);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ type: 'TICKET', id: 1 });
+    expect(events[0].details).toEqual({ id: 1 });
     expect(events[1]).toMatchObject({ type: 'PANIC', reason: 'test' });
+    expect(events[1].details).toEqual({ reason: 'test' });
+  });
+
+  it('ignores blank, malformed, and non-object lines', () => {
+    const lines = [
+      '   ',
+      'not json',
+      '{"event_type":"TRADE","details":{"pnl":250,"fees":5},"timestamp":"2025-02-01T00:00:00Z"}',
+      '42',
+      '{"event_type":"RULE_CHECK","details":null}',
+    ];
+    const events = readEventsFromLines(lines);
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      type: 'TRADE',
+      timestamp: '2025-02-01T00:00:00Z',
+      pnl: 250,
+      fees: 5,
+    });
+    expect(events[0].details).toEqual({ pnl: 250, fees: 5 });
+    expect(events[1]).toMatchObject({ type: 'RULE_CHECK' });
+    expect(events[1].details).toBeNull();
+  });
+
+  it('does not override top-level fields when merging details', () => {
+    const lines = [
+      JSON.stringify({
+        event_type: 'PANIC',
+        type: 'ORIGINAL',
+        message: 'Operator panic button pressed',
+        details: {
+          type: 'DETAIL',
+          reason: 'system',
+          message: 'should not override',
+        },
+      }),
+    ];
+    const [event] = readEventsFromLines(lines);
+    expect(event.type).toBe('PANIC');
+    expect(event.message).toBe('Operator panic button pressed');
+    expect(event.reason).toBe('system');
+    expect(event.details).toEqual({
+      type: 'DETAIL',
+      reason: 'system',
+      message: 'should not override',
+    });
   });
 });

--- a/packages/audit/src/audit.ts
+++ b/packages/audit/src/audit.ts
@@ -1,3 +1,64 @@
+export interface AuditEvent {
+  type?: string;
+  timestamp?: string;
+  message?: string;
+  details?: unknown;
+  [key: string]: unknown;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function readEventsFromLines(lines: Iterable<string>): AuditEvent[] {
+  const events: AuditEvent[] = [];
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (!isPlainRecord(parsed)) {
+      continue;
+    }
+
+    const { event_type, details, ...rest } = parsed;
+
+    const event: AuditEvent = { ...rest };
+
+    if (typeof event_type === 'string') {
+      event.type = event_type;
+    }
+
+    if (details !== undefined) {
+      if (isPlainRecord(details)) {
+        const clonedDetails = { ...details };
+        event.details = clonedDetails;
+
+        for (const [key, value] of Object.entries(clonedDetails)) {
+          if (!Object.prototype.hasOwnProperty.call(event, key)) {
+            event[key] = value;
+          }
+        }
+      } else {
+        event.details = details;
+      }
+    }
+
+    events.push(event);
+  }
+
+  return events;
+}
+
 export function lastAudit() {
   return { ts: new Date().toISOString(), ok: true };
 }

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -1,1 +1,1 @@
-export * from './audit.js';
+export { lastAudit, readEventsFromLines } from './audit.js';


### PR DESCRIPTION
## Summary
- implement `readEventsFromLines` to parse audit JSONL content and flatten detail properties
- export the new reader from the audit package entry point
- extend unit coverage for parsing, invalid line handling, and detail merge behavior

## Testing
- pnpm --filter @prism-apex/audit test
- pnpm --filter @prism-apex/audit exec tsc -p tsconfig.json --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c844de23e8832cba64fb4226af80cc