### PR TITLE
ci(db): backfill + dedup; tolerate REPLACE_ME

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -1,0 +1,41 @@
+name: backfill
+on:
+  workflow_dispatch:
+    inputs:
+      DAYS:
+        description: "Days to backfill (today + previous N-1)"
+        required: false
+        default: "14"
+      S:
+        description: "Strategy"
+        required: false
+        default: "default"
+      REF:
+        description: "Branch/ref to run split-validate on"
+        required: false
+        default: "Test"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Dispatch split-validate for last N days
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const days = parseInt(core.getInput('DAYS') || '14', 10);
+            const ref  = core.getInput('REF')  || 'Test';
+            const S    = core.getInput('S')    || 'default';
+            for (let i=0; i<days; i++) {
+              const d = new Date();
+              d.setUTCDate(d.getUTCDate() - i);
+              const D = d.toISOString().slice(0,10);
+              await github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: '.github/workflows/split-validate.yml',
+                ref,
+                inputs: { D, S }
+              });
+              core.info(`dispatched ${D} ${S}`);
+            }

--- a/.github/workflows/split-validate.yml
+++ b/.github/workflows/split-validate.yml
@@ -89,6 +89,11 @@ jobs:
           # Best-effort health probe (non-fatal)
           curl -fsS "${B_EFF}/health" >/dev/null || echo "ℹ️ health probe non-200; proceeding to /tickets"
 
+          # Normalize placeholder secret to empty so fallback works
+          B_EFF="${B:-}"
+          if [ -z "${B_EFF}" ] || [ "${B_EFF}" = "REPLACE_ME" ]; then
+            B_EFF="http://localhost:3000"
+          fi
           curl -fsSL "${B_EFF}/tickets?date=${D}&strategy=${S}" > "tickets_${D}_${S}.jsonl"
           if [ ! -s "tickets_${D}_${S}.jsonl" ]; then
             echo "No tickets returned"

--- a/bin/load_jsonl_to_pg.sh
+++ b/bin/load_jsonl_to_pg.sh
@@ -1,29 +1,38 @@
 #!/usr/bin/env bash
-# Loads tickets_${D}_${S}.jsonl into prism.tickets_raw using PG_URL.
-# Exits successfully without loading if PG_URL is unset/empty.
 set -euo pipefail
+D="${D:-}"; S="${S:-}"; PG_URL="${PG_URL:-}"; IN="${1:-}"
 
-: "${D:?}"
-: "${S:?}"
-: "${PG_URL:=}"
-
-INPUT="tickets_${D}_${S}.jsonl"
-
-if [ -z "$PG_URL" ]; then
-  echo "PG_URL not set; skipping load"
-  exit 0
+if [ -z "$IN" ]; then
+  [ -n "$D" ] && [ -n "$S" ] || { echo "D and S required or pass input file"; exit 1; }
+  IN="tickets_${D}_${S}.jsonl"
 fi
 
-command -v psql >/dev/null 2>&1 || { echo "psql is required"; exit 1; }
-command -v jq >/dev/null 2>&1 || { echo "jq is required"; exit 1; }
-[ -s "$INPUT" ] || { echo "missing or empty $INPUT"; exit 1; }
+[ -n "$PG_URL" ] || { echo "PG_URL not set; skipping load"; exit 0; }
+[ -s "$IN" ] || { echo "missing or empty $IN"; exit 1; }
+command -v psql >/dev/null || { echo "psql required"; exit 1; }
+command -v jq   >/dev/null || { echo "jq required"; exit 1; }
 
-psql "$PG_URL" -v ON_ERROR_STOP=1 -f "db/db_init.sql"
+psql "$PG_URL" -v ON_ERROR_STOP=1 -f db/db_init.sql
+psql "$PG_URL" -v ON_ERROR_STOP=1 -f db/db_dedup.sql
 
 TMP="$(mktemp)"
-jq -r --arg d "$D" --arg s "$S" '[ $d, $s, tostring ] | @tsv' "$INPUT" > "$TMP"
+# TSV: date \t strategy \t payload-json
+jq -r --arg d "${D:-}" --arg s "${S:-}" '
+  if (($d|length)>0) and (($s|length)>0) then
+    [ $d, $s, tostring ] | @tsv
+  else
+    [ (.date // ""), (.strategy // ""), tostring ] | @tsv
+  end
+' "$IN" > "$TMP"
 
-psql "$PG_URL" -v ON_ERROR_STOP=1 -c "\copy prism.tickets_raw (date, strategy, payload) FROM '$TMP' WITH (FORMAT text, DELIMITER E'\t')"
+psql "$PG_URL" -v ON_ERROR_STOP=1 -c "\copy prism.tickets_raw_stage (date, strategy, payload) FROM '$TMP' WITH (FORMAT text, DELIMITER E'\t')"
+
+psql "$PG_URL" -v ON_ERROR_STOP=1 -c "
+  insert into prism.tickets_raw(date,strategy,payload)
+  select date,strategy,payload from prism.tickets_raw_stage
+  on conflict do nothing;
+  truncate prism.tickets_raw_stage;
+"
 
 rm -f "$TMP"
-echo "loaded $(wc -l < "$INPUT" | tr -d ' ') rows to prism.tickets_raw"
+echo "loaded $(wc -l < "$IN" | tr -d " ") rows (dedup applied)"

--- a/db/db_dedup.sql
+++ b/db/db_dedup.sql
@@ -1,0 +1,21 @@
+create schema if not exists prism;
+
+create table if not exists prism.tickets_raw (
+  date text not null,
+  strategy text not null,
+  payload jsonb not null,
+  ingested_at timestamptz not null default now()
+);
+
+alter table prism.tickets_raw
+  add column if not exists payload_hash text
+  generated always as (md5(payload::text)) stored;
+
+create unique index if not exists uq_tickets_raw_date_strategy_hash
+  on prism.tickets_raw (date, strategy, payload_hash);
+
+create table if not exists prism.tickets_raw_stage (
+  date text not null,
+  strategy text not null,
+  payload jsonb not null
+);


### PR DESCRIPTION
Adds backfill.yml (defaults 14 days). Dedup via payload hash + unique index, loader upserts via staging. Makes split-validate treat REPLACE_ME as empty (fallback to localhost for local API).