### PR TITLE
feat: validate ticket strategy filters

### DIFF
--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -6,6 +6,7 @@ import {
 import { z } from 'zod';
 import { OSBInput, VWAPInput, SuggestionResultSchema } from '../schemas/signals.js';
 import { PromoteInput } from '../schemas/ticketsPromote.js';
+import { TICKET_STRATEGIES } from '../schemas/ticket.js';
 
 extendZodWithOpenApi(z);
 
@@ -179,7 +180,7 @@ registry.registerPath({
       date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
       cursor: z.string().optional(),
       limit: z.string().optional(),
-      strategy: z.string().optional(),
+      strategy: z.enum(TICKET_STRATEGIES).optional(),
     }),
   },
   responses: {

--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -4,6 +4,7 @@ import { listTickets, exportTickets } from '../store/tickets.js';
 import { guardSuggestion } from '../jobs/ticketizer.js';
 import { loadRegistry } from '@prism-apex/config';
 import { getConfig } from '../config/env.js';
+import { TICKET_STRATEGIES } from '../schemas/ticket.js';
 
 export async function ticketsRoutes(app: FastifyInstance) {
   app.get('/tickets', async (req, reply) => {
@@ -12,7 +13,7 @@ export async function ticketsRoutes(app: FastifyInstance) {
         date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
         cursor: z.coerce.number().optional(),
         limit: z.coerce.number().optional(),
-        strategy: z.string().optional(),
+        strategy: z.enum(TICKET_STRATEGIES).optional(),
       })
       .safeParse(req.query);
     if (!q.success) return reply.code(400).send({ error: 'Invalid query' });

--- a/apps/api/src/tests/tickets.api.spec.ts
+++ b/apps/api/src/tests/tickets.api.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { buildServer } from '@prism-apex/app-api/server.js';
+import { resetSchedulerForTests } from '@prism-apex/app-api/jobs/scheduler.js';
+import { TICKET_STRATEGIES } from '@prism-apex/app-api/schemas/ticket.js';
+import type { FastifyInstance } from 'fastify';
+
+describe('tickets API strategy validation', () => {
+  const date = '2024-01-01';
+  let app: FastifyInstance;
+
+  beforeAll(() => {
+    resetSchedulerForTests();
+    app = buildServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    resetSchedulerForTests();
+  });
+
+  for (const strategy of TICKET_STRATEGIES) {
+    it(`accepts known strategy ${strategy}`, async () => {
+      const res = await app.inject({ method: 'GET', url: `/tickets?date=${date}&strategy=${strategy}` });
+      expect(res.statusCode).toBe(200);
+    });
+  }
+
+  it('rejects unknown strategies', async () => {
+    const res = await app.inject({ method: 'GET', url: `/tickets?date=${date}&strategy=UNKNOWN` });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('Invalid query');
+  });
+});


### PR DESCRIPTION
## Summary
- validate `/tickets` strategy query against the known ticket strategy IDs
- document the allowed strategy values in the OpenAPI schema
- add regression tests covering accepted and rejected strategy IDs

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

## PR Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI)
- [x] Contract/security/performance notes (if relevant) – N/A
- [x] Rollback steps (and DOWN scripts if migrations) – revert commit
- [x] Deprecation/cleanup noted or N/A

------
https://chatgpt.com/codex/tasks/task_b_68c9720ac7ec832cb7733b0f2390d7ac