### PR TITLE
chore: align tsconfig path aliases

### DIFF
--- a/apps/dashboard-lite/tsconfig.json
+++ b/apps/dashboard-lite/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "NodeNext",

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -41,9 +41,14 @@
       "@prism-apex/ticketizer": ["packages/ticketizer/src"],
       "@prism-apex/ticketizer/*": ["packages/ticketizer/src/*"],
 
+      "@prism-apex/app-api": ["apps/api/src"],
       "@prism-apex/app-api/*": ["apps/api/src/*"],
+      "@prism-apex/app-dashboard": ["apps/dashboard/src"],
       "@prism-apex/app-dashboard/*": ["apps/dashboard/src/*"],
-      "@prism-apex/app-dashboard-lite/*": ["apps/dashboard-lite/src/*"]
+      "@prism-apex/app-dashboard-lite": ["apps/dashboard-lite/src"],
+      "@prism-apex/app-dashboard-lite/*": ["apps/dashboard-lite/src/*"],
+      "@prism-apex/ingress-yahoo-dev": ["apps/ingress-yahoo-dev/src"],
+      "@prism-apex/ingress-yahoo-dev/*": ["apps/ingress-yahoo-dev/src/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- extend the dashboard-lite tsconfig from the shared base so workspace path aliases resolve
- add root and wildcard path aliases for app workspaces, including ingress-yahoo-dev

## Testing
- pnpm typecheck
- pnpm test

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [ ] Contract/security/performance notes (if relevant)
- [ ] Rollback steps (and DOWN scripts if migrations)
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c8810f75a0832ca5d35d89ea4a1c9e