### PR TITLE
chore: normalize __dirname usage

### DIFF
--- a/apps/api/src/routes/openapi.ts
+++ b/apps/api/src/routes/openapi.ts
@@ -1,7 +1,7 @@
-import { FastifyInstance } from 'fastify';
-import { readFileSync } from 'fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { FastifyInstance } from "fastify";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/apps/api/src/utils/version.ts
+++ b/apps/api/src/utils/version.ts
@@ -1,11 +1,11 @@
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export function getVersion(): string {
-  const pkgPath = resolve(__dirname, '..', '..', '..', '..', 'package.json');
+  const pkgPath = join(__dirname, '..', '..', '..', '..', 'package.json');
   try {
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
     return pkg.version ?? '';

--- a/packages/data-yahoo/scripts/cjs.js
+++ b/packages/data-yahoo/scripts/cjs.js
@@ -1,12 +1,17 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const dist = (p) => `${__dirname}/../dist/${p}`;
-mkdirSync(dist(''), { recursive: true });
+const distDir = join(__dirname, '..', 'dist');
+
+mkdirSync(distDir, { recursive: true });
+
 for (const base of ['index', 'schema', 'io', 'vwap', 'replay-yahoo-bars']) {
-  const code = readFileSync(`${dist(base)}.js`, 'utf8')
+  const inputPath = join(distDir, `${base}.js`);
+  const code = readFileSync(inputPath, 'utf8')
     .replaceAll('export {', 'module.exports = {')
     .replaceAll('export default', 'module.exports.default =');
-  writeFileSync(`${dist(base)}.cjs`, code);
+  const outputPath = join(distDir, `${base}.cjs`);
+  writeFileSync(outputPath, code);
 }

--- a/packages/strategies/src/config/strategy-config.ts
+++ b/packages/strategies/src/config/strategy-config.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 
 export type StrategyKey = 'vwap-first-touch' | 'opening-session-breakout';
 
@@ -35,7 +35,7 @@ export type OpeningSessionBreakoutParams = {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export function loadStrategyConfig<T>(key: StrategyKey): T {
-  const filePath = join(__dirname, '../../../../configs/strategies', `${key}.json`);
+  const filePath = join(__dirname, '..', '..', '..', '..', 'configs', 'strategies', `${key}.json`);
   try {
     const raw = readFileSync(filePath, 'utf8');
     return JSON.parse(raw) as T;

--- a/tools/depcheck.mjs
+++ b/tools/depcheck.mjs
@@ -1,12 +1,12 @@
 // Programmatic depcheck runner that respects .depcheckrc.json
 /* eslint-disable import/no-extraneous-dependencies */
-import fs from 'node:fs';
-import { dirname, resolve, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import depcheck from 'depcheck';
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import depcheck from "depcheck";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(__dirname, '..');
+const repoRoot = join(__dirname, '..');
 
 const cfgPath = join(repoRoot, '.depcheckrc.json');
 // Output directory and file for depcheck results


### PR DESCRIPTION
## Summary
- normalize `__dirname` handling across the API route, version helper, depcheck script, and supporting packages by deriving it from `import.meta.url`
- switch path assembly to `join(__dirname, ...)` and adjust file system helpers accordingly

## Testing
- `pnpm lint`
- `pnpm test`

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI) – N/A
- [x] Contract/security/performance notes (if relevant) – N/A
- [x] Rollback steps (and DOWN scripts if migrations) – N/A
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c912b17480832ca6ce413519e84bc0