### PR TITLE
Local dev: tickets-sync CJS fix, Postgres 55433, Node healthcheck & docs (tickets-only)

### DIFF
--- a/.env.example.local
+++ b/.env.example.local
@@ -1,0 +1,20 @@
+# === Prism-Apex local example (.env) ===
+# Run: docker compose --env-file .env.example.local up -d --build
+
+# Tickets-only posture (no direct orders)
+TICKETS_ONLY=true
+ORDERS_DISABLED=true
+
+# Postgres (local dev)
+POSTGRES_USER=apex
+POSTGRES_PASSWORD=apex
+POSTGRES_DB=prismapex
+POSTGRES_PORT=55433
+DATABASE_URL=postgresql://apex:apex@localhost:55433/prismapex?schema=public
+
+# API
+API_PORT=3000
+
+# Logging
+NODE_ENV=development
+LOG_LEVEL=info

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ reports/
 .env.*
 !.env.example
 !.env.local.example
+!.env.example.local
+
+# Generated local data
+data/*.json
+data/*.jsonl
 
 # Misc
 .DS_Store

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,32 +1,70 @@
+# Dev-only override: CJS runtime for tickets-sync, local Postgres, tickets-only guards,
+# Node-based API healthcheck (no curl), and dual mounts for tickets visibility.
 services:
-  # Ensure API still uses the named volume for /data
   api:
-    volumes:
-      - api-data:/data
-
-  # Tickets sync watches the same /data/tickets
-  tickets-sync:
-    volumes:
-      - api-data:/data
-
-  # Yahoo ingress: write tickets into the SAME place the API reads from
-  ingress-yahoo:
     environment:
-      - APEX_TICKETS_OUTDIR=/data/tickets
-      - APEX_ENABLE_YAHOO_INGRESS=true
-    volumes:
-      - api-data:/data
-
-  # Prefer the lite dashboard during local bring-up to avoid port conflicts
-  dashboard-lite:
-    environment:
-      - API_BASE_URL=http://api:3000
-      - APEX_TICKETS_DIR=/data/tickets
+      TICKETS_ONLY: "${TICKETS_ONLY:-true}"
+      ORDERS_DISABLED: "${ORDERS_DISABLED:-true}"
+      DATABASE_URL: "${DATABASE_URL:-postgresql://apex:apex@db:5432/prismapex?schema=public}"
+      NODE_ENV: "${NODE_ENV:-development}"
+      LOG_LEVEL: "${LOG_LEVEL:-info}"
+    ports:
+      - "${API_PORT:-3000}:3000"
     depends_on:
-      - api
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: [
+        "CMD-SHELL",
+        "node -e \"const http=require('http');const paths=['/health','/'];const tryNext=()=>{if(!paths.length)return process.exit(1);const path=paths.shift();http.get({host:'127.0.0.1',port:3000,path},res=>{if(res.statusCode===200)process.exit(0);tryNext();}).on('error',tryNext);};tryNext();setTimeout(()=>process.exit(1),5000);\""
+      ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     volumes:
-      - api-data:/data:ro
+      - ./data:/app/data
+      - ./data:/data
+
+  tickets-sync:
+    # Force CommonJS execution of syncTickets by copying .js -> .cjs then running it.
+    command: >
+      sh -lc "
+        set -e;
+        TS_JS=/app/apps/api/dist/scripts/syncTickets.js;
+        TS_CJS=/app/apps/api/dist/scripts/syncTickets.cjs;
+        if [ -f \"$$TS_JS\" ]; then cp \"$$TS_JS\" \"$$TS_CJS\"; fi;
+        node \"$$TS_CJS\"
+      "
+    environment:
+      TICKETS_ONLY: "${TICKETS_ONLY:-true}"
+      ORDERS_DISABLED: "${ORDERS_DISABLED:-true}"
+      DATABASE_URL: "${DATABASE_URL:-postgresql://apex:apex@db:5432/prismapex?schema=public}"
+      NODE_ENV: "${NODE_ENV:-development}"
+      LOG_LEVEL: "${LOG_LEVEL:-info}"
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - ./data:/app/data
+      - ./data:/data
+
+  db:
+    image: postgres:16-alpine
+    container_name: prism-apex-db
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER:-apex}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-apex}"
+      POSTGRES_DB: "${POSTGRES_DB:-prismapex}"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-apex} -d ${POSTGRES_DB:-prismapex}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    ports:
+      - "${POSTGRES_PORT:-55433}:5432"
+    volumes:
+      - prismapex_db_data:/var/lib/postgresql/data
 
 volumes:
-  api-data:
-    external: false
+  prismapex_db_data:
+    driver: local

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -1,0 +1,38 @@
+# Prism-Apex — Local Dev (tickets-only)
+
+Run the local pipeline end-to-end without placing real orders: Yahoo → Postgres → strategy → tickets JSONL → dashboard/API.
+
+## Prerequisites
+- Docker Desktop (or compatible) with Compose
+- Checked-out branch `fix/tickets-sync-cjs-and-local-db`
+- Files in repo root: `docker-compose.yml`, `docker-compose.override.yml`, `.env.example.local`
+
+## 1. Start the stack (Postgres on host **55433**)
+```bash
+docker compose --env-file .env.example.local up -d --build
+```
+
+What spins up:
+- **api** – serves on http://localhost:3000 with a Node-based healthcheck (no curl dependency)
+- **tickets-sync** – copies `syncTickets.js` → `.cjs` and runs it under Node 20
+- **db** – postgres:16-alpine bound host 55433 → container 5432
+
+## 2. Verify everything is healthy
+```bash
+docker compose ps
+docker inspect --format '{{json .State.Health}}' $(docker compose ps -q api)
+docker compose logs --no-color tickets-sync | tail -n 60
+docker compose exec -T api sh -lc 'tail -n 10 /app/data/tickets.jsonl || tail -n 10 /data/tickets.jsonl || true'
+```
+You should see new rows in `data/tickets.jsonl`, and the API healthcheck should report `"Status":"healthy"` once `/health` or `/` returns 200.
+
+## 3. Stop the stack
+```bash
+docker compose down        # keep the Postgres volume
+# docker compose down -v   # wipe volumes for a clean slate
+```
+
+## Notes
+- Tickets-only posture is enforced: `TICKETS_ONLY=true`, `ORDERS_DISABLED=true`
+- Generated artifacts under `data/` (e.g., `tickets.jsonl`) are now ignored by Git
+- If port 55433 conflicts, override `POSTGRES_PORT` when invoking `docker compose`


### PR DESCRIPTION
Re-applied local changes on top of origin/Test to ensure shared ancestry.\n\n- tickets-sync runs as CJS via .cjs shim (no ESM exports error)\n- local Postgres on 55433 (dev-only override)\n- Node-based API healthcheck (no curl)\n- docs/LOCAL_DEV.md & .gitignore for data/*.jsonl\n\nNo order APIs; tickets-only posture preserved.