### PR TITLE
feat(api): mock tickets JSONL store + CSV export (TEST_MODE) + local helpers

### DIFF
--- a/apps/api/src/routes/export.ts
+++ b/apps/api/src/routes/export.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { exportTickets as exportFromStore } from '../store/tickets.js';
 import { isMockDbEnabled } from '../utils/testMode.js';
+import { readTickets, toCsv } from '../utils/mockStore.js';
 
 const FOURTEEN_DAYS_MS = 28 * 24 * 60 * 60 * 1000; // now 28-day window
 const DEFAULT_ROW_LIMIT = 50000;
@@ -275,8 +276,22 @@ export async function exportRoutes(app: FastifyInstance) {
     }
   };
 
-  app.get('/api/export/tickets.csv', ticketsHandler);
+  const ticketsCsvMockHandler = async (request: FastifyRequest, reply: FastifyReply) => {
+    if (isMockDbEnabled() && !(request.query as Record<string, string | undefined>)?.date) {
+      const rows = readTickets(5000);
+      const csv = toCsv(rows);
+      reply
+        .header('Content-Type', 'text/csv; charset=utf-8')
+        .header('Content-Disposition', 'attachment; filename="tickets.csv"');
+      return reply.send(csv);
+    }
+
+    return ticketsHandler(request, reply);
+  };
+
   app.get('/export/tickets', ticketsHandler);
+  app.get('/api/export/tickets.csv', ticketsCsvMockHandler);
+  app.get('/export/tickets.csv', ticketsCsvMockHandler);
 }
 
 export default exportRoutes;

--- a/apps/api/src/routes/tickets.debug.ts
+++ b/apps/api/src/routes/tickets.debug.ts
@@ -1,10 +1,36 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
-import { guardSuggestion, type Suggestion } from '../jobs/ticketizer.js';
+import { randomUUID } from 'node:crypto';
 import { loadRegistry } from '@prism-apex/config';
+import { guardSuggestion, type Suggestion } from '../jobs/ticketizer.js';
 import { getConfig } from '../config/env.js';
 import { getRecentTicketSizes } from '../store/tickets.js';
+import { isTestMode } from '../utils/testMode.js';
+import { appendTickets, type MockTicket } from '../utils/mockStore.js';
 
-type DebugReplayRequest = FastifyRequest<{ Body: Suggestion[] }>;
+type BarReplayBody = {
+  symbol: string;
+  strategy: string;
+  bars: Array<{ t: string; o: number; h: number; l: number; c: number; v?: number }>;
+};
+
+type DebugReplayRequest = FastifyRequest<{ Body: Suggestion[] | BarReplayBody }>;
+
+function toMockTicketsFromSuggestions(payload: Suggestion[], tickets: any[]): MockTicket[] {
+  return tickets.map((ticket, idx) => {
+    const suggestion = payload[idx] ?? payload[0];
+    return {
+      id: ticket.id ?? randomUUID(),
+      ts: ticket.timestampUtc ?? new Date().toISOString(),
+      symbol: ticket.symbol ?? suggestion.symbol,
+      strategy: ticket.meta?.strategy ?? suggestion.strategy,
+      side: ticket.side === 'SELL' ? 'SHORT' : 'LONG',
+      price: ticket.entry ?? ticket.price ?? suggestion.price ?? 0,
+      size: ticket.qty ?? ticket.size ?? suggestion.size ?? 1,
+      status: ticket.accepted ? 'ACCEPTED' : 'REJECTED',
+      meta: { ...(ticket.meta ?? {}), seeded: true, source: 'debug-replay:suggestions' },
+    };
+  });
+}
 
 export default async function ticketsDebugRoute(app: FastifyInstance) {
   const registry = loadRegistry();
@@ -17,16 +43,51 @@ export default async function ticketsDebugRoute(app: FastifyInstance) {
   const cfg = getConfig();
 
   app.post('/tickets/debug-replay', async (req: DebugReplayRequest, reply) => {
-    const payload = Array.isArray(req.body) ? req.body : [];
-    const ctx = {
-      accountId: account.id,
-      phase: (account.phase as 'eval' | 'funded') ?? 'funded',
-      maxContracts: account.maxContracts ?? 1,
-      bufferCleared: account.bufferCleared ?? true,
-      recentSizes: getRecentTicketSizes(account.id),
-      flatByUtc: cfg.time.flatByUtc,
-    };
-    const tickets = payload.map((suggestion) => guardSuggestion(suggestion, ctx));
-    return reply.send(tickets);
+    const body = req.body;
+
+    if (Array.isArray(body)) {
+      const payload = body as Suggestion[];
+      const ctx = {
+        accountId: account.id,
+        phase: (account.phase as 'eval' | 'funded') ?? 'funded',
+        maxContracts: account.maxContracts ?? 1,
+        bufferCleared: account.bufferCleared ?? true,
+        recentSizes: getRecentTicketSizes(account.id),
+        flatByUtc: cfg.time.flatByUtc,
+      };
+      const tickets = payload.map((suggestion) => guardSuggestion(suggestion, ctx));
+
+      if (isTestMode()) {
+        const mockTickets = toMockTicketsFromSuggestions(payload, tickets);
+        appendTickets(mockTickets);
+      }
+
+      return reply.send(tickets);
+    }
+
+    if (!isTestMode()) {
+      return reply.code(400).send({ error: 'bars replay requires TEST_MODE=1' });
+    }
+
+    const barsBody = body as BarReplayBody;
+    if (!barsBody?.symbol || !barsBody?.strategy || !Array.isArray(barsBody?.bars) || barsBody.bars.length === 0) {
+      reply.code(400);
+      return reply.send({ error: 'symbol, strategy, and bars[] are required' });
+    }
+
+    const tickets: MockTicket[] = barsBody.bars.map((bar) => ({
+      id: randomUUID(),
+      ts: new Date(bar.t).toISOString(),
+      symbol: barsBody.symbol,
+      strategy: barsBody.strategy,
+      side: 'LONG',
+      price: bar.c,
+      size: 1,
+      status: 'NEW',
+      meta: { seeded: true, source: 'debug-replay:bars' },
+    }));
+
+    appendTickets(tickets);
+    return reply.send({ added: tickets.length, tickets });
   });
 }

--- a/apps/api/src/routes/tickets.ts
+++ b/apps/api/src/routes/tickets.ts
@@ -1,8 +1,9 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { Client } from 'pg';
 import { listTickets } from '../store/tickets.js';
-import { isMockDbEnabled } from '../utils/testMode.js';
+import { isMockDbEnabled, isTestMode } from '../utils/testMode.js';
 import { TICKET_STRATEGIES, type TicketStrategy } from '../schemas/ticket.js';
+import { readTickets } from '../utils/mockStore.js';
 
 type Query = {
   limit?: string;
@@ -53,6 +54,16 @@ export default async function ticketsRoute(app: FastifyInstance) {
     if (strategy && !TICKET_STRATEGIES.includes(strategy as TicketStrategy)) {
       reply.code(400);
       return reply.send({ error: 'Invalid query' });
+    }
+
+    if (isTestMode() && !q.date && !q.from && !q.to) {
+      const cursorIso = typeof q.cursor === 'string' && q.cursor ? q.cursor : undefined;
+      const after = cursorIso ? Date.parse(cursorIso) : undefined;
+      const all = readTickets(limit + 1);
+      const filtered = after ? all.filter((t) => Date.parse(t.ts) > after) : all;
+      const page = filtered.slice(0, limit);
+      const nextCursor = filtered.length > page.length ? page[page.length - 1]?.ts ?? null : null;
+      return reply.send({ total: filtered.length, rows: page, tickets: page, nextCursor });
     }
 
     const where: string[] = [];

--- a/apps/api/src/utils/mockStore.ts
+++ b/apps/api/src/utils/mockStore.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type MockTicket = {
+  id: string;
+  ts: string;
+  symbol: string;
+  strategy: string;
+  side?: 'LONG' | 'SHORT';
+  price?: number;
+  size?: number;
+  status?: string;
+  meta?: Record<string, unknown>;
+};
+
+function dataDir(): string {
+  const base = process.env.DATA_DIR || path.join(process.cwd(), 'var', 'mock-api');
+  fs.mkdirSync(base, { recursive: true });
+  return base;
+}
+
+function filePath(): string {
+  return path.join(dataDir(), 'tickets.jsonl');
+}
+
+export function appendTickets(tix: MockTicket[]): void {
+  if (!tix || tix.length === 0) return;
+  const lines = tix.map((t) => JSON.stringify(t)).join('\n') + '\n';
+  fs.appendFileSync(filePath(), lines, 'utf8');
+}
+
+export function readTickets(limit = 500): MockTicket[] {
+  const fp = filePath();
+  if (!fs.existsSync(fp)) return [];
+  const lines = fs.readFileSync(fp, 'utf8').split(/\r?\n/).filter(Boolean);
+  const rows = lines
+    .map((ln) => {
+      try {
+        return JSON.parse(ln) as MockTicket;
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean) as MockTicket[];
+  return rows.slice(-limit);
+}
+
+export function toCsv(tix: MockTicket[]): string {
+  const header = ['id', 'ts', 'symbol', 'strategy', 'side', 'price', 'size', 'status'];
+  const rows = tix.map((t) => [
+    t.id,
+    t.ts,
+    t.symbol,
+    t.strategy,
+    t.side ?? '',
+    t.price ?? '',
+    t.size ?? '',
+    t.status ?? '',
+  ]);
+  return [header.join(','), ...rows.map((r) => r.join(','))].join('\n') + '\n';
+}

--- a/scripts/dev-api-mock.sh
+++ b/scripts/dev-api-mock.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start the API in a lightweight Docker container that mirrors the local mock stack.
+# This is primarily useful when you want an isolated service without installing
+# the Node toolchain locally.
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT_DIR"
+
+API_PORT="${API_PORT:-8000}"
+NAME="${NAME:-apex-api-dev}"
+IMAGE="${IMAGE:-prism-apex/api:mock-local}"
+DATA_DIR="${DATA_DIR:-$ROOT_DIR/var/mock-api}"
+FORCE_BUILD="${FORCE_BUILD:-0}"
+
+log() { printf '\033[1;36m[dev-api-mock]\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m[dev-api-mock]\033[0m %s\n' "$*" >&2; }
+
+command -v docker >/dev/null 2>&1 || { err "Docker is required"; exit 10; }
+
+mkdir -p "$DATA_DIR"
+
+ensure_image() {
+  if [[ "$FORCE_BUILD" != "0" ]] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    log "Building image ($IMAGE) from Dockerfile target=api..."
+    docker build --target api -t "$IMAGE" .
+  fi
+}
+
+ensure_image
+
+log "Recreating container $NAME (host port ${API_PORT} -> container port 3000)..."
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+
+docker run -d \
+  --name "$NAME" \
+  -p "${API_PORT}:3000" \
+  -e PORT=3000 \
+  -e DATA_DIR=/var/lib/prism-apex-tool \
+  -e NODE_ENV=development \
+  -v "$DATA_DIR":/var/lib/prism-apex-tool \
+  "$IMAGE" >/dev/null
+
+log "API mock running. Try: curl -fsS http://localhost:${API_PORT}/health"

--- a/scripts/dev-web-8000.sh
+++ b/scripts/dev-web-8000.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Boot the dashboard Vite dev server on the canonical port (5173) and point it
+# at a local API endpoint (default http://localhost:8000).
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT_DIR"
+
+WEB_PORT="${WEB_PORT:-5173}"
+API_URL="${API_URL:-http://localhost:8000}"
+HOST_ADDR="${HOST_ADDR:-0.0.0.0}"
+PID_FILE="${PID_FILE:-/tmp/dev_web.pid}"
+LOG_FILE="${LOG_FILE:-/tmp/dev_web.log}"
+
+log() { printf '\033[1;32m[dev-web]\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m[dev-web]\033[0m %s\n' "$*" >&2; }
+
+command -v pnpm >/dev/null 2>&1 || { err "pnpm is required (corepack enable pnpm)"; exit 10; }
+
+# If an old instance is still around, stop it first so we can reuse the port cleanly.
+if [[ -f "$PID_FILE" ]]; then
+  old_pid="$(cat "$PID_FILE" 2>/dev/null || true)"
+  if [[ -n "${old_pid:-}" ]] && kill -0 "$old_pid" >/dev/null 2>&1; then
+    log "Existing dashboard dev process detected (pid=$old_pid). Stopping..."
+    kill "$old_pid" >/dev/null 2>&1 || true
+    sleep 1
+  fi
+  rm -f "$PID_FILE"
+fi
+
+log "Starting dashboard dev server on http://${HOST_ADDR}:${WEB_PORT} (API=${API_URL})..."
+(
+  cd apps/dashboard
+  # Use nohup so callers can detach immediately; logs land in $LOG_FILE.
+  nohup env \
+    VITE_API_BASE="$API_URL" \
+    HOST="$HOST_ADDR" \
+    PORT="$WEB_PORT" \
+    BROWSER=none \
+    pnpm run dev -- --host "$HOST_ADDR" --port "$WEB_PORT" \
+      >"$LOG_FILE" 2>&1 &
+  echo $! >"$PID_FILE"
+)
+
+sleep 2
+if [[ -s "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" >/dev/null 2>&1; then
+  log "Dashboard dev server started (pid=$(cat "$PID_FILE")). Logs: tail -f $LOG_FILE"
+else
+  err "Dashboard failed to start. Inspect $LOG_FILE."
+  exit 1
+fi

--- a/scripts/local-down.sh
+++ b/scripts/local-down.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_CONT="${API_CONT:-apex-api-dev}"
+WEB_CONT="${WEB_CONT:-apex-web-dev-8000}"
+WEB_PID_FILE="${WEB_PID_FILE:-/tmp/dev_web.pid}"
+
+log() { printf '\033[1;35m[local-down]\033[0m %s\n' "$*"; }
+
+log "===== LOCAL-DOWN ====="
+log "-> Stopping dashboard container (if any)..."
+docker rm -f "$WEB_CONT" >/dev/null 2>&1 || true
+
+log "-> Stopping API container (if any)..."
+docker rm -f "$API_CONT" >/dev/null 2>&1 || true
+
+log "-> Killing native dev_api.sh (if running)..."
+pkill -f "bash ./dev_api.sh" >/dev/null 2>&1 || true
+
+log "-> Killing dashboard dev server (pnpm) if running..."
+if [[ -f "$WEB_PID_FILE" ]]; then
+  if kill -0 "$(cat "$WEB_PID_FILE")" >/dev/null 2>&1; then
+    kill "$(cat "$WEB_PID_FILE")" >/dev/null 2>&1 || true
+    sleep 1
+  fi
+  rm -f "$WEB_PID_FILE"
+fi
+pkill -f "pnpm run dev -- --host" >/dev/null 2>&1 || true
+
+log "[ok] Local dev stack stopped."

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_URL="${API_URL:-http://localhost:8000}"
+WEB_URL="${WEB_URL:-http://localhost:5173}"
+
+echo "===== LOCAL SMOKE ====="
+echo "API_URL=$API_URL"
+echo "WEB_URL=$WEB_URL"
+echo
+
+# 1) API health
+echo "-> API /health"
+set +e
+API_HEALTH="$(curl -fsS "$API_URL/health" || curl -fsS "$API_URL/api/health")"
+API_CODE=$?
+set -e
+if [ $API_CODE -eq 0 ]; then
+  echo "[ok] API health OK: $API_HEALTH"
+else
+  echo "[x] API health failed"
+fi
+
+# 2) /tickets (mock mode should respond even if empty)
+echo
+echo "-> API /tickets (first 400 bytes)"
+set +e
+TICKETS="$(curl -fsS "$API_URL/tickets" | head -c 400)"
+TICKETS_CODE=$?
+set -e
+if [ $TICKETS_CODE -eq 0 ]; then
+  printf "[ok] /tickets OK: %s\n" "$TICKETS"
+else
+  echo "[x] /tickets failed"
+fi
+
+# 3) /export/tickets.csv (mock mode emits CSV headers)
+echo
+echo "-> API /export/tickets.csv (first 5 lines)"
+set +e
+CSV="$(curl -fsS "$API_URL/export/tickets.csv" | head -n 5)"
+CSV_CODE=$?
+set -e
+if [ $CSV_CODE -eq 0 ]; then
+  printf "[ok] CSV OK:\n%s\n" "$CSV"
+else
+  echo "[!] CSV not available (may be empty in fresh mock mode)"
+fi
+
+# 4) Dashboard root
+echo
+echo "-> WEB / (root HTML check)"
+set +e
+WEB_ROOT="$(curl -fsS "$WEB_URL" | head -n 1)"
+WEB_CODE=$?
+set -e
+if [ $WEB_CODE -eq 0 ]; then
+  echo "[ok] Dashboard responded: $(echo "$WEB_ROOT" | sed 's/[[:cntrl:]]//g')"
+else
+  echo "[x] Dashboard not responding"
+fi
+
+echo
+echo "===== OUTCOME REPORT ====="
+echo "api_health: $([ $API_CODE -eq 0 ] && echo up || echo down)"
+echo "tickets_ok: $([ $TICKETS_CODE -eq 0 ] && echo yes || echo no)"
+echo "csv_ok:     $([ $CSV_CODE -eq 0 ] && echo yes || echo no)"
+echo "web_ok:     $([ $WEB_CODE -eq 0 ] && echo yes || echo no)"
+
+echo
+echo "next:"
+echo " - If any [x] above: send this output; I will dig in."
+echo " - If all [ok]: we can run clean-room tests or a DB-mode smoke next."

--- a/scripts/local-up.sh
+++ b/scripts/local-up.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_PORT="${API_PORT:-8000}"
+WEB_PORT="${WEB_PORT:-5173}"
+API_CONT="${API_CONT:-apex-api-dev}"
+WEB_CONT="${WEB_CONT:-apex-web-dev-8000}"
+
+log() { printf '\033[1;34m[local-up]\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m[local-up]\033[0m %s\n' "$*" >&2; }
+
+log "===== LOCAL-UP (mock stack) ====="
+log "API_PORT=$API_PORT  WEB_PORT=$WEB_PORT"
+
+# --- API --------------------------------------------------------------------
+if [[ -x ./dev_api.sh ]]; then
+  log "-> Using ./dev_api.sh (native). Expect Fastify listening on :$API_PORT"
+  nohup bash ./dev_api.sh >/tmp/dev_api.log 2>&1 &
+  sleep 2
+else
+  if [[ -x scripts/dev-api-mock.sh ]]; then
+    log "-> Using scripts/dev-api-mock.sh (Dockerized mock API)"
+    API_PORT="$API_PORT" NAME="$API_CONT" bash scripts/dev-api-mock.sh >/tmp/dev_api.log 2>&1 &
+    sleep 2
+  else
+    err "[x] No API script found (dev_api.sh or scripts/dev-api-mock.sh)"
+    exit 2
+  fi
+fi
+
+log "-> Waiting for API health on :$API_PORT (up to 60s)..."
+API_OK=0
+for _ in $(seq 1 60); do
+  if curl -fsS "http://localhost:${API_PORT}/health" >/dev/null 2>&1 || \
+     curl -fsS "http://localhost:${API_PORT}/api/health" >/dev/null 2>&1; then
+    API_OK=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$API_OK" -eq 1 ]]; then
+  log "[ok] API up"
+else
+  err "[!] API did not confirm health (check /tmp/dev_api.log)"
+fi
+
+# --- Dashboard --------------------------------------------------------------
+if [[ -x scripts/dev-web-8000.sh ]]; then
+  log "-> Starting dashboard dev server on :$WEB_PORT (VITE_API_BASE -> http://localhost:$API_PORT)"
+  WEB_PORT="$WEB_PORT" API_URL="http://localhost:${API_PORT}" bash scripts/dev-web-8000.sh >/tmp/dev_web.log 2>&1 || true
+else
+  err "[x] Missing scripts/dev-web-8000.sh"
+  exit 3
+fi
+
+log "-> Waiting for Dashboard on :$WEB_PORT (up to 40s)..."
+WEB_OK=0
+for _ in $(seq 1 40); do
+  if curl -fsS "http://localhost:${WEB_PORT}" >/dev/null 2>&1; then
+    WEB_OK=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$WEB_OK" -eq 1 ]]; then
+  log "[ok] Dashboard up"
+else
+  err "[!] Dashboard not responding (check /tmp/dev_web.log)"
+fi
+
+log ""
+log "===== LOCAL-UP OUTCOME ====="
+log "api_url:       http://localhost:${API_PORT}"
+log "dashboard_url: http://localhost:${WEB_PORT}"
+if [[ "$API_OK" -eq 1 ]]; then
+  API_STATE="up"
+else
+  API_STATE="unknown"
+fi
+if [[ "$WEB_OK" -eq 1 ]]; then
+  WEB_STATE="up"
+else
+  WEB_STATE="down"
+fi
+log "api_health:    $API_STATE"
+log "web_health:    $WEB_STATE"
+log ""
+log "logs:"
+log "  tail -n 120 /tmp/dev_api.log"
+log "  tail -n 120 /tmp/dev_web.log"
+log ""
+log "cleanup:"
+log "  bash scripts/local-down.sh"

--- a/scripts/retry-seed-tickets-nojq.sh
+++ b/scripts/retry-seed-tickets-nojq.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_URL="${API_URL:-http://localhost:8000}"
+
+echo "===== RETRY SEED (no jq) ====="
+echo "API_URL=$API_URL"
+
+echo
+
+probe_post() {
+  local label="$1"
+  local json="$2"
+  echo "→ $label"
+  echo "payload:"
+  echo "$json" | head -c 400
+  echo
+  set +e
+  local resp
+  resp="$(curl -fsS -X POST "$API_URL/tickets/debug-replay" -H "Content-Type: application/json" -d "$json")"
+  local code=$?
+  set -e
+  echo "http_code: $code"
+  if [ $code -eq 0 ]; then
+    echo "response:"
+    echo "$resp" | head -c 400
+    echo
+  else
+    echo "[x] request failed"
+  fi
+}
+
+probe_get() {
+  local path="$1"
+  local label="$2"
+  echo
+  echo "→ $label ($path)"
+  set +e
+  local resp
+  resp="$(curl -fsS "$API_URL$path")"
+  local code=$?
+  set -e
+  echo "http_code: $code"
+  if [ $code -eq 0 ]; then
+    echo "$resp" | head -c 400
+    echo
+  else
+    echo "[x] request failed"
+  fi
+  return $code
+}
+
+probe_get "/health" "API /health" || probe_get "/api/health" "API /api/health" || true
+
+BARS_JSON=$(cat <<'JSON'
+[
+  {"t":"2025-10-01T14:30:00Z","o":4800.00,"h":4801.00,"l":4799.50,"c":4800.75,"v":1000},
+  {"t":"2025-10-01T14:31:00Z","o":4800.75,"h":4802.25,"l":4800.25,"c":4801.50,"v":950},
+  {"t":"2025-10-01T14:32:00Z","o":4801.50,"h":4802.75,"l":4800.75,"c":4802.25,"v":875},
+  {"t":"2025-10-01T14:33:00Z","o":4802.25,"h":4803.00,"l":4801.00,"c":4802.75,"v":900}
+]
+JSON
+)
+
+payload_A=$(cat <<JSON
+{ "symbol":"ESZ5","strategy":"APX-DDB-01","persist":true,"writeStore":true,"bars":$BARS_JSON }
+JSON
+)
+
+payload_B=$(cat <<JSON
+{ "symbol":"ESZ5","strategy":"APX-DDB-01","persist":true,"store":"mock","bars":$BARS_JSON }
+JSON
+)
+
+payload_C=$(cat <<JSON
+{ "symbol":"ESZ5","strategy":"APX-DDB-01","save":true,"persistTickets":true,"bars":$BARS_JSON }
+JSON
+)
+
+payload_D=$(cat <<JSON
+{ "symbol":"ESZ5","strategy":"VWAP-FT","persist":true,"writeStore":true,"bars":$BARS_JSON }
+JSON
+)
+
+run_attempt() {
+  local name="$1"
+  local payload="$2"
+  echo
+  echo "===== ATTEMPT: $name ====="
+  probe_post "$name" "$payload" || true
+  probe_get "/tickets" "GET /tickets" || true
+  echo "CSV head:"
+  set +e
+  curl -fsS "$API_URL/export/tickets.csv" | head -n 10 || echo "[!] CSV not available yet"
+  set -e
+}
+
+run_attempt "persist=true, writeStore=true" "$payload_A"
+run_attempt "persist to mock store" "$payload_B"
+run_attempt "save=true, persistTickets=true" "$payload_C"
+run_attempt "VWAP-FT strategy" "$payload_D"
+
+echo
+echo "===== OUTCOME REPORT ====="
+echo "api_url: $API_URL"
+echo "tickets_tip: inspect the GET output above for any rows"
+echo "csv_tip: head output above will show headers if export succeeds"

--- a/scripts/seed-debug-tickets.sh
+++ b/scripts/seed-debug-tickets.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_URL="${API_URL:-http://localhost:8000}"
+
+echo "===== SEED TICKETS (mock mode) ====="
+echo "API_URL=$API_URL"
+command -v curl >/dev/null || { echo "[x] curl missing"; exit 1; }
+
+# 1) quick health
+echo "-> Health probe"
+set +e
+curl -fsS "$API_URL/health" >/dev/null 2>&1 || curl -fsS "$API_URL/api/health" >/dev/null 2>&1
+HEALTH=$?
+set -e
+if [ $HEALTH -eq 0 ]; then
+  echo "[ok] API is up"
+else
+  echo "[!] API did not confirm; proceeding anyway"
+fi
+
+# 2) seed a few bars through the debug-replay endpoint (APX-DDB-01)
+payload='{
+  "symbol": "ESZ5",
+  "strategy": "APX-DDB-01",
+  "bars": [
+    {"t":"2025-10-01T14:30:00Z","o":4800.00,"h":4801.00,"l":4799.50,"c":4800.75,"v":1000},
+    {"t":"2025-10-01T14:31:00Z","o":4800.75,"h":4802.25,"l":4800.25,"c":4801.50,"v":950},
+    {"t":"2025-10-01T14:32:00Z","o":4801.50,"h":4802.75,"l":4800.75,"c":4802.25,"v":875},
+    {"t":"2025-10-01T14:33:00Z","o":4802.25,"h":4803.00,"l":4801.00,"c":4802.75,"v":900}
+  ]
+}'
+
+echo
+echo "-> POST /tickets/debug-replay (seed)"
+set +e
+SEED_RESP="$(curl -fsS -X POST "$API_URL/tickets/debug-replay" -H "Content-Type: application/json" -d "$payload")"
+SEED_CODE=$?
+set -e
+if [ $SEED_CODE -eq 0 ]; then
+  echo "[ok] Seeded tickets (truncated):"
+  echo "$SEED_RESP" | head -c 400; echo
+else
+  echo "[x] Seeding failed (debug-replay POST)."
+fi
+
+# 3) confirm tickets exist
+echo
+echo "-> GET /tickets (first 400 bytes)"
+set +e
+TICKETS="$(curl -fsS "$API_URL/tickets" | head -c 400)"
+TICKETS_CODE=$?
+set -e
+if [ $TICKETS_CODE -eq 0 ]; then
+  printf "[ok] tickets ok:\n%s\n" "$TICKETS"
+else
+  echo "[x] /tickets failed"
+fi
+
+# 4) check CSV export
+echo
+echo "-> GET /export/tickets.csv (first 10 lines)"
+set +e
+CSV="$(curl -fsS "$API_URL/export/tickets.csv" | head -n 10)"
+CSV_CODE=$?
+set -e
+if [ $CSV_CODE -eq 0 ]; then
+  echo "[ok] CSV ok:"
+  echo "$CSV"
+else
+  echo "[!] CSV still not available (may need more tickets or endpoint path differs)"
+fi
+
+echo
+echo "===== OUTCOME REPORT ====="
+echo "api_url: $API_URL"
+echo "seed_post: $([ $SEED_CODE -eq 0 ] && echo ok || echo failed)"
+echo "tickets_ok: $([ $TICKETS_CODE -eq 0 ] && echo yes || echo no)"
+echo "csv_ok: $([ $CSV_CODE -eq 0 ] && echo yes || echo no)"
+
+echo
+echo "next:"
+echo " - If csv_ok=no: paste output here; we can try a second seed batch or confirm export route mapping."


### PR DESCRIPTION
Adds a JSONL-backed mock store and CSV export in TEST_MODE; wires /tickets/debug-replay to persist, /tickets to read, and /export/tickets.csv to stream CSV. Includes local-up/down and smoke/seed scripts for quick dev.

Clean-room (TEST_MODE=1) passed: lint/type/test ✅