### PR TITLE
feat: sync disk ticket files into the API store

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ Data & volumes
 
 API persists state under Docker volume api-data mounted at /data (e.g., /data/tickets/YYYY-MM-DD/*.json).
 
+A companion `tickets-sync` service continuously imports per-ticket JSON into `/data/tickets.jsonl` for the API.
+
 UIs mount the same volume read-only to display tickets.
 
 Environment (safe defaults)
 
-NODE_ENV=production, LOG_LEVEL=info, APEX_DATA_DIR=/data
+NODE_ENV=production, LOG_LEVEL=info, DATA_DIR=/data, TICKETS_DIR=/data/tickets (APEX_DATA_DIR still honored)
 
 TRADOVATE_BASE_URL=http://localhost/disabled (market-data OFF by default)
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint . --ext .ts",
     "format": "prettier -w .",
     "format:check": "prettier -c .",
-    "openapi:emit": "tsx src/scripts/openapi.ts > openapi.json"
+    "openapi:emit": "tsx src/scripts/openapi.ts > openapi.json",
+    "sync:tickets": "tsx src/scripts/syncTickets.ts"
   },
   "devDependencies": {
     "@types/node": "^20.19.11",

--- a/apps/api/src/jobs/__tests__/ticketsDiskSync.spec.ts
+++ b/apps/api/src/jobs/__tests__/ticketsDiskSync.spec.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sampleTicket = {
+  symbol: 'MESZ5',
+  side: 'BUY' as const,
+  entry: 5550.25,
+  stop: 5544.25,
+  target: 5560.25,
+  qty: 2,
+  accountId: 'APEX-123456',
+  timestampUtc: '2025-09-09T14:31:22Z',
+  meta: {
+    strategy: 'VWAP_FT' as const,
+    rr: 1.5,
+    guardrails: ['rrInRange'],
+    sizingHint: 'half-size',
+    consistencyNotes: 'test',
+  },
+  accepted: true,
+  reasons: [],
+};
+
+describe('tickets disk sync job', () => {
+  let tmpDir: string;
+  let ticketsDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pat-sync-'));
+    ticketsDir = path.join(tmpDir, 'tickets');
+    process.env.DATA_DIR = tmpDir;
+    process.env.TICKETS_DIR = ticketsDir;
+    fs.mkdirSync(ticketsDir, { recursive: true });
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    const store = await import('../../store/tickets.js');
+    store._clear();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.DATA_DIR;
+    delete process.env.TICKETS_DIR;
+    vi.resetModules();
+  });
+
+  it('imports ticket files into the JSONL store', async () => {
+    const day = sampleTicket.timestampUtc.slice(0, 10);
+    const dayDir = path.join(ticketsDir, day);
+    fs.mkdirSync(dayDir, { recursive: true });
+    fs.writeFileSync(path.join(dayDir, 'ticket-1.json'), JSON.stringify(sampleTicket, null, 2));
+
+    const store = await import('../../store/tickets.js');
+    store._clear();
+
+    const { syncTicketsFromDisk, resetTicketsDiskSyncState } = await import('../ticketsDiskSync.js');
+    resetTicketsDiskSyncState();
+
+    const processed = await syncTicketsFromDisk({ rootDir: ticketsDir });
+    expect(processed).toBe(1);
+
+    const result = store.listTickets(day, 0, 10);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].symbol).toBe(sampleTicket.symbol);
+  });
+});

--- a/apps/api/src/jobs/ticketsDiskSync.ts
+++ b/apps/api/src/jobs/ticketsDiskSync.ts
@@ -1,0 +1,112 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { Dirent } from 'node:fs';
+import { TicketSchema } from '../schemas/ticket.js';
+import type { Ticket } from '../store/tickets.js';
+import { saveTicket } from '../store/tickets.js';
+import { resolveTicketsDir } from '../utils/dirs.js';
+
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const processedFiles = new Set<string>();
+
+type Logger = {
+  debug?: (...args: any[]) => void;
+  info?: (...args: any[]) => void;
+  warn?: (...args: any[]) => void;
+  error?: (...args: any[]) => void;
+};
+
+export type TicketsSyncOptions = {
+  rootDir?: string;
+  force?: boolean;
+  logger?: Logger;
+};
+
+async function readDirSafe(dir: string, logger?: Logger): Promise<Dirent[]> {
+  try {
+    return await fs.readdir(dir, { withFileTypes: true });
+  } catch (err: any) {
+    if (err?.code === 'ENOENT' || err?.code === 'ENOTDIR') {
+      logger?.debug?.({ dir }, 'tickets directory missing');
+      return [];
+    }
+    logger?.error?.({ err, dir }, 'failed to read tickets directory');
+    return [];
+  }
+}
+
+async function loadTicket(file: string, logger?: Logger): Promise<Ticket | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, 'utf8');
+  } catch (err) {
+    logger?.warn?.({ err, file }, 'failed to read ticket file');
+    return null;
+  }
+  if (!raw.trim()) {
+    logger?.warn?.({ file }, 'ticket file empty');
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    logger?.warn?.({ err, file }, 'invalid JSON ticket file');
+    return null;
+  }
+  const result = TicketSchema.safeParse(parsed);
+  if (!result.success) {
+    logger?.warn?.({ file, issues: result.error.issues }, 'ticket file failed validation');
+    return null;
+  }
+  return result.data;
+}
+
+export async function syncTicketsFromDisk(options: TicketsSyncOptions = {}): Promise<number> {
+  if (options.force) processedFiles.clear();
+  const rootDir = options.rootDir ?? resolveTicketsDir();
+  const dayDirs = await readDirSafe(rootDir, options.logger);
+  if (dayDirs.length === 0) return 0;
+
+  let processed = 0;
+  for (const entry of dayDirs) {
+    if (!entry.isDirectory() || !DAY_RE.test(entry.name)) continue;
+    const dayDir = path.join(rootDir, entry.name);
+    let files: Dirent[] = [];
+    try {
+      files = await fs.readdir(dayDir, { withFileTypes: true });
+    } catch (err) {
+      options.logger?.warn?.({ err, dayDir }, 'failed to read tickets day directory');
+      continue;
+    }
+    for (const file of files) {
+      if (!file.isFile() || !file.name.toLowerCase().endsWith('.json')) continue;
+      const fullPath = path.join(dayDir, file.name);
+      if (!options.force && processedFiles.has(fullPath)) continue;
+      const ticket = await loadTicket(fullPath, options.logger);
+      if (!ticket) {
+        processedFiles.add(fullPath);
+        continue;
+      }
+      try {
+        await saveTicket(ticket);
+        processedFiles.add(fullPath);
+        processed++;
+      } catch (err) {
+        options.logger?.error?.({ err, file: fullPath }, 'failed to save ticket');
+      }
+    }
+  }
+  if (processed > 0) {
+    options.logger?.info?.({ processed }, 'synced tickets from disk');
+  }
+  return processed;
+}
+
+export async function runTicketsDiskSyncJob(logger?: Logger): Promise<void> {
+  await syncTicketsFromDisk({ logger });
+}
+
+export function resetTicketsDiskSyncState(): void {
+  processedFiles.clear();
+}

--- a/apps/api/src/lib/accounts.ts
+++ b/apps/api/src/lib/accounts.ts
@@ -1,9 +1,10 @@
 import { loadAccounts, type AccountsFile, type AccountRecord } from '@prism-apex/accounts';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { resolveDataDir } from '../utils/dirs.js';
 
 function dataDir(): string {
-  return process.env.DATA_DIR ?? path.resolve(process.cwd(), 'data');
+  return resolveDataDir();
 }
 function filePath(): string {
   return path.join(dataDir(), 'accounts.json');

--- a/apps/api/src/scripts/syncTickets.ts
+++ b/apps/api/src/scripts/syncTickets.ts
@@ -1,0 +1,51 @@
+import process from 'node:process';
+import { syncTicketsFromDisk } from '../jobs/ticketsDiskSync.js';
+
+function parseArgs(argv: string[]): { once: boolean; interval: number; force: boolean } {
+  let once = false;
+  let interval = 30_000;
+  let force = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--once') {
+      once = true;
+    } else if (arg === '--watch') {
+      once = false;
+    } else if (arg.startsWith('--interval=')) {
+      const value = Number(arg.split('=')[1]);
+      if (Number.isFinite(value) && value > 0) interval = value;
+    } else if (arg === '--interval' || arg === '-i') {
+      const next = argv[i + 1];
+      const value = Number(next);
+      if (Number.isFinite(value) && value > 0) {
+        interval = value;
+        i++;
+      }
+    } else if (arg === '--force') {
+      force = true;
+    }
+  }
+  return { once, interval, force };
+}
+
+async function runOnce(force: boolean): Promise<void> {
+  try {
+    await syncTicketsFromDisk({ logger: console, force });
+  } catch (err) {
+    console.error('[sync-tickets] run failed', err);
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  await runOnce(args.force);
+  if (args.once) return;
+  setInterval(() => {
+    void runOnce(false);
+  }, args.interval);
+}
+
+main().catch((err) => {
+  console.error('[sync-tickets] fatal error', err);
+  process.exitCode = 1;
+});

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -38,6 +38,7 @@ import { registerJob, startJobs, stopJobs } from './jobs/scheduler.js';
 import { jobMissingBrackets } from './jobs/missingBrackets.js';
 import { jobDailyLoss } from './jobs/dailyLoss.js';
 import { jobConsistency } from './jobs/consistency.js';
+import { runTicketsDiskSyncJob } from './jobs/ticketsDiskSync.js';
 
 const DISABLE = process.env.DISABLE_JOBS === '1' || process.env.NODE_ENV === 'test';
 
@@ -108,8 +109,8 @@ export function buildServer() {
   app.register(ticketsRoutes);
   app.register(telemetryRoutes);
   app.register(tradingviewWebhookRoutes, { prefix: '/webhooks' });
-app.register(jobsBoot);
-// ---- Jobs ----
+  app.register(jobsBoot);
+  // ---- Jobs ----
   registerStrategiesJob();
   registerTicketizerJob();
   registerTelemetryJob();
@@ -117,6 +118,7 @@ app.register(jobsBoot);
   registerJob('MISSING_BRACKETS', 15_000, jobMissingBrackets);
   registerJob('DAILY_LOSS', 60_000, jobDailyLoss);
   registerJob('CONSISTENCY', 300_000, jobConsistency);
+  registerJob('DISK_TICKETS_SYNC', 30_000, () => runTicketsDiskSyncJob(app.log));
 
   if (!DISABLE) {
     jobManager.startAll().catch((err) => app.log.error({ err }, 'job start failed'));
@@ -126,7 +128,7 @@ app.register(jobsBoot);
     stopJobs();
     await jobManager.stopAll();
   });
-app.register(openapi);
+  app.register(openapi);
 
   return app;
 }

--- a/apps/api/src/store.ts
+++ b/apps/api/src/store.ts
@@ -2,10 +2,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import type { Ticket as StoreTicket, ParseResult } from './types.js';
+import { resolveDataDir } from './utils/dirs.js';
 export type { Ticket } from './store/tickets.js';
 export type TicketType = import('./store/tickets.js').Ticket;
 
-const DATA_DIR = process.env.DATA_DIR || '/var/lib/prism-apex-tool';
+const DATA_DIR = resolveDataDir();
 const DATA_FILE = path.join(DATA_DIR, 'data.json');
 
 type TicketEntry = { when: string; ticket: StoreTicket; reasons: string[] };

--- a/apps/api/src/store/tickets.ts
+++ b/apps/api/src/store/tickets.ts
@@ -3,8 +3,9 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import type { Ticket } from '../schemas/ticket.js';
 export type { Ticket } from '../schemas/ticket.js';
+import { resolveDataDir } from '../utils/dirs.js';
 
-const DATA_DIR = process.env.DATA_DIR || '/var/lib/prism-apex-tool';
+const DATA_DIR = resolveDataDir();
 const FILE = path.join(DATA_DIR, 'tickets.jsonl');
 
 type Stored = Ticket & { hash: string };

--- a/apps/api/src/utils/dirs.ts
+++ b/apps/api/src/utils/dirs.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+
+const DEFAULT_DATA_DIR = '/var/lib/prism-apex-tool';
+
+export function resolveDataDir(): string {
+  return process.env.DATA_DIR || process.env.APEX_DATA_DIR || DEFAULT_DATA_DIR;
+}
+
+export function resolveTicketsDir(): string {
+  return process.env.TICKETS_DIR || path.join(resolveDataDir(), 'tickets');
+}
+
+export { DEFAULT_DATA_DIR };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     environment:
       NODE_ENV: production
       LOG_LEVEL: info
+      DATA_DIR: /data
       APEX_DATA_DIR: /data
+      TICKETS_DIR: /data/tickets
       # Safe defaults; provide real values via env/.env if needed
       TRADOVATE_BASE_URL: "http://localhost/disabled"
       TRADINGVIEW_WEBHOOK_SECRET: ""
@@ -22,6 +24,26 @@ services:
       timeout: 3s
       start_period: 20s
       retries: 5
+    restart: unless-stopped
+
+  tickets-sync:
+    build:
+      context: .
+      target: api
+    image: prism-apex/api:local
+    container_name: prism-apex-tickets-sync
+    depends_on:
+      api:
+        condition: service_started
+    environment:
+      NODE_ENV: production
+      LOG_LEVEL: info
+      DATA_DIR: /data
+      APEX_DATA_DIR: /data
+      TICKETS_DIR: /data/tickets
+    command: ['node', '/app/apps/api/dist/scripts/syncTickets.js', '--watch', '--interval=15000']
+    volumes:
+      - api-data:/data
     restart: unless-stopped
 
 volumes:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -19,7 +19,7 @@ UI loads (5178 for Lite, 8080 for Full)
 
 Confirm tickets path
 
-API writes to /data/tickets/YYYY-MM-DD/*.json (volume api-data)
+API writes to /data/tickets/YYYY-MM-DD/*.json (volume api-data); tickets-sync keeps /data/tickets.jsonl aggregated
 
 Copy tickets to broker
 

--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -1,6 +1,6 @@
 # Accounts Registry API
 
-The accounts registry stores account metadata on disk under `DATA_DIR/accounts`. Each account is saved as a JSON file and has the shape:
+The accounts registry stores account metadata on disk under `DATA_DIR/accounts` (falls back to `APEX_DATA_DIR` when set). Each account is saved as a JSON file and has the shape:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- add a disk-ticket sync worker and CLI so per-ticket JSON files land in the API JSONL store
- register the sync job with the API server, schedule it in Docker compose, and expose a pnpm helper script
- centralize DATA_DIR/TICKETS_DIR resolution and document the new tickets-sync flow with regression coverage

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [x] Contract/security/performance notes (if relevant) – N/A
- [x] Rollback steps (and DOWN scripts if migrations) – N/A
- [x] Deprecation/cleanup noted or N/A – N/A

------
https://chatgpt.com/codex/tasks/task_b_68c95aa5d1b8832c80d68ed64fc3d50a