### PR TITLE
feat: add apx-ddb-01 strategy to dashboard filters

### DIFF
--- a/apps/dashboard/src/components/TicketsTable.tsx
+++ b/apps/dashboard/src/components/TicketsTable.tsx
@@ -9,7 +9,7 @@ export interface Ticket {
   qty: number;
   accountId: string;
   timestampUtc: string;
-  meta: { strategy: 'VWAP_FT' | 'OSB'; rr: number; guardrails: string[] };
+  meta: { strategy: 'VWAP_FT' | 'OSB' | 'APX-DDB-01'; rr: number; guardrails: string[] };
   accepted: boolean;
   reasons?: string[];
 }

--- a/apps/dashboard/src/constants.ts
+++ b/apps/dashboard/src/constants.ts
@@ -1,2 +1,2 @@
 export const SYMBOLS = ['ES', 'NQ', 'MES', 'MNQ'];
-export const STRATEGIES = ['VWAP_FT', 'OSB'];
+export const STRATEGIES = ['VWAP_FT', 'OSB', 'APX-DDB-01'];


### PR DESCRIPTION
## Summary
- add APX-DDB-01 to the dashboard strategies constant so it can be selected in filters
- extend the ticket meta strategy union type to accept the new strategy in the tickets table

## Testing
- pnpm --filter prism-apex-dashboard test -- --run

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [ ] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI) — N/A
- [ ] Contract/security/performance notes (if relevant) — N/A
- [ ] Rollback steps (and DOWN scripts if migrations) — N/A
- [ ] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c948a6850c832c9d446c8face0bc7e