### PR TITLE
chore: resolve lint warnings

### DIFF
--- a/apps/api/scripts/postbuild.mjs
+++ b/apps/api/scripts/postbuild.mjs
@@ -32,9 +32,7 @@ ensureDir(path.join(DIST, 'plugins'));
 
 if (fs.existsSync(SRC)) {
   walk(SRC, SRC);
-  // eslint-disable-next-line no-console
   console.info('✅ postbuild: ensured dist/routes & dist/plugins and copied non-TS files.');
 } else {
-  // eslint-disable-next-line no-console
   console.info('ℹ️ postbuild: no src/ found to copy from.');
 }

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -28,6 +28,7 @@
     "@tailwindcss/postcss": "4.1.12",
     "tailwindcss": "4.1.12",
     "typescript": "^5.9.2",
-    "vite": "^5.3.5"
+    "vite": "^5.3.5",
+    "vitest": "^2.0.0"
   }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,7 @@ export default [
     },
     rules: {
       // Keep noise low but catch obvious foot-guns (WARN ONLY)
-      'no-console': 'warn',
+      'no-console': ['warn', { allow: ['info', 'warn', 'error'] }],
       'no-empty': ['warn', { allowEmptyCatch: true }],
       'no-undef': 'off',
       eqeqeq: ['warn', 'smart'],
@@ -53,6 +53,8 @@ export default [
           devDependencies: [
             '**/*.spec.*',
             '**/__tests__/**',
+            '**/test/**',
+            '**/tests/**',
             '**/vitest.config.*',
             '**/*.config.*',
             '**/src/tests/**',

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -33,6 +33,7 @@
     "typescript-eslint": "^8.7.0",
     "prettier": "^3.3.3",
     "tsup": "^8.0.1",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -29,6 +29,7 @@
     "eslint": "^9.10.0",
     "@eslint/js": "^9.10.0",
     "typescript-eslint": "^8.7.0",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -29,6 +29,7 @@
     "eslint": "^9.10.0",
     "@eslint/js": "^9.10.0",
     "typescript-eslint": "^8.7.0",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,5 +21,8 @@
       "require": "./dist/index.js",
       "default": "./dist/index.js"
     }
+  },
+  "devDependencies": {
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -21,7 +21,8 @@
     "eslint": "^9.10.0",
     "@eslint/js": "^9.10.0",
     "typescript-eslint": "^8.7.0",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "vitest": "^2.0.0"
   },
   "exports": {
     ".": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       vite:
         specifier: ^5.3.5
         version: 5.4.19(@types/node@20.19.11)(lightningcss@1.30.1)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
 
   apps/dashboard-lite:
     dependencies:
@@ -384,6 +387,9 @@ importers:
       typescript-eslint:
         specifier: ^8.7.0
         version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
 
   packages/clients-tradovate:
     dependencies:
@@ -564,6 +570,9 @@ importers:
       typescript-eslint:
         specifier: ^8.7.0
         version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
 
   packages/rules-apex:
     devDependencies:
@@ -594,8 +603,15 @@ importers:
       typescript-eslint:
         specifier: ^8.7.0
         version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
 
-  packages/sdk: {}
+  packages/sdk:
+    devDependencies:
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
 
   packages/signals:
     devDependencies:
@@ -611,6 +627,9 @@ importers:
       typescript-eslint:
         specifier: ^8.7.0
         version: 8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.11)(jsdom@26.1.0)(lightningcss@1.30.1)
 
   packages/strategies:
     devDependencies:

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -6,7 +6,6 @@
  * - Reduce console noise (keep warn/error)
  */
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { beforeAll, beforeEach, afterEach, vi } from 'vitest';
 
 beforeAll(() => {


### PR DESCRIPTION
## Summary
- allow console info/warn/error and extend lint devDependency patterns
- add `vitest` as a dev dependency to packages that host tests
- drop obsolete eslint-disable directives in scripts now that console info is allowed

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68c928b35940832c8142dfd2d479624c