### PR TITLE
refactor: tighten tradovate websocket typings

### DIFF
--- a/apps/ingress-yahoo-dev/src/server.ts
+++ b/apps/ingress-yahoo-dev/src/server.ts
@@ -25,16 +25,22 @@ const DISABLE_NEWS = (process.env.APEX_NEWS_BLACKOUT || '')
   .map((s) => s.trim())
   .filter(Boolean);
 
-// Static configs
-const products = safeJson('config/products.json');
-const sessions = safeJson('config/sessions.json');
-const rollmap = safeJson('config/roll.json');
+type ProductConfig = Record<string, { tickSize?: number; tickValue?: number }>;
+interface SessionConfig {
+  roots?: Record<string, { flat_by?: string }>;
+}
+type RollMapConfig = Record<string, { month?: string }>;
 
-function safeJson(p: string): any {
+// Static configs
+const products = safeJson<ProductConfig>('config/products.json');
+const sessions = safeJson<SessionConfig>('config/sessions.json');
+const rollmap = safeJson<RollMapConfig>('config/roll.json');
+
+function safeJson<T>(p: string): T {
   try {
-    return JSON.parse(readFileSync(p, 'utf8'));
+    return JSON.parse(readFileSync(p, 'utf8')) as T;
   } catch {
-    return {};
+    return {} as T;
   }
 }
 

--- a/packages/clients-tradovate/src/__tests__/ws.spec.ts
+++ b/packages/clients-tradovate/src/__tests__/ws.spec.ts
@@ -1,17 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import { MarketDataWS } from '../ws.js';
+import type { TradovateMessage } from '../ws.js';
 
 class FakeWebSocket {
   static instances: FakeWebSocket[] = [];
   onopen: (() => void) | null = null;
   onclose: (() => void) | null = null;
-  onmessage: ((ev: { data: any }) => void) | null = null;
-  sent: any[] = [];
+  onmessage: ((ev: { data: TradovateMessage }) => void) | null = null;
+  sent: Array<string | ArrayBufferLike> = [];
   constructor(public url: string) {
     FakeWebSocket.instances.push(this);
     setTimeout(() => this.onopen && this.onopen(), 0);
   }
-  send(data: any) {
+  send(data: string | ArrayBufferLike) {
     this.sent.push(data);
   }
   close() {

--- a/packages/clients-tradovate/src/quotes.ts
+++ b/packages/clients-tradovate/src/quotes.ts
@@ -1,20 +1,45 @@
 import { Quote } from './types.js';
+import type { TradovateMessage, TradovateQuotePayload } from './ws.js';
 
 export type PublishQuote = (q: Quote) => void;
 
+function safeParseQuote(msg: TradovateMessage): TradovateQuotePayload | null {
+  if (typeof msg === 'string') {
+    try {
+      const parsed = JSON.parse(msg) as unknown;
+      return isQuotePayload(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return isQuotePayload(msg) ? msg : null;
+}
+
+function isQuotePayload(value: unknown): value is TradovateQuotePayload {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'fullSymbol' in value &&
+    typeof (value as { fullSymbol: unknown }).fullSymbol === 'string'
+  );
+}
+
 export class QuoteHandler {
   constructor(private publish: PublishQuote) {}
-  onMessage(msg: any) {
-    const q = typeof msg === 'string' ? JSON.parse(msg) : msg;
-    if (q && q.fullSymbol) {
-      this.publish({
-        ts: Number(q.ts || Date.now()),
-        last: Number(q.last),
-        bid: q.bid !== undefined ? Number(q.bid) : undefined,
-        ask: q.ask !== undefined ? Number(q.ask) : undefined,
-        volume: Number(q.volume || 0),
-        fullSymbol: String(q.fullSymbol),
-      });
-    }
+  onMessage(msg: TradovateMessage) {
+    const quote = safeParseQuote(msg);
+    if (!quote) return;
+
+    const tsSource = quote.ts;
+    const tsValue = tsSource ? Number(tsSource) : Date.now();
+
+    this.publish({
+      ts: Number.isFinite(tsValue) ? tsValue : Date.now(),
+      last: Number(quote.last),
+      bid: quote.bid !== undefined ? Number(quote.bid) : undefined,
+      ask: quote.ask !== undefined ? Number(quote.ask) : undefined,
+      volume: Number(quote.volume ?? 0),
+      fullSymbol: String(quote.fullSymbol),
+    });
   }
 }

--- a/packages/clients-tradovate/src/ws.ts
+++ b/packages/clients-tradovate/src/ws.ts
@@ -1,10 +1,42 @@
 import { TradovateClientError } from './types.js';
 
+export interface TradovateQuotePayload {
+  fullSymbol: string;
+  ts?: number | string;
+  last?: number | string;
+  bid?: number | string;
+  ask?: number | string;
+  volume?: number | string;
+  [key: string]: unknown;
+}
+
+export interface TradovateSubscriptionAck {
+  type: 'subscription' | 'unsubscription' | 'subscriptionStatus';
+  success?: boolean;
+  symbol?: string;
+  requestId?: number;
+  [key: string]: unknown;
+}
+
+export interface TradovateErrorPayload {
+  type: 'error';
+  code?: number | string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export type TradovateStructuredMessage =
+  | TradovateQuotePayload
+  | TradovateSubscriptionAck
+  | TradovateErrorPayload;
+
+export type TradovateMessage = string | ArrayBufferLike | TradovateStructuredMessage;
+
 interface WsLike {
   onopen: (() => void) | null;
   onclose: (() => void) | null;
-  onmessage: ((ev: { data: any }) => void) | null;
-  send(data: any): void;
+  onmessage: ((ev: { data: TradovateMessage }) => void) | null;
+  send(data: string | ArrayBufferLike): void;
   close(): void;
 }
 
@@ -12,7 +44,7 @@ export interface WSConfig {
   url: string;
   token: string;
   WebSocketCtor?: new (url: string) => WsLike;
-  onMessage?: (data: any) => void;
+  onMessage?: (data: TradovateMessage) => void;
 }
 
 export class MarketDataWS {


### PR DESCRIPTION
## Summary
- add explicit Tradovate websocket message payload interfaces and propagate typed events
- harden quote handler parsing and update fake websocket/test expectations
- genericize ingress safeJson loader to return typed configs

## Testing
- `pnpm --filter @prism-apex/clients-tradovate exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter ingress-yahoo-dev exec tsc -p tsconfig.json --noEmit`

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI) (N/A)
- [x] Contract/security/performance notes (if relevant) (N/A)
- [x] Rollback steps (and DOWN scripts if migrations) (N/A)
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c8585472b0832caa958af1fab7811b