### PR TITLE
Downloads: 28-day window & all-symbols bars export

### DIFF
--- a/apps/api/src/routes/export.ts
+++ b/apps/api/src/routes/export.ts
@@ -1,0 +1,245 @@
+import type { FastifyInstance } from 'fastify';
+import { Client } from 'pg';
+import fs from 'node:fs';
+import { join } from 'node:path';
+
+const FOURTEEN_DAYS_MS = 28 * 24 * 60 * 60 * 1000; // now 28-day window
+const DEFAULT_ROW_LIMIT = 50000;
+
+function asUtcIso(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed.toISOString();
+}
+
+function clampWindow14d(startIso: string, endIso: string) {
+  let startValue = Date.parse(startIso);
+  let endValue = Date.parse(endIso);
+  if (!Number.isFinite(startValue) || !Number.isFinite(endValue)) {
+    return { startIso, endIso };
+  }
+  if (endValue < startValue) {
+    [startValue, endValue] = [endValue, startValue];
+  }
+  if (endValue - startValue > FOURTEEN_DAYS_MS) {
+    endValue = startValue + FOURTEEN_DAYS_MS;
+  }
+  return {
+    startIso: new Date(startValue).toISOString(),
+    endIso: new Date(endValue).toISOString(),
+  };
+}
+
+function ensureRange(startIso?: string, endIso?: string) {
+  let start = startIso;
+  let end = endIso;
+  const now = Date.now();
+
+  if (!start && !end) {
+    end = new Date(now).toISOString();
+    start = new Date(now - FOURTEEN_DAYS_MS).toISOString();
+  } else if (!start && end) {
+    const endValue = Date.parse(end);
+    if (Number.isFinite(endValue)) {
+      start = new Date(endValue - FOURTEEN_DAYS_MS).toISOString();
+    }
+  } else if (start && !end) {
+    const startValue = Date.parse(start);
+    if (Number.isFinite(startValue)) {
+      end = new Date(Math.min(Date.now(), startValue + FOURTEEN_DAYS_MS)).toISOString();
+    }
+  }
+
+  if (!start || !end) {
+    const fallbackEnd = new Date(now).toISOString();
+    const fallbackStart = new Date(now - FOURTEEN_DAYS_MS).toISOString();
+    return { startIso: fallbackStart, endIso: fallbackEnd };
+  }
+
+  return clampWindow14d(start, end);
+}
+
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n]/.test(str)) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
+function buildCsv(rows: Record<string, unknown>[], columns: { key: string; label: string }[]) {
+  const header = columns.map((col) => col.label).join(',');
+  const data = rows.map((row) => columns.map((col) => csvEscape(row[col.key])).join(','));
+  return [header, ...data].join('\n');
+}
+
+export async function exportRoutes(app: FastifyInstance) {
+  app.get('/api/export/readme.md', async (_, reply) => {
+    const readmePath = join(process.cwd(), 'README.md');
+    if (!fs.existsSync(readmePath)) {
+      reply.code(404);
+      return reply.send({ error: 'README not found' });
+    }
+    reply
+      .header('Content-Type', 'text/markdown; charset=utf-8')
+      .header('Content-Disposition', 'attachment; filename="README.md"');
+    return reply.send(fs.createReadStream(readmePath));
+  });
+
+  app.get('/api/export/bars.csv', async (request, reply) => {
+    const { symbol, start, end, limit, all } = (request.query ?? {}) as {
+      symbol?: string;
+      start?: string;
+      end?: string;
+      limit?: string;
+      all?: string;
+    };
+
+    const wantAll = (all === '1') || (symbol?.toUpperCase() === 'ALL');
+    if (!wantAll && !symbol) {
+      reply.code(400);
+      return reply.send({ error: 'symbol is required (or use all=1)' });
+    }
+
+    const startIso = asUtcIso(start);
+    const endIso = asUtcIso(end);
+    const range = ensureRange(startIso, endIso);
+
+    const rowLimit = Math.max(1, Math.min(DEFAULT_ROW_LIMIT, Number(limit ?? DEFAULT_ROW_LIMIT)));
+
+    const client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+
+    try {
+      const whereClauses: string[] = [];
+      const params: unknown[] = [];
+
+      if (!wantAll) {
+        params.push(symbol);
+        whereClauses.push(`symbol = $${params.length}`);
+      }
+
+      params.push(range.startIso);
+      whereClauses.push(`ts_utc >= $${params.length}`);
+
+      params.push(range.endIso);
+      whereClauses.push(`ts_utc < $${params.length}`);
+
+      const whereSql = whereClauses.join(' AND ');
+
+      const query = `
+        SELECT symbol, ts_utc, open, high, low, close, volume
+          FROM bars_1m
+         WHERE ${whereSql}
+         ORDER BY ${wantAll ? 'symbol ASC, ' : ''}ts_utc ASC
+         LIMIT ${rowLimit}
+      `;
+
+      const { rows } = await client.query(query, params);
+
+      const csv = buildCsv(rows, [
+        { key: 'symbol', label: 'symbol' },
+        { key: 'ts_utc', label: 'ts_utc' },
+        { key: 'open', label: 'open' },
+        { key: 'high', label: 'high' },
+        { key: 'low', label: 'low' },
+        { key: 'close', label: 'close' },
+        { key: 'volume', label: 'volume' },
+      ]);
+
+      const fileLabel = wantAll ? 'ALL' : symbol;
+      reply
+        .header('Content-Type', 'text/csv; charset=utf-8')
+        .header('Content-Disposition', `attachment; filename="bars-${fileLabel}.csv"`);
+      return reply.send(csv);
+    } finally {
+      await client.end();
+    }
+  });
+
+  app.get('/api/export/tickets.csv', async (request, reply) => {
+    const { strategy, status, direction, source, start, end, limit, symbol } = (request.query ?? {}) as {
+      strategy?: string;
+      status?: string;
+      direction?: string;
+      source?: string;
+      start?: string;
+      end?: string;
+      limit?: string;
+      symbol?: string;
+    };
+
+    const startIso = asUtcIso(start);
+    const endIso = asUtcIso(end);
+    const range = startIso && endIso ? clampWindow14d(startIso, endIso) : ensureRange(startIso, endIso);
+
+    const rowLimit = Math.max(1, Math.min(DEFAULT_ROW_LIMIT, Number(limit ?? DEFAULT_ROW_LIMIT)));
+
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+
+    const addClause = (sql: string, value?: string) => {
+      if (!value) return;
+      params.push(value);
+      clauses.push(sql.replace('?', `$${params.length}`));
+    };
+
+    addClause('symbol = ?', symbol);
+    addClause('strategy = ?', strategy);
+    addClause('status = ?', status);
+    addClause('direction = ?', direction);
+    addClause('source = ?', source);
+
+    if (range.startIso) {
+      params.push(range.startIso);
+      clauses.push(`opened_at_utc >= $${params.length}`);
+    }
+    if (range.endIso) {
+      params.push(range.endIso);
+      clauses.push(`opened_at_utc < $${params.length}`);
+    }
+
+    const whereSql = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+
+    const client = new Client({ connectionString: process.env.DATABASE_URL });
+    await client.connect();
+
+    try {
+      const query = `
+        SELECT opened_at_utc, symbol, strategy, direction, status, source,
+               entry_price, stop_price, target_price, rr, actionable, non_actionable_reason
+          FROM tickets
+          ${whereSql}
+         ORDER BY opened_at_utc ASC
+         LIMIT ${rowLimit}
+      `;
+      const { rows } = await client.query(query, params);
+
+      const csv = buildCsv(rows, [
+        { key: 'opened_at_utc', label: 'opened_at_utc' },
+        { key: 'symbol', label: 'symbol' },
+        { key: 'strategy', label: 'strategy' },
+        { key: 'direction', label: 'direction' },
+        { key: 'status', label: 'status' },
+        { key: 'source', label: 'source' },
+        { key: 'entry_price', label: 'entry_price' },
+        { key: 'stop_price', label: 'stop_price' },
+        { key: 'target_price', label: 'target_price' },
+        { key: 'rr', label: 'rr' },
+        { key: 'actionable', label: 'actionable' },
+        { key: 'non_actionable_reason', label: 'non_actionable_reason' },
+      ]);
+
+      reply
+        .header('Content-Type', 'text/csv; charset=utf-8')
+        .header('Content-Disposition', 'attachment; filename="tickets.csv"');
+      return reply.send(csv);
+    } finally {
+      await client.end();
+    }
+  });
+}
+
+export default exportRoutes;

--- a/apps/dashboard/src/pages/Downloads.tsx
+++ b/apps/dashboard/src/pages/Downloads.tsx
@@ -1,0 +1,158 @@
+import React, { useMemo, useState } from 'react';
+import Badge from '../ui/Badge';
+import Button from '../ui/Button';
+import { getApiBase } from '../lib/apiBase';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_RANGE_MS = 28 * DAY_MS;
+
+function clampWindow(startIso: string, endIso: string) {
+  const startMs = Date.parse(startIso);
+  const endMs = Date.parse(endIso);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+    return { startIso, endIso, ok: false };
+  }
+  const low = Math.min(startMs, endMs);
+  const high = Math.max(startMs, endMs);
+  const ok = high - low <= MAX_RANGE_MS;
+  return {
+    startIso: new Date(ok ? low : high - MAX_RANGE_MS).toISOString(),
+    endIso: new Date(high).toISOString(),
+    ok,
+  };
+}
+
+function toLocalInput(iso: string) {
+  const date = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(date.getUTCHours())}:${pad(
+    date.getUTCMinutes(),
+  )}`;
+}
+
+export default function Downloads() {
+  const apiBase = getApiBase();
+
+  const [symbol, setSymbol] = useState('ES=F');
+  const [allSymbols, setAllSymbols] = useState(false);
+  const [strategy, setStrategy] = useState('ORR');
+
+  const nowIso = useMemo(() => new Date().toISOString(), []);
+  const [startInput, setStartInput] = useState(() => toLocalInput(new Date(Date.now() - 7 * DAY_MS).toISOString()));
+  const [endInput, setEndInput] = useState(() => toLocalInput(nowIso));
+
+  const range = useMemo(() => {
+    const startIso = new Date(startInput).toISOString();
+    const endIso = new Date(endInput).toISOString();
+    return clampWindow(startIso, endIso);
+  }, [startInput, endInput]);
+
+  const applyPreset = (days: number) => {
+    const end = new Date();
+    const start = new Date(end.getTime() - days * DAY_MS);
+    const { startIso, endIso } = clampWindow(start.toISOString(), end.toISOString());
+    setStartInput(toLocalInput(startIso));
+    setEndInput(toLocalInput(endIso));
+  };
+
+  const barsUrl = useMemo(() => {
+    const params = new URLSearchParams({ start: range.startIso, end: range.endIso });
+    if (allSymbols) {
+      params.set('all', '1');
+    } else {
+      params.set('symbol', symbol);
+    }
+    return `${apiBase}/api/export/bars.csv?${params.toString()}`;
+  }, [apiBase, allSymbols, symbol, range.startIso, range.endIso]);
+
+  const ticketsUrl = useMemo(() => {
+    const params = new URLSearchParams({ strategy, start: range.startIso, end: range.endIso });
+    return `${apiBase}/api/export/tickets.csv?${params.toString()}`;
+  }, [apiBase, strategy, range.startIso, range.endIso]);
+
+  const readmeUrl = useMemo(() => `${apiBase}/api/export/readme.md`, [apiBase]);
+
+  const openDownload = (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Downloads</h1>
+        <Badge tone="neutral">Max range: 28 days</Badge>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button onClick={() => applyPreset(1)}>Last Day</Button>
+        <Button onClick={() => applyPreset(7)}>Last 7 Days</Button>
+        <Button onClick={() => applyPreset(28)}>Last 28 Days</Button>
+        <Badge tone={range.ok ? 'green' : 'amber'} className="ml-auto">
+          {range.ok ? 'Range OK' : 'Range exceeds 28 days'}
+        </Badge>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-gray-600">Symbol</span>
+          <input
+            className="rounded border px-2 py-1"
+            value={symbol}
+            onChange={(event) => setSymbol(event.target.value)}
+            disabled={allSymbols}
+          />
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            id="toggle-all-symbols"
+            type="checkbox"
+            checked={allSymbols}
+            onChange={(event) => setAllSymbols(event.target.checked)}
+          />
+          <label htmlFor="toggle-all-symbols" className="text-sm text-gray-600">
+            All symbols
+          </label>
+        </div>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-gray-600">Strategy</span>
+          <input
+            className="rounded border px-2 py-1"
+            value={strategy}
+            onChange={(event) => setStrategy(event.target.value)}
+          />
+        </label>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-gray-600">Start (UTC)</span>
+          <input
+            type="datetime-local"
+            className="rounded border px-2 py-1"
+            value={startInput}
+            onChange={(event) => setStartInput(event.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm text-gray-600">End (UTC)</span>
+          <input
+            type="datetime-local"
+            className="rounded border px-2 py-1"
+            value={endInput}
+            onChange={(event) => setEndInput(event.target.value)}
+          />
+        </label>
+      </div>
+
+      <div className="flex flex-wrap gap-2 border-t pt-4">
+        <Button disabled={!range.ok} onClick={() => openDownload(barsUrl)}>
+          Download Bars CSV
+        </Button>
+        <Button disabled={!range.ok} onClick={() => openDownload(ticketsUrl)}>
+          Download Tickets CSV
+        </Button>
+        <Button onClick={() => openDownload(readmeUrl)}>Download README.md</Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend export clamp to 28 days (API + UI messaging)
- add `?all=1` support to `/api/export/bars.csv` so operators can pull every symbol in one CSV
- update Downloads tab with an "All symbols" checkbox, disables the symbol input, and adds a "Last 28 days" preset

## Testing
- docker compose -f docker-compose.yml -f docker-compose.db.yml up -d --build api dashboard
- curl -I "http://localhost:3000/api/export/bars.csv?symbol=ES=F&start=<now-28d>&end=<now>"
- curl -I "http://localhost:3000/api/export/bars.csv?all=1&start=<now-28d>&end=<now>"
- curl -I "http://localhost:3000/api/export/tickets.csv?strategy=ORR&start=<now-28d>&end=<now>"
- curl -I http://localhost:3000/api/export/readme.md
