### PR TITLE
feat: allow filtering tickets by strategy

### DIFF
--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -179,6 +179,7 @@ registry.registerPath({
       date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
       cursor: z.string().optional(),
       limit: z.string().optional(),
+      strategy: z.string().optional(),
     }),
   },
   responses: {

--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -12,11 +12,12 @@ export async function ticketsRoutes(app: FastifyInstance) {
         date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
         cursor: z.coerce.number().optional(),
         limit: z.coerce.number().optional(),
+        strategy: z.string().optional(),
       })
       .safeParse(req.query);
     if (!q.success) return reply.code(400).send({ error: 'Invalid query' });
     const limit = Math.min(Math.max(q.data.limit ?? 50, 1), 200);
-    const { items, nextCursor } = listTickets(q.data.date, q.data.cursor, limit);
+    const { items, nextCursor } = listTickets(q.data.date, q.data.cursor, limit, q.data.strategy);
     return { tickets: items, nextCursor: nextCursor ?? null };
   });
 

--- a/apps/api/src/store/tickets.ts
+++ b/apps/api/src/store/tickets.ts
@@ -64,13 +64,18 @@ export function listTickets(
   date: string,
   cursor = 0,
   limit = 50,
+  strategy?: string,
 ): {
   items: Ticket[];
   nextCursor?: number;
 } {
   const day = days.get(date) ?? [];
-  const slice = day.slice(cursor, cursor + limit).map(({ hash: _hash, ...t }) => t);
-  const nextCursor = cursor + limit < day.length ? cursor + limit : undefined;
+  const strategyFilter = strategy?.trim();
+  const filtered = strategyFilter
+    ? day.filter((ticket) => ticket.meta.strategy === strategyFilter)
+    : day;
+  const slice = filtered.slice(cursor, cursor + limit).map(({ hash: _hash, ...t }) => t);
+  const nextCursor = cursor + limit < filtered.length ? cursor + limit : undefined;
   return { items: slice, nextCursor };
 }
 

--- a/apps/api/src/tests/tickets.store.spec.ts
+++ b/apps/api/src/tests/tickets.store.spec.ts
@@ -74,6 +74,37 @@ describe('ticket store', () => {
     await app.close();
   });
 
+  it('filters tickets by strategy when provided', async () => {
+    const base: Ticket = {
+      symbol: 'ESZ4',
+      side: 'BUY',
+      entry: 100,
+      stop: 99,
+      target: 102,
+      qty: 1,
+      accountId: 'A1',
+      timestampUtc: '2024-01-01T10:00:00Z',
+      meta: { strategy: 'VWAP_FT', rr: 2, guardrails: [] },
+      accepted: true,
+    };
+    await store.saveTicket(base);
+    await store.saveTicket({
+      ...base,
+      timestampUtc: '2024-01-01T11:00:00Z',
+      meta: { ...base.meta, strategy: 'OSB' },
+    });
+    const app = buildServer();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/tickets?date=2024-01-01&strategy=OSB',
+    });
+    const body = res.json();
+    expect(body.tickets).toHaveLength(1);
+    expect(body.tickets[0].meta.strategy).toBe('OSB');
+    expect(body.nextCursor).toBeNull();
+    await app.close();
+  });
+
   it('exports CSV with strategy column', async () => {
     const t: Ticket = {
       symbol: 'ESZ4',

--- a/docs/operator-console.md
+++ b/docs/operator-console.md
@@ -7,7 +7,7 @@ You don’t need to code. Follow these steps exactly. Prism-Apex never places or
 
 Open the local dashboard (or call the API):
 
-GET /tickets?date=YYYY-MM-DD → list of today’s tickets
+GET /tickets?date=YYYY-MM-DD[&strategy=STRATEGY] → list of today’s tickets (optionally filter by strategy)
 
 GET /export/tickets?date=YYYY-MM-DD → CSV export
 

--- a/docs/tickets.md
+++ b/docs/tickets.md
@@ -125,7 +125,7 @@ Dashboard displays an EOD countdown to flat window start.
 
 7) Endpoints (read-only)
 
-GET /tickets?date=YYYY-MM-DD — JSONL aggregation for the day.
+GET /tickets?date=YYYY-MM-DD[&strategy=STRATEGY] — JSONL aggregation for the day (optional strategy filter).
 
 GET /export/tickets?date=YYYY-MM-DD — CSV snapshot.
 


### PR DESCRIPTION
## Summary
- allow the GET /tickets route to accept an optional strategy query and pass it to the store
- filter stored tickets by strategy before paginating and cover the behaviour with tests
- document the strategy filter in the OpenAPI spec and operator docs

## Testing
- pnpm --filter @prism-apex/api test
- pnpm lint:api

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [x] Contract/security/performance notes (if relevant)
- [x] Rollback steps (and DOWN scripts if migrations)
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c94b339050832cbd439cbc6a554f8a