### PR TITLE
chore(db): nightly Postgres maintenance (VACUUM/ANALYZE) + local DB compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPOSE=docker compose -f docker-compose.yml
+COMPOSE=docker compose -f docker-compose.yml -f docker-compose.db.yml
 
 .PHONY: up down build logs
 up:
@@ -9,3 +9,9 @@ build:
 	$(COMPOSE) build --no-cache
 logs:
 	$(COMPOSE) logs -f --tail=200
+
+.PHONY: ps maint
+ps:
+	$(COMPOSE) ps
+maint:
+	$(COMPOSE) run --rm db_maint sh -lc 'psql "$$DATABASE_URL" -v ON_ERROR_STOP=1 -f /maintenance/maintenance.sql && echo "VACUUM ANALYZE completed"'

--- a/deploy/db/maintenance.sql
+++ b/deploy/db/maintenance.sql
@@ -1,0 +1,7 @@
+-- SAFE maintenance for performance stats; does NOT delete user data.
+-- Runs a whole-database VACUUM (ANALYZE). Adds autovacuum stats to the planner.
+VACUUM (ANALYZE);
+
+-- If you later want per-table targeting, copy these lines and name tables explicitly:
+-- VACUUM (ANALYZE) public.bars;
+-- VACUUM (ANALYZE) public.tickets;

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,38 @@
+services:
+  # Local Postgres (for dev/staging laptop use).
+  # Uses credentials referenced by .env (DATABASE_URL).
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: ${PGUSER:-apex}
+      POSTGRES_PASSWORD: ${PGPASSWORD:-apex}
+      POSTGRES_DB: ${PGDATABASE:-prismapex}
+    ports:
+      - "${PGHOSTPORT:-55433}:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  # Nightly VACUUM(ANALYZE) using cron + psql
+  db_maint:
+    image: alpine:3.20
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgres://apex:apex@db:5432/prismapex}
+      TZ: ${TZ:-UTC}
+    volumes:
+      - ./deploy/db:/maintenance:ro
+    entrypoint: ["/bin/sh","-lc"]
+    command: |
+      set -e
+      apk add --no-cache postgresql-client tzdata >/dev/null
+      # Install crontab to run daily at 02:00 container-local time
+      crontab - <<'CRON'
+      0 2 * * * psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /maintenance/maintenance.sql >> /var/log/cron.log 2>&1
+      CRON
+      touch /var/log/cron.log
+      echo "[db_maint] cron started (nightly VACUUM ANALYZE @ 02:00)"
+      crond -f -l 8
+
+volumes:
+  db_data:


### PR DESCRIPTION
Adds safe nightly VACUUM(ANALYZE) cron sidecar and a local Postgres compose add-on. Includes 'make maint' for manual runs. No data deletion.