### PR TITLE
SAFE cleanup: add dry-run option

### DIFF
--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -36,3 +36,15 @@ docker compose down        # keep the Postgres volume
 - Tickets-only posture is enforced: `TICKETS_ONLY=true`, `ORDERS_DISABLED=true`
 - Generated artifacts under `data/` (e.g., `tickets.jsonl`) are now ignored by Git
 - If port 55433 conflicts, override `POSTGRES_PORT` when invoking `docker compose`
+
+## Cleanup (SAFE / dry-run)
+Preview what would be removed (no deletions):
+```bash
+tools/cleanup_yahoo_data.sh --dry-run
+# or set DRY_RUN=1 tools/cleanup_yahoo_data.sh
+```
+Perform the real cleanup (creates a backups/yahoo-data-*.tar.gz archive first):
+```bash
+tools/cleanup_yahoo_data.sh
+```
+Reports land in `docs/YAHOO_DATA_CLEANUP.md`.

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -1,0 +1,17 @@
+# Maintenance — SAFE Data Cleanup
+
+Use `tools/cleanup_yahoo_data.sh` to clear Yahoo-style artifacts in a controlled way.
+
+1. **Dry run (recommended first)**
+   ```bash
+   tools/cleanup_yahoo_data.sh --dry-run
+   ```
+   Only reports what *would* be backed up/removed (writes to `docs/YAHOO_DATA_CLEANUP.md`).
+
+2. **Real cleanup**
+   ```bash
+   tools/cleanup_yahoo_data.sh
+   ```
+   Creates a timestamped `backups/yahoo-data-*.tar.gz` archive before deleting untracked candidates.
+
+Tracked files are never deleted; tracked candidates are listed for manual inspection.

--- a/tools/cleanup_yahoo_data.sh
+++ b/tools/cleanup_yahoo_data.sh
@@ -1,7 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# SAFE cleanup for Yahoo-style data: only remove **untracked** files under data/cache/tmp-like dirs.
+# Supports dry-run mode via --dry-run flag or DRY_RUN=1 env.
+# Always creates a backup archive before real deletions.
+
 ROOT="${1:-$(pwd)}"
+shift || true
+
+DRY_RUN="${DRY_RUN:-0}"
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run|--dryrun) DRY_RUN=1 ;;
+    -h|--help)
+      cat <<'HELP'
+Usage: tools/cleanup_yahoo_data.sh [ROOT] [--dry-run]
+
+Scans for untracked Yahoo-style data files (csv/json/parquet/sqlite) under
+ data/, .cache/, cache/, caches/, tmp/, apps/*/data/, packages/*/data/.
+
+Flags:
+  --dry-run    Preview backup/removal (no files deleted, no backup archive)
+Env:
+  DRY_RUN=1    Same as --dry-run
+HELP
+      exit 0
+      ;;
+  esac
+done
+
 TS="$(date -u +%Y%m%d%H%M%S)"
 REPORT="$ROOT/docs/YAHOO_DATA_CLEANUP.md"
 BACKUP_DIR="$ROOT/backups"
@@ -10,42 +37,36 @@ BACKUP="$BACKUP_DIR/yahoo-data-${TS}.tar.gz"
 NAME_RE='(yahoo|yf|quote|quotes|ohlc|bars|candles|history|cache)'
 EXT_RE='\.(csv|json|jsonl|ndjson|parquet|feather|arrow|sqlite|db)$'
 
-is_in_scope() {
+in_scope() {
   case "$1" in
-    data/*|.cache/*|cache/*|caches/*|tmp/*|apps/*/data/*|packages/*/data/*)
-      return 0 ;;
-    *)
-      return 1 ;;
+    data/*|.cache/*|cache/*|caches/*|tmp/*|apps/*/data/*|packages/*/data/*) return 0 ;;
+    *) return 1 ;;
   esac
 }
 
 mkdir -p "$ROOT/docs" "$BACKUP_DIR"
 
-# Gather untracked file list
 CAND_UNTRACKED=()
 while IFS= read -r -d '' rel; do
   [[ -z "$rel" ]] && continue
-  # Skip directories (git won't output them)
-  is_in_scope "$rel" || continue
+  in_scope "$rel" || continue
   abs="$ROOT/$rel"
   [ -f "$abs" ] || continue
   base="${rel##*/}"
   shopt -s nocasematch
   if [[ "$base" =~ $NAME_RE ]] || [[ "$abs" =~ $EXT_RE ]]; then
     case "$rel" in
-      backups/*|*.tar.gz|*.tgz) ;; # skip backups themselves
+      backups/*|*.tar.gz|*.tgz) : ;; # skip backups themselves
       *) CAND_UNTRACKED+=("$abs") ;;
     esac
   fi
   shopt -u nocasematch
-
 done < <(git -C "$ROOT" ls-files --others --exclude-standard -z)
 
-# Gather tracked candidates (report only)
 CAND_TRACKED=()
 while IFS= read -r -d '' rel; do
   [[ -z "$rel" ]] && continue
-  is_in_scope "$rel" || continue
+  in_scope "$rel" || continue
   abs="$ROOT/$rel"
   [ -f "$abs" ] || continue
   base="${rel##*/}"
@@ -54,15 +75,15 @@ while IFS= read -r -d '' rel; do
     CAND_TRACKED+=("$abs")
   fi
   shopt -u nocasematch
-
 done < <(git -C "$ROOT" ls-files -z)
 
 {
   echo "# Yahoo Data Cleanup (SAFE: untracked-only)"
   echo "- UTC: $(date -u '+%Y-%m-%d %H:%M:%S')"
+  echo "- Mode: $([ "$DRY_RUN" = "1" ] && echo "DRY-RUN" || echo "REAL")"
   echo "- Backup (untracked set): \`backups/$(basename "$BACKUP")\`"
   echo
-  echo "## Untracked candidates (backed up + removed)"
+  echo "## Untracked candidates ($([ "$DRY_RUN" = "1" ] && echo "preview" || echo "backed up + removed"))"
   if [ ${#CAND_UNTRACKED[@]} -eq 0 ]; then
     echo "_None_"
   else
@@ -94,11 +115,17 @@ done < <(git -C "$ROOT" ls-files -z)
 } > "$REPORT"
 
 if [ ${#CAND_UNTRACKED[@]} -eq 0 ]; then
-  echo "No untracked Yahoo-style data to backup/remove."
-  exit 0
+  echo "No untracked Yahoo-style data to process."; exit 0
 fi
 
-python3 - "$ROOT" "$BACKUP" "${CAND_UNTRACKED[@]}" <<'PY'
+if [ "$DRY_RUN" = "1" ]; then
+  echo "[DRY-RUN] Would create backup: $BACKUP"
+  for abs in "${CAND_UNTRACKED[@]}"; do
+    rel="${abs#"$ROOT/"}"
+    echo "[DRY-RUN] Would delete: $rel"
+  done
+else
+  python3 - "$ROOT" "$BACKUP" "${CAND_UNTRACKED[@]}" <<'PY'
 import os, sys, tarfile
 root = os.path.abspath(sys.argv[1])
 backup = os.path.abspath(sys.argv[2])
@@ -112,11 +139,10 @@ with tarfile.open(backup, 'w:gz') as tar:
             tar.add(f, arcname=os.path.relpath(f, root))
 print(f"Backed up {len(files)} files to {backup}")
 PY
-
-for abs in "${CAND_UNTRACKED[@]}"; do
-  rm -f -- "$abs"
-
-done
+  for abs in "${CAND_UNTRACKED[@]}"; do
+    rm -f -- "$abs" || true
+  done
+fi
 
 {
   echo
@@ -124,9 +150,13 @@ done
   echo '```'
   for abs in "${CAND_UNTRACKED[@]}"; do
     rel="${abs#"$ROOT/"}"
-    [ ! -f "$abs" ] && echo "$rel"
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "[DRY-RUN] still present: $rel"
+    else
+      [ ! -f "$abs" ] && echo "$rel"
+    fi
   done
   echo '```'
 } >> "$REPORT"
 
-echo "SAFE cleanup complete."
+echo "SAFE cleanup complete. Mode: $([ "$DRY_RUN" = "1" ] && echo "DRY-RUN" || echo "REAL")"


### PR DESCRIPTION
Adds a dry-run guardrail to the untracked Yahoo/data cleanup tool.\n\n- `tools/cleanup_yahoo_data.sh` supports \ or \ to preview actions.\n- Updates \ and new \ to document usage.\n\nNo product/runtime changes; still untracked-only with backups before real deletes.