### PR TITLE
docs: correct dashboard-lite filter alias

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -12,7 +12,7 @@ API (dev script, if provided): 8000 (hot-reload)
 
 Dev workflow (hot reload, if scripts exist)
 ./dev_api.sh              # API on :8000 (Fastify watch) — optional
-pnpm --filter @prism-apex*/dashboard-lite dev   # Vite dev UI on :5173 (if applicable)
+pnpm --filter @prism-apex/dashboard-lite dev   # Vite dev UI on :5173 (if applicable)
 
 Prod-like workflow (Docker)
 docker compose up -d --build


### PR DESCRIPTION
## Summary
- fix the dashboard-lite dev command to use the scoped workspace name without a glob suffix

## Testing
- pnpm lint README-dev.md *(warns that the file is ignored because no matching configuration was supplied)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [x] Contract/security/performance notes (if relevant)
- [x] Rollback steps (and DOWN scripts if migrations)
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c86e2b7680832c8ba7a9ee6c11a1d0