### PR TITLE
chore: configure ingress docker compose override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,32 @@
+services:
+  # Ensure API still uses the named volume for /data
+  api:
+    volumes:
+      - api-data:/data
+
+  # Tickets sync watches the same /data/tickets
+  tickets-sync:
+    volumes:
+      - api-data:/data
+
+  # Yahoo ingress: write tickets into the SAME place the API reads from
+  ingress-yahoo:
+    environment:
+      - APEX_TICKETS_OUTDIR=/data/tickets
+      - APEX_ENABLE_YAHOO_INGRESS=true
+    volumes:
+      - api-data:/data
+
+  # Prefer the lite dashboard during local bring-up to avoid port conflicts
+  dashboard-lite:
+    environment:
+      - API_BASE_URL=http://api:3000
+      - APEX_TICKETS_DIR=/data/tickets
+    depends_on:
+      - api
+    volumes:
+      - api-data:/data:ro
+
+volumes:
+  api-data:
+    external: false


### PR DESCRIPTION
## Summary
- add docker-compose override so ingress, tickets-sync, and dashboard-lite share the api-data volume
- set yahoo ingress ticket output directory to the shared /data/tickets path for local end-to-end visibility

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

## Checklist
- [x] Scope limited as described
- [x] No prohibited behavior introduced (e.g., no API order placement if project forbids)
- [x] Lint/type/tests considered (logs attached if failures pre-exist)
- [x] Docs updated if applicable (README/docs/ADR/CHANGELOG/OpenAPI) — N/A
- [x] Contract/security/performance notes (if relevant) — N/A
- [x] Rollback steps (and DOWN scripts if migrations) — N/A
- [x] Deprecation/cleanup noted or N/A


------
https://chatgpt.com/codex/tasks/task_b_68c9825dbf90832cba58c1c2655767b6