### PR TITLE
chore(ingest): nightly 1m gapfill cron

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -35,3 +35,14 @@ make build    # rebuild images (no cache)
 - **Port already in use (3000/8080)** → stop the conflicting process or container (`docker ps` then `docker stop <id>`).
 - **Build fails on dashboard** → ensure TypeScript DOM libs/shims are present; run `pnpm -C apps/dashboard build` locally to check.
 - **Health endpoint** → If `/health` is not implemented, either add one in the API or adjust/remove the healthcheck.
+
+## Gapfill maintenance (1-minute bars)
+- One-shot: `make gapfill` (fetches only missing minutes in the last 30 days; duplicate-safe).
+- Nightly: `gapfill-cron` service runs at **02:20 UTC (GMT)** and writes logs to `/var/log/gapfill-cron.log`.
+
+Verify:
+```bash
+docker compose -f docker-compose.yml -f docker-compose.db.yml up -d gapfill-cron
+docker compose -f docker-compose.yml -f docker-compose.db.yml logs --tail=20 gapfill-cron
+```
+

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,7 @@ ps:
 	$(COMPOSE) ps
 maint:
 	$(COMPOSE) run --rm db_maint sh -lc 'psql "$$DATABASE_URL" -v ON_ERROR_STOP=1 -f /maintenance/maintenance.sql && echo "VACUUM ANALYZE completed"'
+
+.PHONY: gapfill
+gapfill:
+	$(COMPOSE) run --rm gapfill-once

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -36,5 +36,30 @@ services:
           echo "[db_maint] cron started (nightly VACUUM ANALYZE @ 02:00)"
           crond -f -l 8
 
+  gapfill-cron:
+    image: alpine:3.20
+    depends_on:
+      - db
+    environment:
+      - TZ=UTC
+      - DATABASE_URL=${DATABASE_URL:-postgres://apex:apex@db:5432/prismapex}
+      - YAHOO_SYMBOLS=${YAHOO_SYMBOLS:-ES=F,NQ=F,GC=F,CL=F}
+      - YAHOO_INTERVAL=${YAHOO_INTERVAL:-1m}
+    volumes:
+      - ./:/repo:ro
+    entrypoint:
+      - /bin/sh
+      - -lc
+      - |
+          set -e
+          apk add --no-cache nodejs-current npm >/dev/null
+          corepack enable >/dev/null 2>&1 || true
+          crontab - <<'CRON'
+          20 2 * * * node /repo/apps/ingest/dist/gapfill.js >> /var/log/gapfill-cron.log 2>&1
+          CRON
+          touch /var/log/gapfill-cron.log
+          echo "[gapfill-cron] scheduled daily 02:20 UTC (GMT)."
+          crond -f -l 8
+
 volumes:
   db_data:


### PR DESCRIPTION
Adds `gapfill-cron` sidecar (02:20 UTC/GMT) and a `make gapfill` one-shot helper. Safe dedupe; light on Yahoo.