### PR TITLE
fix: align ticketizer TypeScript config with package src

### DIFF
--- a/packages/ticketizer/tsconfig.json
+++ b/packages/ticketizer/tsconfig.json
@@ -2,7 +2,14 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "../..",
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@prism-apex/accounts": ["types/@prism-apex/accounts/index.d.ts"],
+      "@prism-apex/accounts/*": ["types/@prism-apex/accounts/*"],
+      "@prism-apex/rules/apex.js": ["types/@prism-apex/rules/apex.d.ts"],
+      "@prism-apex/rules/*": ["types/@prism-apex/rules/*"]
+    },
     "declaration": true,
     "declarationMap": true,
     "allowImportingTsExtensions": false,

--- a/packages/ticketizer/types/@prism-apex/accounts/index.d.ts
+++ b/packages/ticketizer/types/@prism-apex/accounts/index.d.ts
@@ -1,0 +1,21 @@
+declare module '@prism-apex/accounts' {
+  export type AccountMode = 'eval' | 'funded';
+
+  export interface AccountRecord {
+    name: string;
+    accountId: number;
+    accountSpec: string;
+    mode: AccountMode;
+    planMaxContracts: number;
+    baseSize: number;
+    multiplier?: number;
+    minQty?: number;
+  }
+
+  export interface AccountsFile {
+    accounts: AccountRecord[];
+  }
+
+  export function loadAccounts(filePath?: string): AccountsFile;
+  export function getAccounts(): AccountRecord[];
+}

--- a/packages/ticketizer/types/@prism-apex/rules/apex.d.ts
+++ b/packages/ticketizer/types/@prism-apex/rules/apex.d.ts
@@ -1,0 +1,24 @@
+declare module '@prism-apex/rules/apex.js' {
+  export type OrderParams = {
+    qty: number;
+    entryPrice: number;
+    stopLoss?: number;
+    takeProfit?: number;
+  };
+
+  export type GuardContext = {
+    mode: 'funded' | 'evaluation';
+    bufferCleared: boolean;
+    maxContractsAllowed: number;
+    now?: Date;
+    cfg?: unknown;
+  };
+
+  export type GuardResult = {
+    allow: boolean;
+    reason?: string;
+    ticket?: OrderParams;
+  };
+
+  export function guardApexFundingRules(t: OrderParams, ctx: GuardContext): GuardResult;
+}


### PR DESCRIPTION
## Summary
- set the ticketizer TypeScript rootDir to the src folder and keep build output in dist
- override local module resolution to use package-scoped declaration shims for cross-package imports

## Testing
- pnpm --filter @prism-apex/ticketizer build
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_b_68c87e1cb52c832cb72655652ccf474c