### PR TITLE
ci(backfill): pat-based gh dispatch

### DIFF
--- a/.github/workflows/backfill.yml
+++ b/.github/workflows/backfill.yml
@@ -14,28 +14,24 @@ on:
         description: "Branch/ref to run split-validate on"
         required: false
         default: "Test"
-
+permissions:
+  actions: write
+  contents: read
 jobs:
   dispatch:
     runs-on: ubuntu-24.04
     steps:
-      - name: Dispatch split-validate for last N days
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const days = parseInt(core.getInput('DAYS') || '14', 10);
-            const ref  = core.getInput('REF')  || 'Test';
-            const S    = core.getInput('S')    || 'default';
-            for (let i=0; i<days; i++) {
-              const d = new Date();
-              d.setUTCDate(d.getUTCDate() - i);
-              const D = d.toISOString().slice(0,10);
-              await github.request('POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches', {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: '.github/workflows/split-validate.yml',
-                ref,
-                inputs: { D, S }
-              });
-              core.info(`dispatched ${D} ${S}`);
-            }
+      - name: Require PAT secret
+        run: test -n "${{ secrets.GH_PAT_WORKFLOWS }}"
+      - name: Dispatch split-validate via gh CLI
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+        run: |
+          set -euo pipefail
+          DAYS="${{ inputs.DAYS }}"; S="${{ inputs.S }}"; REF="${{ inputs.REF }}"
+          : "${DAYS:=14}"; : "${S:=default}"; : "${REF:=Test}"
+          for ((i=0;i<DAYS;i++)); do
+            D=$(date -u -d "$i days ago" +%F)
+            gh workflow run .github/workflows/split-validate.yml -r "$REF" -f D="$D" -f S="$S"
+            echo "dispatched $D $S"
+          done


### PR DESCRIPTION
Use GH_PAT_WORKFLOWS with gh CLI to dispatch split-validate.