### PR TITLE
Restore app typechecks after regenerating package declarations

### DIFF
--- a/apps/api/src/services/rules/engine.ts
+++ b/apps/api/src/services/rules/engine.ts
@@ -1,4 +1,4 @@
-import rules from '../../../../../apex/rules.json';
+import rules from '../../../../../apex/rules.json' with { type: 'json' };
 
 export type Phase = 'evaluation' | 'funded' | 'payout';
 

--- a/apps/dashboard-lite/tsconfig.typecheck.json
+++ b/apps/dashboard-lite/tsconfig.typecheck.json
@@ -5,7 +5,8 @@
     "strict": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
   "include": ["src", "vite.config.ts", "index.html", "../../types/**/*.d.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       fastify-plugin:
         specifier: 5.0.1
         version: 5.0.1
+      tsconfig-paths:
+        specifier: latest
+        version: 4.2.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -168,9 +171,6 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.6.2
-      tsconfig-paths:
-        specifier: latest
-        version: 4.2.0
       tsup:
         specifier: 8.5.0
         version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)


### PR DESCRIPTION
## Summary
- add an import attribute for the API rules JSON so NodeNext type checking succeeds
- extend the dashboard-lite typecheck configuration with DOM libraries used by the React app
- update the pnpm lockfile so tsconfig-paths is tracked under the API workspace importer

## Testing
- `pnpm -r --filter "./packages/**" build`
- `pnpm --filter @prism-apex/api typecheck`
- `pnpm --filter @prism-apex/dashboard-lite typecheck`
- `pnpm --filter @prism-apex/ingress-yahoo-dev typecheck`

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [x] Contract/security/performance notes (if relevant)
- [x] Rollback steps (and DOWN scripts if migrations)
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c9239feb44832cb346073836325a3b