### PR TITLE
fix: align tsconfig module resolution with base configuration

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -6,8 +6,6 @@
     "declaration": false,
     "sourceMap": true,
     "composite": false,
-    "module": "NodeNext",
-    "moduleResolution": "nodenext",
     "types": ["node"]
   },
   "include": ["src/**/*"],

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,15 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "NodeNext",
     "outDir": "dist",
     "rootDir": ".",
     "declaration": true,
     "declarationMap": true,
     "types": ["node", "vitest/globals"],
     "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "moduleResolution": "nodenext"
+    "skipLibCheck": true
   },
   "include": ["src", "types/**/*.d.ts", "vitest.config.ts"]
 }

--- a/apps/api/tsconfig.typecheck.json
+++ b/apps/api/tsconfig.typecheck.json
@@ -4,8 +4,7 @@
     "rootDir": "../..",
     "types": ["vitest/globals"],
     "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "moduleResolution": "nodenext"
+    "skipLibCheck": true
   },
   "include": ["src", "types/**/*.d.ts"],
   "exclude": ["src/__tests__/**", "src/tests/**", "**/*.spec.ts", "vitest.config.ts"]

--- a/apps/dashboard-lite/tsconfig.json
+++ b/apps/dashboard-lite/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "jsx": "react-jsx",
     "strict": true,
     "skipLibCheck": true,

--- a/apps/dashboard-lite/tsconfig.server.json
+++ b/apps/dashboard-lite/tsconfig.server.json
@@ -1,8 +1,7 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "outDir": "dist-server",
     "strict": true,
     "skipLibCheck": true

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -2,7 +2,7 @@
   "name": "@prism-apex/accounts",
   "version": "0.1.0",
   "private": true,
-  "type": "commonjs",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- remove module and moduleResolution overrides from app tsconfigs so they inherit the base NodeNext settings
- mark the accounts workspace package as ESM by setting its package.json type field to module

## Testing
- pnpm --filter "./packages/**" build
- pnpm typecheck

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI) – N/A
- [x] Contract/security/performance notes (if relevant) – N/A
- [x] Rollback steps (and DOWN scripts if migrations) – Revert commit
- [x] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c90f88d8b4832c9749502c5f7e4a4c