### PR TITLE
Yahoo health: env-tunable ok/degraded/down/paused + proxy path

### DIFF
--- a/apps/api/src/routes/health.yahoo.ts
+++ b/apps/api/src/routes/health.yahoo.ts
@@ -1,30 +1,93 @@
 import type { FastifyInstance } from 'fastify';
 import { Client } from 'pg';
 
-export default async function yahooHealthRoute(app: FastifyInstance) {
-  const handler = async () => {
-    const client = new Client({ connectionString: process.env.DATABASE_URL });
+function num(v: string | undefined, dflt: number): number {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : dflt;
+}
+
+/**
+ * Thresholds (minutes)
+ * - OK if every symbol < OK_LAG
+ * - DEGRADED if some < DEGRADED_LAG (but not all < OK_LAG)
+ * - DOWN if any >= DEGRADED_LAG
+ *
+ * Tune via env:
+ *   YAHOO_OK_LAG_MIN (default 25)
+ *   YAHOO_DEGRADED_LAG_MIN (default 90)
+ */
+const OK_LAG = num(process.env.YAHOO_OK_LAG_MIN, 25);
+const DEG_LAG = num(process.env.YAHOO_DEGRADED_LAG_MIN, 90);
+
+export async function yahooHealthRoutes(app: FastifyInstance) {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    app.get('/api/health/yahoo', async (_, reply) =>
+      reply.code(500).send({ status: 'down', error: 'DATABASE_URL missing' }),
+    );
+    app.get('/health/yahoo', async (_, reply) =>
+      reply.code(500).send({ status: 'down', error: 'DATABASE_URL missing' }),
+    );
+    return;
+  }
+
+  // We do a short-lived client per request; fast enough for health.
+  async function queryRows(): Promise<{ symbol: string; last_bar_utc: string; minutes_behind: number }[]> {
+    const client = new Client({ connectionString: databaseUrl });
     await client.connect();
     try {
-      const { rows } = await client.query(`
-        SELECT symbol,
-               MAX(ts_utc) AS last_bar,
-               EXTRACT(EPOCH FROM (NOW() - MAX(ts_utc)))/60 AS minutes_behind
+      const res = await client.query(`
+        WITH last AS (
+          SELECT symbol, MAX(ts_utc) AS last_bar
           FROM bars_1m
-         GROUP BY 1
-         ORDER BY 1;
+          GROUP BY symbol
+        )
+        SELECT
+          symbol,
+          last_bar AS last_bar_utc,
+          EXTRACT(EPOCH FROM (NOW() AT TIME ZONE 'UTC' - last_bar)) / 60.0 AS minutes_behind
+        FROM last
+        ORDER BY symbol ASC;
       `);
-      const status = rows.every((r) => r.minutes_behind < 20)
-        ? 'ok'
-        : rows.some((r) => r.minutes_behind < 60)
-          ? 'degraded'
-          : 'down';
-      return { status, rows };
+      return res.rows.map((r) => ({
+        symbol: r.symbol,
+        last_bar_utc: new Date(r.last_bar_utc).toISOString(),
+        minutes_behind: Number(r.minutes_behind),
+      }));
     } finally {
-      await client.end();
+      await client.end().catch(() => {});
     }
-  };
+  }
 
-  app.get('/health/yahoo', handler);
-  app.get('/api/health/yahoo', handler);
+  async function handle(reply: any) {
+    const rows = await queryRows();
+
+    // Optional: if it’s the weekend and everything is very stale, call it "paused"
+    const now = new Date();
+    const isWeekend = now.getUTCDay() === 0 || now.getUTCDay() === 6;
+    const allVeryStale = rows.length > 0 && rows.every((r) => r.minutes_behind >= 720); // 12h+
+    let status: 'ok' | 'degraded' | 'down' | 'paused';
+
+    if (isWeekend && allVeryStale) {
+      status = 'paused';
+    } else if (rows.every((r) => r.minutes_behind < OK_LAG)) {
+      status = 'ok';
+    } else if (rows.some((r) => r.minutes_behind < DEG_LAG)) {
+      status = 'degraded';
+    } else {
+      status = 'down';
+    }
+
+    return reply.send({
+      status,
+      ok_lag_min: OK_LAG,
+      degraded_lag_min: DEG_LAG,
+      rows,
+      now_utc: now.toISOString(),
+    });
+  }
+
+  app.get('/api/health/yahoo', async (_req, reply) => handle(reply));
+  app.get('/health/yahoo', async (_req, reply) => handle(reply)); // non-prefixed twin
 }
+export default yahooHealthRoutes;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -17,7 +17,7 @@ import versionRoute from './routes/version.js';
 import { analyticsRoutes } from './routes/analytics.js';
 import { auditRoutes } from './routes/audit.js';
 import { accountsRoutes } from './routes/accounts.js';
-import yahooHealthRoute from './routes/health.yahoo.js';
+import yahooHealthRoutes from './routes/health.yahoo.js';
 import { exportRoutes } from './routes/export.js';
 import ticketsRoute from './routes/tickets.js';
 import ticketCompleteRoute from './routes/ticket.complete.js';
@@ -106,7 +106,7 @@ export function buildServer() {
   app.register(analyticsRoutes);
   app.register(auditRoutes);
   app.register(accountsRoutes);
-  app.register(yahooHealthRoute);
+  app.register(yahooHealthRoutes);
   app.register(exportRoutes);
 
   app.register(marketRoutes);

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,8 @@ services:
       RTH_OPEN_UTC: ${RTH_OPEN_UTC:-13:30Z}
       RTH_CLOSE_UTC: ${RTH_CLOSE_UTC:-20:59Z}
       FASTIFY_HOST: 0.0.0.0
+      YAHOO_OK_LAG_MIN: ${YAHOO_OK_LAG_MIN:-25}
+      YAHOO_DEGRADED_LAG_MIN: ${YAHOO_DEGRADED_LAG_MIN:-90}
     ports: ["3000:3000"]
     depends_on:
       db:


### PR DESCRIPTION
Adds /api/health/yahoo and /health/yahoo with env thresholds (YAHOO_OK_LAG_MIN, YAHOO_DEGRADED_LAG_MIN). Returns per-symbol minutes_behind + weekend 'paused' state. Includes compose defaults.