### PR TITLE
fix: include global contracts for SDK typecheck

### DIFF
--- a/packages/sdk/tsconfig.typecheck.json
+++ b/packages/sdk/tsconfig.typecheck.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src", "types/**/*.d.ts"],
+  "include": ["src", "types/**/*.d.ts", "../../types/global/contracts.d.ts"],
   "exclude": ["src/__tests__/**", "**/*.spec.ts", "vitest.config.ts"],
   "compilerOptions": {
     "types": ["vitest/globals"],


### PR DESCRIPTION
## Summary
- ensure the SDK typecheck configuration includes the shared global contracts so ambient PrismApex types resolve

## Testing
- pnpm typecheck

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c84a9de6c4832ca37d794353312e1c