### PR TITLE
Add APX-DDB-01 suggestion handling

### DIFF
--- a/apps/api/fixtures/strategies.config.json
+++ b/apps/api/fixtures/strategies.config.json
@@ -1,4 +1,10 @@
 {
   "VWAP_FT": {},
-  "OSB": { "orMinutes": 5 }
+  "OSB": { "orMinutes": 5 },
+  "APX-DDB-01": {
+    "bufferTicks": 2,
+    "minStopTicks": { "ES": 12 },
+    "rr": 3,
+    "guardrails": ["WEEKLY_VWAP_BIAS"]
+  }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -49,6 +49,7 @@
     "@prism-apex/rules-apex": "workspace:*",
     "@prism-apex/signals": "workspace:*",
     "@prism-apex/strategies": "workspace:*",
+    "@prism-apex/strategy-apx-ddb01": "workspace:*",
     "@prism-apex/runtime": "workspace:*",
     "fastify": "5.5.0",
     "fastify-plugin": "5.0.1",

--- a/apps/api/src/jobs/__tests__/strategies.apx-ddb01.spec.ts
+++ b/apps/api/src/jobs/__tests__/strategies.apx-ddb01.spec.ts
@@ -1,0 +1,112 @@
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { publish, subscribe, resetBusForTests } from '../../lib/bus.js';
+import {
+  startStrategies,
+  stopStrategies,
+  strategies,
+  type BarMessage,
+  type Suggestion,
+} from '../strategies.js';
+
+describe('APX-DDB-01 strategy integration', () => {
+  const suggestions: Suggestion[] = [];
+  let unsubscribe: (() => void) | undefined;
+
+  beforeEach(async () => {
+    resetBusForTests();
+    suggestions.length = 0;
+    process.env.STRATEGIES_CONFIG_PATH = path.resolve('fixtures/strategies.config.json');
+    unsubscribe = subscribe<Suggestion>('suggestion', (s) => {
+      suggestions.push(s);
+    });
+    await startStrategies();
+  });
+
+  afterEach(async () => {
+    await stopStrategies();
+    unsubscribe?.();
+    resetBusForTests();
+    delete process.env.STRATEGIES_CONFIG_PATH;
+    strategies.counts['APX-DDB-01'] = 0;
+  });
+
+  it('emits a single APX-DDB-01 suggestion once prior day data is present', () => {
+    const symbol = 'ES';
+    const contract = 'ESZ4';
+    const mondayOpen = new Date('2024-06-03T13:30:00.000Z');
+    const mondayBars = [
+      { high: 5310, low: 5298, close: 5305, volume: 1000 },
+      { high: 5320, low: 5305, close: 5315, volume: 1000 },
+      { high: 5330, low: 5315, close: 5325, volume: 1000 },
+      { high: 5332, low: 5320, close: 5328, volume: 1000 },
+      { high: 5334.75, low: 5325, close: 5330, volume: 1000 },
+    ];
+
+    mondayBars.forEach((bar, idx) => {
+      const ts = new Date(mondayOpen.getTime() + idx * 60_000).toISOString();
+      publish<BarMessage>('bars.1m', {
+        symbol,
+        contract,
+        ts,
+        open: bar.close,
+        high: bar.high,
+        low: bar.low,
+        close: bar.close,
+        volume: bar.volume,
+        session: 'RTH',
+      });
+    });
+
+    expect(suggestions).toHaveLength(0);
+
+    const tuesdayOpen = new Date('2024-06-04T13:30:00.000Z');
+    const tuesdayBars = [
+      { high: 5336, low: 5330, close: 5335, volume: 1200 },
+      { high: 5338, low: 5332, close: 5336, volume: 1100 },
+    ];
+
+    tuesdayBars.forEach((bar, idx) => {
+      const ts = new Date(tuesdayOpen.getTime() + idx * 60_000).toISOString();
+      publish<BarMessage>('bars.1m', {
+        symbol,
+        contract,
+        ts,
+        open: bar.close,
+        high: bar.high,
+        low: bar.low,
+        close: bar.close,
+        volume: bar.volume,
+        session: 'RTH',
+      });
+    });
+
+    expect(suggestions).toHaveLength(1);
+    const suggestion = suggestions[0];
+    expect(suggestion.meta.strategy).toBe('APX-DDB-01');
+    expect(suggestion.entry).toBeCloseTo(5334.25, 5);
+    expect(suggestion.stop).toBeCloseTo(5331.25, 5);
+    expect(suggestion.target).toBeCloseTo(5343.25, 5);
+    expect(suggestion.meta.rr).toBeCloseTo(3, 5);
+    expect(suggestion.meta.weeklyVwap).toBeGreaterThan(0);
+    expect(suggestion.meta.priorHigh).toBeCloseTo(5334.75, 5);
+    expect(suggestion.meta.stopTicks).toBe(12);
+    expect(suggestion.meta.bufferTicks).toBe(2);
+    expect(strategies.counts['APX-DDB-01']).toBe(1);
+
+    const extraTs = new Date(tuesdayOpen.getTime() + 2 * 60_000).toISOString();
+    publish<BarMessage>('bars.1m', {
+      symbol,
+      contract,
+      ts: extraTs,
+      open: 5335,
+      high: 5337,
+      low: 5333,
+      close: 5334,
+      volume: 1000,
+      session: 'RTH',
+    });
+
+    expect(suggestions).toHaveLength(1);
+  });
+});

--- a/apps/api/src/jobs/strategies.ts
+++ b/apps/api/src/jobs/strategies.ts
@@ -12,6 +12,7 @@ import {
   openingSwingBreakout,
   type Suggestion as StratSuggestion,
 } from '@prism-apex/strategies';
+import { planLongOnlyRetest } from '@prism-apex/strategy-apx-ddb01';
 import { trackEvent } from '@prism-apex/analytics';
 import fs from 'fs';
 import path from 'path';
@@ -37,6 +38,10 @@ export type Suggestion = StratSuggestion & {
     atrTicks?: number;
     orHigh?: number;
     orLow?: number;
+    weeklyVwap?: number;
+    priorHigh?: number;
+    stopTicks?: number;
+    bufferTicks?: number;
   };
 };
 
@@ -44,6 +49,17 @@ interface DebounceState {
   vwapActive: boolean;
   osbLong: boolean;
   osbShort: boolean;
+  ddbLong: boolean;
+}
+
+interface Ddb01State {
+  weekKey: string;
+  cumulativeTPV: number;
+  cumulativeVolume: number;
+  weeklyVwap: number;
+  priorRthHigh?: number;
+  currentRthHigh?: number;
+  lastSuggestionSession?: string;
 }
 
 interface ContractState {
@@ -55,6 +71,7 @@ interface ContractState {
   debounce: DebounceState;
   orHigh?: number;
   orLow?: number;
+  ddb01: Ddb01State;
 }
 
 const TICK_SPECS: Record<string, { tickSize: number }> = {
@@ -79,13 +96,22 @@ export const strategies = {
   counts: makeStrategyCounter(),
 };
 
+interface Ddb01Config {
+  enabled?: boolean;
+  bufferTicks?: number;
+  minStopTicks?: number | Record<string, number>;
+  rr?: number;
+  guardrails?: string[];
+  sizingHintPctOfMax?: number;
+}
+
 interface Config {
   VWAP_FT: Record<string, any>;
   OSB: Record<string, any>;
-  'APX-DDB-01'?: Record<string, any>;
+  'APX-DDB-01': Ddb01Config;
 }
 
-let cfg: Config = { VWAP_FT: {}, OSB: {} };
+let cfg: Config = { VWAP_FT: {}, OSB: {}, 'APX-DDB-01': {} };
 
 function loadConfig(): Config {
   const defaultPath =
@@ -95,7 +121,12 @@ function loadConfig(): Config {
     ? defaultPath
     : path.join(process.cwd(), '../../configs/strategies.default.json');
   const txt = fs.readFileSync(p, 'utf8');
-  return JSON.parse(txt);
+  const parsed = JSON.parse(txt) as Partial<Config>;
+  return {
+    VWAP_FT: parsed?.VWAP_FT ?? {},
+    OSB: parsed?.OSB ?? {},
+    'APX-DDB-01': parsed?.['APX-DDB-01'] ?? {},
+  };
 }
 
 let unsub: (() => void) | null = null;
@@ -103,6 +134,14 @@ const state = new Map<string, ContractState>();
 
 function sessionKey(ts: string): string {
   return ts.slice(0, 10);
+}
+
+function weekKey(ts: string): string {
+  const d = new Date(ts);
+  const day = d.getUTCDay();
+  const diff = (day + 6) % 7; // 0 -> Monday
+  d.setUTCDate(d.getUTCDate() - diff);
+  return d.toISOString().slice(0, 10);
 }
 
 async function start(): Promise<void> {
@@ -127,16 +166,31 @@ function onBar(bar: BarMessage): void {
   const key = `${bar.contract}`;
   let cs = state.get(key);
   const skey = sessionKey(bar.ts);
+  const wkey = weekKey(bar.ts);
   if (!cs || cs.sessionKey !== skey) {
+    const prevDdb = cs?.ddb01;
+    const sameWeek = prevDdb?.weekKey === wkey;
     cs = {
       sessionKey: skey,
       bars: [],
       vwapState: initialVwapState(),
       vwapSeries: [],
       atrSeries: [],
-      debounce: { vwapActive: false, osbLong: false, osbShort: false },
+      debounce: { vwapActive: false, osbLong: false, osbShort: false, ddbLong: false },
       orHigh: undefined,
       orLow: undefined,
+      ddb01: {
+        weekKey: wkey,
+        cumulativeTPV: sameWeek && prevDdb ? prevDdb.cumulativeTPV : 0,
+        cumulativeVolume: sameWeek && prevDdb ? prevDdb.cumulativeVolume : 0,
+        weeklyVwap: sameWeek && prevDdb ? prevDdb.weeklyVwap : NaN,
+        priorRthHigh:
+          typeof prevDdb?.currentRthHigh === 'number' && Number.isFinite(prevDdb.currentRthHigh)
+            ? prevDdb.currentRthHigh
+            : undefined,
+        currentRthHigh: undefined,
+        lastSuggestionSession: undefined,
+      },
     };
     state.set(key, cs);
   }
@@ -159,6 +213,9 @@ function onBar(bar: BarMessage): void {
     cs.orHigh = Math.max(...orWindow.map((b) => b.high));
     cs.orLow = Math.min(...orWindow.map((b) => b.low));
   }
+
+  updateDdbState(cs, bar, wkey);
+  maybeEmitDdbSuggestion(bar, cs, tick, cfg['APX-DDB-01']);
 
   swings(cs.bars as any, 3); // computed for side-effects (debug)
 
@@ -212,6 +269,111 @@ function onBar(bar: BarMessage): void {
       }
     }
   }
+}
+
+function updateDdbState(cs: ContractState, bar: BarMessage, currentWeekKey: string): void {
+  if (cs.ddb01.weekKey !== currentWeekKey) {
+    cs.ddb01.weekKey = currentWeekKey;
+    cs.ddb01.cumulativeTPV = 0;
+    cs.ddb01.cumulativeVolume = 0;
+    cs.ddb01.weeklyVwap = NaN;
+  }
+
+  const vol = Number.isFinite(bar.volume) ? Math.max(0, bar.volume) : 0;
+  if (vol > 0) {
+    const typicalPrice = (bar.high + bar.low + bar.close) / 3;
+    cs.ddb01.cumulativeTPV += typicalPrice * vol;
+    cs.ddb01.cumulativeVolume += vol;
+    cs.ddb01.weeklyVwap = cs.ddb01.cumulativeTPV / cs.ddb01.cumulativeVolume;
+  }
+
+  const currentHigh = cs.ddb01.currentRthHigh ?? -Infinity;
+  cs.ddb01.currentRthHigh = Math.max(currentHigh, bar.high);
+}
+
+function maybeEmitDdbSuggestion(
+  bar: BarMessage,
+  cs: ContractState,
+  tick: { tickSize: number },
+  config: Ddb01Config,
+): void {
+  if (config.enabled === false) return;
+  if (cs.debounce.ddbLong) return;
+  if (cs.ddb01.lastSuggestionSession === cs.sessionKey) return;
+
+  const priorHigh = cs.ddb01.priorRthHigh;
+  const weeklyVwap = cs.ddb01.weeklyVwap;
+  if (typeof priorHigh !== 'number' || !Number.isFinite(priorHigh) || priorHigh <= 0) return;
+  if (!Number.isFinite(weeklyVwap)) return;
+
+  const bufferTicks = config.bufferTicks ?? 2;
+  const minStopTicks = resolveMinStopTicks(config, bar.symbol, Math.max(bufferTicks, 12));
+  const plan = planLongOnlyRetest({
+    tickSize: tick.tickSize,
+    currentPrice: bar.close,
+    weeklyVwap,
+    priorHigh,
+    bufferTicks,
+    minStopTicks,
+    rr: config.rr,
+  });
+  if (!plan) return;
+
+  const stopTicks = plan.stopTicks;
+  if (!(stopTicks > 0)) return;
+  const targetTicks = Math.max(1, Math.round(plan.rr * stopTicks));
+  const entry = roundToTick(plan.entry, tick.tickSize);
+  const stop = roundPrice(entry - stopTicks * tick.tickSize);
+  const target = roundPrice(entry + targetTicks * tick.tickSize);
+
+  const meta: Suggestion['meta'] = {
+    strategy: 'APX-DDB-01',
+    rr: plan.rr,
+    notes: plan.notes,
+    weeklyVwap,
+    priorHigh,
+    stopTicks,
+    bufferTicks,
+  };
+  if (Array.isArray(config.guardrails) && config.guardrails.length > 0) {
+    meta.guardrails = config.guardrails;
+  }
+  if (typeof config.sizingHintPctOfMax === 'number') {
+    meta.sizingHintPctOfMax = config.sizingHintPctOfMax;
+  }
+
+  const suggestion: Suggestion = {
+    symbol: bar.symbol,
+    contract: bar.contract,
+    side: 'BUY',
+    entry,
+    stop,
+    target,
+    timestampUtc: bar.ts,
+    meta,
+  };
+
+  cs.debounce.ddbLong = true;
+  cs.ddb01.lastSuggestionSession = cs.sessionKey;
+  emitSuggestion(suggestion);
+}
+
+function resolveMinStopTicks(config: Ddb01Config, symbol: string, fallback: number): number {
+  const { minStopTicks } = config;
+  if (typeof minStopTicks === 'number') return minStopTicks;
+  if (minStopTicks && typeof minStopTicks[symbol] === 'number') {
+    return minStopTicks[symbol] as number;
+  }
+  return fallback;
+}
+
+function roundToTick(price: number, tickSize: number): number {
+  if (tickSize <= 0) return price;
+  return Number((Math.round(price / tickSize) * tickSize).toFixed(10));
+}
+
+function roundPrice(price: number): number {
+  return Number(price.toFixed(10));
 }
 
 function emitSuggestion(s: Suggestion): void {

--- a/apps/api/src/tests/strategies.orchestrator.spec.ts
+++ b/apps/api/src/tests/strategies.orchestrator.spec.ts
@@ -134,12 +134,14 @@ describe('strategy orchestrator', () => {
       'VWAP_FT',
       'OSB',
       'VWAP_FT',
+      'APX-DDB-01',
     ]);
     expect(suggestions.map((s) => s.side)).toEqual([
       'BUY',
       'BUY',
       'SELL',
       'SELL',
+      'BUY',
     ]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@prism-apex/strategies':
         specifier: workspace:*
         version: link:../../packages/strategies
+      '@prism-apex/strategy-apx-ddb01':
+        specifier: workspace:*
+        version: link:../../packages/strategy-apx-ddb01
       fastify:
         specifier: 5.5.0
         version: 5.5.0


### PR DESCRIPTION
## Summary
- extend the strategies job with APX-DDB-01 state, config loading, and suggestion emission using `planLongOnlyRetest`
- wire configuration and dependencies for APX-DDB-01 including fixture defaults
- add integration coverage for the new handler and update orchestrator expectations

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI) - N/A
- [x] Contract/security/performance notes (if relevant) - N/A
- [x] Rollback steps (and DOWN scripts if migrations) - N/A
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c9514ff10c832c844a9bb21b95f164