### PR TITLE
feat: support APX-DDB-01 strategy in API

### DIFF
--- a/apps/api/src/jobs/strategies.ts
+++ b/apps/api/src/jobs/strategies.ts
@@ -15,6 +15,8 @@ import {
 import { trackEvent } from '@prism-apex/analytics';
 import fs from 'fs';
 import path from 'path';
+import { TICKET_STRATEGIES } from '../schemas/ticket.js';
+import type { TicketStrategy } from '../schemas/ticket.js';
 
 export interface BarMessage {
   symbol: string; // root e.g., ES
@@ -64,16 +66,23 @@ const TICK_SPECS: Record<string, { tickSize: number }> = {
 
 const MAX_BARS = 300;
 
+const makeStrategyCounter = (): Record<TicketStrategy, number> =>
+  Object.fromEntries(TICKET_STRATEGIES.map((strategy) => [strategy, 0])) as Record<
+    TicketStrategy,
+    number
+  >;
+
 export const strategies = {
   running: false,
   lastBarTs: '',
   lastSuggestionTs: '',
-  counts: { VWAP_FT: 0, OSB: 0 },
+  counts: makeStrategyCounter(),
 };
 
 interface Config {
   VWAP_FT: Record<string, any>;
   OSB: Record<string, any>;
+  'APX-DDB-01'?: Record<string, any>;
 }
 
 let cfg: Config = { VWAP_FT: {}, OSB: {} };
@@ -207,7 +216,8 @@ function onBar(bar: BarMessage): void {
 
 function emitSuggestion(s: Suggestion): void {
   strategies.lastSuggestionTs = s.timestampUtc;
-  strategies.counts[s.meta.strategy as 'VWAP_FT' | 'OSB']++;
+  const strategy: TicketStrategy = s.meta.strategy;
+  strategies.counts[strategy] += 1;
   publish<Suggestion>('suggestion', s);
   trackEvent('strategies.suggestion', { strategy: s.meta.strategy, contract: s.contract });
 }

--- a/apps/api/src/jobs/ticketizer.ts
+++ b/apps/api/src/jobs/ticketizer.ts
@@ -3,7 +3,8 @@ import { jobManager } from '../lib/jobManager.js';
 import { applyGuardWithSizing } from '@prism-apex/rules-apex';
 import { loadRegistry } from '@prism-apex/config';
 import { getConfig } from '../config/env.js';
-import type { Ticket } from '../schemas/ticket.js';
+import { TICKET_STRATEGIES } from '../schemas/ticket.js';
+import type { Ticket, TicketStrategy } from '../schemas/ticket.js';
 import { saveTicket, getRecentTicketSizes } from '../store/tickets.js';
 import { getAccount as getTelemetryAccount } from '../store/telemetry.js';
 
@@ -21,6 +22,12 @@ function buildConsistencyNotes(phase: 'eval' | 'funded'): string {
   return notes;
 }
 
+const makeStrategyCounter = (): Record<TicketStrategy, number> =>
+  Object.fromEntries(TICKET_STRATEGIES.map((strategy) => [strategy, 0])) as Record<
+    TicketStrategy,
+    number
+  >;
+
 export type Suggestion = {
   symbol: string; // root symbol
   contract: string; // full contract
@@ -30,15 +37,15 @@ export type Suggestion = {
   target: number;
   qty?: number;
   timestampUtc: string;
-  meta: { strategy: 'VWAP_FT' | 'OSB' };
+  meta: { strategy: TicketStrategy };
 };
 
 export const ticketizer = {
   running: false,
   lastSuggestionTs: '',
   lastAcceptedTs: '',
-  accepted: { VWAP_FT: 0, OSB: 0 },
-  rejected: { VWAP_FT: 0, OSB: 0 },
+  accepted: makeStrategyCounter(),
+  rejected: makeStrategyCounter(),
 };
 
 let unsub: (() => void) | null = null;

--- a/apps/api/src/schemas/ticket.ts
+++ b/apps/api/src/schemas/ticket.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+export const TICKET_STRATEGIES = ['VWAP_FT', 'OSB', 'APX-DDB-01'] as const;
+
 export const TicketSchema = z.object({
   symbol: z.string(),
   side: z.enum(['BUY', 'SELL']),
@@ -10,7 +12,7 @@ export const TicketSchema = z.object({
   accountId: z.string(),
   timestampUtc: z.string(),
   meta: z.object({
-    strategy: z.enum(['VWAP_FT', 'OSB']),
+    strategy: z.enum(TICKET_STRATEGIES),
     rr: z.number(),
     guardrails: z.array(z.string()),
     sizingHint: z.string().optional(),
@@ -21,3 +23,4 @@ export const TicketSchema = z.object({
 });
 
 export type Ticket = z.infer<typeof TicketSchema>;
+export type TicketStrategy = (typeof TICKET_STRATEGIES)[number];

--- a/apps/api/src/tests/ticket.schema.spec.ts
+++ b/apps/api/src/tests/ticket.schema.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { TicketSchema } from '../schemas/ticket.js';
+
+describe('ticket schema', () => {
+  it('accepts APX-DDB-01 strategy', () => {
+    const result = TicketSchema.parse({
+      symbol: 'ESZ4',
+      side: 'BUY',
+      entry: 100,
+      stop: 99,
+      target: 102,
+      qty: 1,
+      accountId: 'A1',
+      timestampUtc: '2024-01-01T10:00:00Z',
+      meta: {
+        strategy: 'APX-DDB-01',
+        rr: 2,
+        guardrails: [],
+      },
+      accepted: true,
+    });
+
+    expect(result.meta.strategy).toBe('APX-DDB-01');
+  });
+});

--- a/packages/rules-apex/src/types.ts
+++ b/packages/rules-apex/src/types.ts
@@ -1,12 +1,14 @@
 export type AccountPhase = 'eval' | 'funded';
 
+export type StrategyId = 'VWAP_FT' | 'OSB' | 'APX-DDB-01';
+
 export type Suggestion = {
   symbol: string;
   side: 'BUY' | 'SELL';
   entry: number;
   stop?: number;
   qty: number;
-  strategy: 'VWAP_FT' | 'OSB';
+  strategy: StrategyId;
   target?: number;
 };
 
@@ -19,7 +21,7 @@ export type Ticket = {
   accountId: string;
   timestampUtc: string;
   meta: {
-    strategy: 'VWAP_FT' | 'OSB';
+    strategy: StrategyId;
     rr: number;
     guardrails: string[];
     sizingHint?: string;

--- a/packages/strategies/src/types.ts
+++ b/packages/strategies/src/types.ts
@@ -7,6 +7,8 @@ export type Candle = {
   volume?: number;
 };
 
+export type StrategyId = 'VWAP_FT' | 'OSB' | 'APX-DDB-01';
+
 export type Suggestion = {
   symbol: string; // full contract, e.g., ESZ4
   side: 'BUY' | 'SELL';
@@ -16,7 +18,7 @@ export type Suggestion = {
   qty?: number; // suggested size (optional here)
   timestampUtc: string; // when generated
   meta: {
-    strategy: 'VWAP_FT' | 'OSB';
+    strategy: StrategyId;
     rr: number;
     notes?: string;
     guardrails?: string[]; // e.g., ["RR_CLAMPED","MIN_TICKS_BUMP"]


### PR DESCRIPTION
## Summary
- allow tickets to carry the APX-DDB-01 strategy and share the union across API helpers
- extend ticketizer and strategies jobs to initialize counters for every supported strategy
- broaden shared strategy typings and add a schema test covering APX-DDB-01 acceptance

## Testing
- pnpm --filter @prism-apex/api test
- pnpm --filter @prism-apex/api typecheck *(fails: existing missing module/type declarations)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI) (N/A)
- [x] Contract/security/performance notes (if relevant) (N/A)
- [x] Rollback steps (and DOWN scripts if migrations) (N/A)
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c8642c9fe8832c9b0ee422e03aaa2d