### PR TITLE
docs: clarify path alias guidance

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -44,7 +44,9 @@ The codebase must never introduce broker order placement (tickets-only). CI enfo
 - If your entry file is not `src/server.ts`, update `apps/api/tsup.config.ts`.
 
 ### Path aliases
-- TS path aliases are maintained in `tsconfig.paths.json`, which is extended by `tsconfig.base.json`.
-  Example: `@prism-apex/app-api/*` → `apps/api/src/*`.
-- Vitest uses `vite-tsconfig-paths` and `tsconfig-paths/register` to resolve these aliases (`apps/api/test.setup.ts`).
-- If you change folder layout, update the `paths` map accordingly.
+- Source of truth: `tsconfig.paths.json`. `tsconfig.base.json` extends it so every workspace inherits the same `paths` map.
+- Use the `@prism-apex/<workspace>` pattern when importing. Examples:
+  - `@prism-apex/app-api/*` → `apps/api/src/*`
+  - `@prism-apex/rules-apex/*` → `packages/rules-apex/src/*`
+- Vitest pulls in the map via the `vite-tsconfig-paths` plugin (see the shared `vitest.config.ts` family), and Node-based setups/scripts load `tsconfig-paths/register` (e.g., `apps/api/test.setup.ts`).
+- Update `tsconfig.paths.json` whenever folders move; the rest follows automatically.


### PR DESCRIPTION
## Summary
- explain that the shared TypeScript path map lives in `tsconfig.paths.json` and is inherited through `tsconfig.base.json`
- replace legacy alias examples with the `@prism-apex/<workspace>` pattern and call out supporting tooling for tests/scripts

## Testing
- Not run (docs-only change)

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist) — docs-only change
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [x] Contract/security/performance notes (if relevant) — N/A
- [x] Rollback steps (and DOWN scripts if migrations) — N/A
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c935a937f4832ca49faa80469c5fe0