### PR TITLE
fix: reuse pnpm binary in api runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ COPY --from=build /app/configs /app/configs
 COPY --from=build /app/apex /app/apex
 # Install production deps (respect lockfile)
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-RUN corepack enable && corepack prepare pnpm@9.0.0 --activate \
- && pnpm install --frozen-lockfile --prod
+COPY --from=build /usr/local/bin/pnpm /usr/local/bin/
+RUN pnpm install --frozen-lockfile --prod
 
 EXPOSE 3000
 VOLUME ["/data"]


### PR DESCRIPTION
## Summary
- remove the redundant corepack enable step from the API runtime image
- reuse the pnpm binary prepared during the build stage when installing production deps

## Testing
- `pnpm install --silent`
- `pnpm lint`
- `pnpm typecheck` *(fails: @prism-apex/ticketizer typecheck exits 2)*
- `pnpm test`
- `docker build -t prism-apex/api:local .` *(fails: docker command unavailable in environment)*
- `scripts/smoke-api-docker.sh` *(fails: API container not running because docker is unavailable)*

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [N/A] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [N/A] Contract/security/performance notes (if relevant)
- [N/A] Rollback steps (and DOWN scripts if migrations)
- [N/A] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c870915a50832cafd5e9ff87fd3166