### PR TITLE
fix(db): add tickets.source for CSV export + update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- DB: add `tickets.source` (and `ticket_events.source`) for CSV export compatibility.
 
 ## [1.0.0] - 2025-10-25
 ### Added

--- a/deploy/sql/007_add_source_to_tickets.sql
+++ b/deploy/sql/007_add_source_to_tickets.sql
@@ -1,0 +1,28 @@
+-- 007_add_source_to_tickets.sql
+-- Adds a nullable text column "source" to public.tickets if it doesn't exist.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'tickets' AND column_name = 'source'
+  ) THEN
+    ALTER TABLE public.tickets ADD COLUMN source text;
+  END IF;
+END $$;
+
+-- Optional: if you also track ticket events, keep this harmlessly idempotent.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+     WHERE table_schema = 'public' AND table_name = 'ticket_events'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'ticket_events' AND column_name = 'source'
+  ) THEN
+    ALTER TABLE public.ticket_events ADD COLUMN source text;
+  END IF;
+END $$;
+
+-- If a materialized view or view expects "source", it will now resolve from the base tables.
+-- We intentionally do not DROP/CREATE views here to avoid breaking other dependencies.


### PR DESCRIPTION
Adds idempotent migration `deploy/sql/007_add_source_to_tickets.sql` to ensure `tickets.source` (and `ticket_events.source` when present) exist, fixing /export/tickets.csv 500s in DB mode.\n\n- API (compose) healthy on :3000\n- CSV now responds 200 text/csv with header including source\n- CHANGELOG updated.