### PR TITLE
chore: add rapidapi guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "lint:api": "eslint apps/api",
     "build:cjs:api": "tsc --module commonjs --target ES2020 --moduleResolution node --esModuleInterop --resolveJsonModule --outDir apps/api/dist-cjs/scripts apps/api/src/scripts/syncTickets.ts",
     "lint:legacy": "eslint -c .eslint/flat-merge.mjs .",
-    "guard:orders": "bash scripts/guard_no_order_placement.sh"
+    "guard:orders": "bash scripts/guard_no_order_placement.sh",
+    "guard:no-rapidapi": "bash scripts/guard_no_rapidapi.sh"
   },
   "engines": {
     "node": ">=20 <21"

--- a/scripts/guard_no_rapidapi.sh
+++ b/scripts/guard_no_rapidapi.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v rg >/dev/null 2>&1; then
+  hits=$(rg -n --no-ignore -S \
+    -e 'rapidapi\.com' \
+    -e 'X-RapidAPI-(Key|Host)' \
+    -e '\bRAPIDAPI_[A-Z0-9_]+' \
+    -g '!node_modules' -g '!.git' -g '!dist' -g '!build' \
+    || true)
+else
+  hits=$(grep -RInE 'rapidapi\.com|X-RapidAPI-(Key|Host)|\bRAPIDAPI_[A-Z0-9_]+' \
+    --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist --exclude-dir=build \
+    . || true)
+fi
+
+if [[ -n "$hits" ]]; then
+  echo "RapidAPI references detected:\n$hits" >&2
+  exit 1
+fi
+
+echo "RapidAPI guard: no references found."


### PR DESCRIPTION
## Summary
- added RapidAPI guard: no references found. to enforce no RapidAPI host/header/env references
- wired new  WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.7.0","pnpm":"9.0.0"})

> prism-apex-tool@0.1.0 guard:no-rapidapi /Users/seankeane/code/prism-apex-tool
> bash scripts/guard_no_rapidapi.sh

RapidAPI guard: no references found. helper, keeping native Yahoo fetches untouched

## Verification
- \ WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.7.0","pnpm":"9.0.0"})

> prism-apex-tool@0.1.0 guard:no-rapidapi /Users/seankeane/code/prism-apex-tool
> bash scripts/guard_no_rapidapi.sh

RapidAPI guard: no references found. (passes)
- \ WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.7.0","pnpm":"9.0.0"})

> prism-apex-tool@0.1.0 lint /Users/seankeane/code/prism-apex-tool
> eslint .


/Users/seankeane/code/prism-apex-tool/apps/api/src/scripts/syncTickets.ts
  100:3  warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console

/Users/seankeane/code/prism-apex-tool/apps/api/src/server.ts
  16:8  error  'versionRoute' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
  16:8  error  'versionRoute' is defined but never used                                        unused-imports/no-unused-imports

/Users/seankeane/code/prism-apex-tool/apps/api/start-runtime.cjs
   6:69  warning  '_' is defined but never used                                                            @typescript-eslint/no-unused-vars
  23:5   warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console

/Users/seankeane/code/prism-apex-tool/apps/dashboard/vitest.config.ts
  3:1  warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')

/Users/seankeane/code/prism-apex-tool/apps/ingest/src/backfill.ts
  116:3  warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console
  120:5  warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console
  196:5  warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console
  199:5  error    'total' is assigned a value but never used. Allowed unused vars must match /^_/u         @typescript-eslint/no-unused-vars
  199:5  warning  'total' is assigned a value but never used. Allowed unused vars must match /^_/u         unused-imports/no-unused-vars
  200:5  warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console
  204:3  warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console

/Users/seankeane/code/prism-apex-tool/apps/ingest/src/gapfill.ts
  131:5  warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console
  139:9  warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console
  146:3  warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console

/Users/seankeane/code/prism-apex-tool/apps/ingress-yahoo-dev/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/apps/tickets/src/backfill-orr.ts
   39:7   warning  'close' is never reassigned. Use 'const' instead                                         prefer-const
  195:24  error    'reason' is assigned a value but never used. Allowed unused vars must match /^_/u        @typescript-eslint/no-unused-vars
  195:24  warning  'reason' is assigned a value but never used. Allowed unused vars must match /^_/u        unused-imports/no-unused-vars
  262:5   warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console
  266:3   warning  Unexpected console statement. Only these console methods are allowed: info, warn, error  no-console

/Users/seankeane/code/prism-apex-tool/packages/accounts/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/audit/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/clients-tradovate/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/data-yahoo/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/reporting/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/risk-state/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/rules-apex/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/sdk/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/signals/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/strategy-apx-ddb01/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

/Users/seankeane/code/prism-apex-tool/packages/ticketizer/vitest.config.ts
  2:1   warning  Unused eslint-disable directive (no problems were reported from 'import/no-extraneous-dependencies')
  5:44  warning  'vite-tsconfig-paths' should be listed in the project's dependencies. Run 'npm i -S vite-tsconfig-paths' to add it  import/no-extraneous-dependencies

✖ 45 problems (4 errors, 41 warnings)
  1 error and 14 warnings potentially fixable with the `--fix` option.

 ELIFECYCLE  Command failed with exit code 1. (fails: pre-existing lint warnings/errors, unchanged)
- \ WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.7.0","pnpm":"9.0.0"})

> prism-apex-tool@0.1.0 typecheck /Users/seankeane/code/prism-apex-tool
> pnpm --filter "./packages/**" typecheck

.                                        |  WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.7.0","pnpm":"9.0.0"})
Scope: 19 of 26 workspace projects
packages/accounts typecheck$ tsc -p tsconfig.json --noEmit
packages/consistency typecheck$ tsc -p tsconfig.json --noEmit
packages/audit typecheck$ tsc -p tsconfig.json --noEmit
packages/config typecheck$ tsc -p tsconfig.json --noEmit
packages/consistency typecheck: Done
packages/indicators typecheck$ tsc -p tsconfig.json --noEmit
packages/audit typecheck: Done
packages/metrics typecheck$ tsc -p tsconfig.json --noEmit
packages/accounts typecheck: Done
packages/reporting typecheck$ tsc -p tsconfig.json --noEmit
packages/config typecheck: Done
packages/rules typecheck$ tsc -p tsconfig.json --noEmit
packages/indicators typecheck: Done
packages/rules-apex typecheck$ tsc -p tsconfig.json --noEmit
packages/metrics typecheck: Done
packages/runtime typecheck$ tsc -p tsconfig.json --noEmit
packages/reporting typecheck: Done
packages/sdk typecheck$ tsc -p tsconfig.typecheck.json --noEmit
packages/rules typecheck: Done
packages/signals typecheck$ tsc -p tsconfig.typecheck.json --noEmit
packages/rules-apex typecheck: Done
packages/strategies typecheck$ tsc -p tsconfig.json
packages/runtime typecheck: Done
packages/sdk typecheck: Done
packages/signals typecheck: Done
packages/strategies typecheck: Done
packages/ticketizer typecheck$ tsc -p tsconfig.json --noEmit
packages/ticketizer typecheck: Done (passes)
- \ WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.7.0","pnpm":"9.0.0"})

> prism-apex-tool@0.1.0 test /Users/seankeane/code/prism-apex-tool
> pnpm run test:api

 WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.7.0","pnpm":"9.0.0"})

> prism-apex-tool@0.1.0 test:api /Users/seankeane/code/prism-apex-tool
> pnpm -r --filter @prism-apex/api test

.                                        |  WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.7.0","pnpm":"9.0.0"})

> @prism-apex/api@ test /Users/seankeane/code/prism-apex-tool/apps/api
> vitest run --reporter=verbose --passWithNoTests

/Users/seankeane/code/prism-apex-tool/apps/api:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @prism-apex/api@ test: `vitest run --reporter=verbose --passWithNoTests`
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Test failed. See above for more details. (fails: rollup optional dependency missing, existing issue)
- \ WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.7.0","pnpm":"9.0.0"})

> prism-apex-tool@0.1.0 scan:dead /Users/seankeane/code/prism-apex-tool
> depcheck --ignores="@typescript-eslint/*,@eslint/js,@types/react,@types/react-dom,eslint-config-prettier,eslint-plugin-import,eslint-plugin-prettier,eslint-plugin-simple-import-sort,globals,rimraf,ts-node,typescript-eslint"

No depcheck issue (passes)
