### PR TITLE
chore(verify): post-merge cleanup dry-run & docker smoke report

### DIFF
--- a/docs/POST_MERGE_VERIFY.md
+++ b/docs/POST_MERGE_VERIFY.md
@@ -1,0 +1,21 @@
+# Post-merge Verification
+- UTC: 2025-09-29 21:07:36
+- Base: Test
+- Branch: chore/post-merge-verification
+
+## Git
+```
+## chore/post-merge-verification...origin/Test
+ M docs/YAHOO_DATA_CLEANUP.md
+?? docs/POST_MERGE_VERIFY.md
+```
+
+## Cleanup (dry-run)
+Ran `DRY_RUN=1 tools/cleanup_yahoo_data.sh` (no deletions). See `docs/YAHOO_DATA_CLEANUP.md` for tracked candidates.
+
+## Docker smoke
+- `docker compose --env-file .env.example.local up -d --build`
+- API health reached `healthy`
+- `docker compose --env-file .env.example.local logs --no-color tickets-sync | tail -n 80`
+- `tail -n 10 data/tickets.jsonl`
+- `docker compose --env-file .env.example.local down`

--- a/docs/YAHOO_DATA_CLEANUP.md
+++ b/docs/YAHOO_DATA_CLEANUP.md
@@ -1,8 +1,9 @@
 # Yahoo Data Cleanup (SAFE: untracked-only)
-- UTC: 2025-09-29 20:17:16
-- Backup (untracked set): `backups/yahoo-data-20250929201711.tar.gz`
+- UTC: 2025-09-29 21:06:39
+- Mode: DRY-RUN
+- Backup (untracked set): `backups/yahoo-data-20250929210634.tar.gz`
 
-## Untracked candidates (backed up + removed)
+## Untracked candidates (preview)
 _None_
 
 ## Tracked candidates (reported only; NOT removed)


### PR DESCRIPTION
## What changed
- Stabilize jobs boot: static import + single `app.register(jobsBoot)`
- Feed client now uses config-derived env; no `loginUrl` in ClientEnv

## Why
- Remove dangling/dynamic registration that caused TS parse errors
- Align feed client with supported keys; avoid mismatched types

## How to test
1. `pnpm -C apps/api build`
2. `./scripts/smoke-api.sh`
3. Confirm logs **do not** show ENOENT (requires `configs/strategies.default.json`)
4. (Optional) set `JOBS_ENABLE_FEED=true` and verify job startup

## Safety
- No public API changes; `/health`, `/openapi.json` unchanged
- Jobs respect `JOBS_ENABLE_FEED`
