### PR TITLE
feat: add Yahoo bars fetch helper

### DIFF
--- a/packages/data-yahoo/src/fetch.ts
+++ b/packages/data-yahoo/src/fetch.ts
@@ -1,0 +1,120 @@
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const SECOND_IN_MS = 1000;
+const YAHOO_CHART_BASE = 'https://query1.finance.yahoo.com/v8/finance/chart/';
+
+type QuoteEntry = {
+  high?: Array<number | null>;
+  low?: Array<number | null>;
+  close?: Array<number | null>;
+  volume?: Array<number | null>;
+};
+
+type ChartResult = {
+  meta?: { symbol?: string | null };
+  timestamp?: Array<number | null>;
+  indicators?: { quote?: QuoteEntry[] };
+};
+
+type YahooChartResponse = {
+  chart?: { result?: ChartResult[] };
+};
+
+export interface YahooBar {
+  symbol: string;
+  ts: string;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+}
+
+function ensureDate(value: Date, name: string) {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new Error(`${name} must be a valid Date instance`);
+  }
+}
+
+export async function fetchYahooBars(symbol: string, from: Date, to: Date): Promise<YahooBar[]> {
+  if (!symbol || !symbol.trim()) {
+    throw new Error('symbol is required');
+  }
+  ensureDate(from, 'from');
+  ensureDate(to, 'to');
+
+  if (to.getTime() < from.getTime()) {
+    throw new Error('`to` must be on or after `from`');
+  }
+
+  const period1 = Math.floor(from.getTime() / SECOND_IN_MS);
+  const period2 = Math.floor((to.getTime() + DAY_IN_MS - 1) / SECOND_IN_MS);
+
+  const url = new URL(`${YAHOO_CHART_BASE}${encodeURIComponent(symbol)}`);
+  url.searchParams.set('period1', String(period1));
+  url.searchParams.set('period2', String(period2));
+  url.searchParams.set('interval', '1d');
+  url.searchParams.set('events', 'history');
+  url.searchParams.set('includeAdjustedClose', 'true');
+
+  const response = await fetch(url.toString(), {
+    headers: { accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Yahoo chart request failed: ${response.status} ${response.statusText}`.trim());
+  }
+
+  const payload = (await response.json()) as YahooChartResponse;
+  const result = payload.chart?.result?.[0];
+
+  if (!result || !Array.isArray(result.timestamp)) {
+    throw new Error('Yahoo chart payload missing timestamps');
+  }
+
+  const quote = result.indicators?.quote?.[0];
+  if (!quote) {
+    throw new Error('Yahoo chart payload missing quote data');
+  }
+
+  const symbolFromMeta =
+    typeof result.meta?.symbol === 'string' && result.meta.symbol.trim()
+      ? result.meta.symbol
+      : symbol;
+
+  const { high = [], low = [], close = [], volume = [] } = quote;
+
+  const bars: YahooBar[] = [];
+
+  for (let i = 0; i < result.timestamp.length; i += 1) {
+    const ts = result.timestamp[i];
+    const h = high[i];
+    const l = low[i];
+    const c = close[i];
+    const v = volume[i];
+
+    if (
+      typeof ts !== 'number' ||
+      typeof h !== 'number' ||
+      typeof l !== 'number' ||
+      typeof c !== 'number' ||
+      typeof v !== 'number' ||
+      !Number.isFinite(ts) ||
+      !Number.isFinite(h) ||
+      !Number.isFinite(l) ||
+      !Number.isFinite(c) ||
+      !Number.isFinite(v)
+    ) {
+      continue;
+    }
+
+    bars.push({
+      symbol: symbolFromMeta,
+      ts: new Date(ts * SECOND_IN_MS).toISOString(),
+      high: h,
+      low: l,
+      close: c,
+      volume: v,
+    });
+  }
+
+  return bars;
+}

--- a/packages/data-yahoo/src/index.ts
+++ b/packages/data-yahoo/src/index.ts
@@ -1,3 +1,4 @@
 export * from './schema.js';
 export * from './io.js';
 export * from './vwap.js';
+export * from './fetch.js';

--- a/packages/data-yahoo/test/fetch.test.ts
+++ b/packages/data-yahoo/test/fetch.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchYahooBars } from '../src/fetch.js';
+import { appendJSONL, barsFile } from '../src/io.js';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+
+describe('fetchYahooBars', () => {
+  let fetchStub: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchStub = vi.fn();
+    vi.stubGlobal('fetch', fetchStub);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requests Yahoo chart data and normalizes bars', async () => {
+    const startMs = Date.UTC(2024, 0, 1);
+    const timestamps = [0, 1, 2].map((i) => Math.floor((startMs + i * 24 * 60 * 60 * 1000) / 1000));
+
+    fetchStub.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        chart: {
+          result: [
+            {
+              meta: { symbol: 'AAPL' },
+              timestamp: timestamps,
+              indicators: {
+                quote: [
+                  {
+                    high: [190.1, 191.2, 192.3],
+                    low: [188.5, 189.4, 190.6],
+                    close: [189.9, 190.8, 191.7],
+                    volume: [100_000_000, 120_000_000, null],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    } as unknown as Response);
+
+    const from = new Date(startMs);
+    const to = new Date(startMs + 2 * 24 * 60 * 60 * 1000);
+    const bars = await fetchYahooBars('AAPL', from, to);
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    const [url] = fetchStub.mock.calls[0];
+    const parsed = new URL(String(url));
+    expect(parsed.pathname.endsWith('/AAPL')).toBe(true);
+    expect(parsed.searchParams.get('interval')).toBe('1d');
+    expect(parsed.searchParams.get('period1')).toBe(String(Math.floor(startMs / 1000)));
+    expect(parsed.searchParams.get('period2')).toBe(
+      String(Math.floor((to.getTime() + 24 * 60 * 60 * 1000 - 1) / 1000)),
+    );
+
+    expect(bars).toHaveLength(2);
+    expect(bars[0]).toEqual({
+      symbol: 'AAPL',
+      ts: new Date(timestamps[0] * 1000).toISOString(),
+      high: 190.1,
+      low: 188.5,
+      close: 189.9,
+      volume: 100_000_000,
+    });
+    expect(bars[1].symbol).toBe('AAPL');
+  });
+
+  it('integrates with file helpers to persist JSONL caches', async () => {
+    const startMs = Date.UTC(2024, 0, 1);
+    const timestamps = [0, 1].map((i) => Math.floor((startMs + i * 24 * 60 * 60 * 1000) / 1000));
+
+    fetchStub.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        chart: {
+          result: [
+            {
+              meta: { symbol: 'MSFT' },
+              timestamp: timestamps,
+              indicators: {
+                quote: [
+                  {
+                    high: [340.1, 341.2],
+                    low: [338.4, 339.6],
+                    close: [339.8, 340.9],
+                    volume: [90_000_000, 95_000_000],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    } as unknown as Response);
+
+    const bars = await fetchYahooBars(
+      'MSFT',
+      new Date(startMs),
+      new Date(startMs + 24 * 60 * 60 * 1000),
+    );
+
+    const tmp = mkdtempSync(join(dirname(fileURLToPath(import.meta.url)), 'yahoo-bars-'));
+    try {
+      for (const bar of bars) {
+        const file = barsFile(tmp, bar.symbol, bar.ts.slice(0, 10));
+        appendJSONL(file, bar);
+      }
+
+      const firstDayPath = barsFile(tmp, 'MSFT', '2024-01-01');
+      const secondDayPath = barsFile(tmp, 'MSFT', '2024-01-02');
+
+      const firstDayLines = readFileSync(firstDayPath, 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      const secondDayLines = readFileSync(secondDayPath, 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+
+      expect(firstDayLines).toEqual([bars[0]]);
+      expect(secondDayLines).toEqual([bars[1]]);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a Yahoo Finance chart fetch helper that normalizes bar data
- export the helper from the package entrypoint and add tests covering fetch and file I/O integration

## Testing
- pnpm --filter @prism-apex/data-yahoo test
- pnpm --filter @prism-apex/data-yahoo exec tsc --noEmit

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c8696c401c832ca496c537777bbac1