### PR TITLE
chore(guardrails): block large blobs and forbidden data types

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,0 +1,25 @@
+name: repo-guard
+on:
+  pull_request:
+    branches: [ Test, Main, main ]
+  push:
+    branches: [ Test, Main, main ]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Block >10MB blobs in history
+        run: |
+          git rev-list --objects --all \
+          | git cat-file --batch-check='%(objecttype) %(objectname) %(objectsize) %(rest)' \
+          | awk '$1=="blob" && $3>10*1024*1024{print; bad=1} END{exit bad}'
+      - name: Block forbidden file types / paths in working tree
+        run: |
+          git ls-files -z \
+          | egrep -z -i '\\.(parquet|sqlite|csv)$' && { echo "Forbidden extensions present"; exit 1; } || true
+          # hard path checks (ignore dotfiles)
+          egrep -z -i '(^|/)\.pnpm-store/|(^|/)data/|(^|/)dump(s)?/|(^|/)cache/' < <(git ls-files -z) \
+            && { echo "Forbidden paths present"; exit 1; } || true

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+THRESH=$((10*1024*1024))
+status=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -z "${local_sha:-}" ] && continue
+  range="$remote_sha..$local_sha"
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    range="$local_sha"
+  fi
+  if ! git rev-list --objects "$range" \
+    | git cat-file --batch-check='%(objecttype) %(objectname) %(objectsize) %(rest)' \
+    | awk -v T="$THRESH" '$1=="blob" && $3>T{printf "❌ large blob: %s bytes %s\n", $3, $4; bad=1} END{exit bad+0}'; then
+    status=1
+  fi
+done
+
+FILES=$(git ls-files -z -- ':!apps/api/data/*')
+if printf "%s" "$FILES" | egrep -z -i '\\.(parquet|sqlite|csv)$'; then
+  echo "❌ forbidden extensions present (excluding apps/api/data)"
+  status=1
+fi
+if printf "%s" "$FILES" | egrep -z -i '(^|/)\.pnpm-store/|(^|/)data/|(^|/)dump(s)?/|(^|/)cache/'; then
+  echo "❌ forbidden paths present"
+  status=1
+fi
+
+if [ "$status" -ne 0 ]; then
+  exit 1
+fi
+
+echo "✅ pre-push checks passed"


### PR DESCRIPTION
Adds CI checks and an optional local pre-push hook to prevent `.pnpm-store/**`, `data/**`, `dump*/**`, `**/cache/**` and `*.parquet|*.sqlite|*.csv`; also blocks >10MB blobs.