### PR TITLE
docs(deploy): add server-up helper + canonical port workflow

### DIFF
--- a/PORTS.md
+++ b/PORTS.md
@@ -1,0 +1,13 @@
+# Canonical Ports (Local & Compose)
+
+| Surface              | Port | Notes                                                 |
+|----------------------|------|-------------------------------------------------------|
+| API (DB mode)        | 3000 | Fastify with DATABASE_URL / compose `api` service      |
+| API (mock mode)      | 8000 | Fastify dev server via `scripts/local-up.sh`          |
+| Dashboard (dev/Vite) | 5173 | Vite dev helper (`scripts/dev-web-8000.sh`)           |
+| Dashboard (prod)     | 5180 | Nginx compose service (dashboards)                    |
+| Postgres (host)      | 55433| Host port mapped from compose `db:5432`               |
+
+## Guardrail
+
+Only reference the host ports above directly; everything else should flow through environment variables. Run `tools/guards/ports-check.sh` to detect drift.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,52 @@
 - `make up` (starts the local stack – db, api, dashboard, ingress, cron)
 - `pnpm docs:lint`
 
+## Deployment (Local & Server)
+
+### Canonical Ports
+- API (DB mode): **3000**
+- API (mock mode): **8000**
+- Dashboard dev (Vite): **5173**
+- Dashboard prod (compose): **5180**
+- Postgres (host-mapped): **55433**
+
+See [PORTS.md](./PORTS.md) for the canonical matrix and guardrail script.
+
+### Local Mock Stack (fast dev loop)
+```bash
+# Start Fastify mock API (:8000) + Vite dashboard (:5173)
+bash scripts/local-up.sh
+
+# Quick smoke (health + tickets JSON/CSV)
+bash scripts/local-smoke.sh
+
+# Stop everything
+bash scripts/local-down.sh
+```
+
+### Local DB Mode (compose db + API, dev dashboard)
+```bash
+# 1) Database (host:55433 → db:5432)
+docker compose up -d db
+
+# 2) API (compose)
+DATABASE_URL=postgresql://apex:apex@db:5432/prismapex docker compose up -d api
+# Health: http://localhost:3000/health
+
+# 3) Dashboard (dev helper pointing to API :3000)
+API_URL=http://localhost:3000 bash scripts/dev-web-8000.sh
+# Open http://localhost:5173
+```
+
+### Server / Production-ish Bring-Up (from a tag)
+```bash
+# From a clone on the server (defaults to v1.0.0)
+TAG=v1.0.0 bash scripts/server-up.sh
+# DB: host:55433, API: http://<server>:3000, Web: http://<server>:5180
+```
+
+All flows reuse existing scripts/compose services; no new workflows were introduced.
+
 ### Docker Profiles at a Glance
 
 | Scenario            | Command                              | Services (profile)                             |

--- a/scripts/server-up.sh
+++ b/scripts/server-up.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prism-Apex server bootstrap helper (canonical ports)
+# - DB host:55433  -> compose service db:5432
+# - API host:3000  -> compose service api:3000
+# - Web host:5180  -> compose service dashboards:80
+
+TAG="${TAG:-v1.0.0}"
+SERVICES="${SERVICES:-db api dashboards}"
+
+echo "===== PRISM-APEX SERVER-UP ====="
+echo "tag: $TAG"
+echo "services: $SERVICES"
+echo
+
+command -v docker >/dev/null || { echo "❌ docker missing"; exit 1; }
+docker compose version >/dev/null 2>&1 || { echo "❌ docker compose missing"; exit 1; }
+
+# If inside a git repo, fetch tags and checkout the requested tag (best-effort)
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git fetch --all --tags --prune --quiet || true
+  if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+    git checkout -q "$TAG"
+  fi
+fi
+
+echo "→ docker compose pull (best-effort)"
+docker compose pull || true
+
+echo "→ docker compose up -d $SERVICES"
+set +e
+docker compose up -d $SERVICES
+UP_RC=$?
+set -e
+if [ $UP_RC -ne 0 ]; then
+  echo "⚠️ docker compose up returned $UP_RC (continuing to health probes)"
+fi
+
+DB_MAP="$(docker compose port db 5432 2>/dev/null | head -n1 || true)"
+API_MAP="$(docker compose port api 3000 2>/dev/null | head -n1 || true)"
+WEB_MAP="$(docker compose port dashboards 80 2>/dev/null | head -n1 || true)"
+
+DB_PORT="${DB_MAP##*:}"
+API_PORT="${API_MAP##*:}"
+WEB_PORT="${WEB_MAP##*:}"
+
+API_URL="http://localhost:${API_PORT:-3000}"
+WEB_URL="http://localhost:${WEB_PORT:-5180}"
+
+echo
+echo "→ Waiting for API $API_URL/health (up to 90s)…"
+API_OK=0
+for _ in $(seq 1 90); do
+  if curl -fsS "$API_URL/health" >/dev/null 2>&1 || curl -fsS "$API_URL/api/health" >/dev/null 2>&1; then
+    API_OK=1
+    break
+  fi
+  sleep 1
+done
+
+echo "→ Waiting for dashboard $WEB_URL (up to 90s)…"
+WEB_OK=0
+for _ in $(seq 1 90); do
+  if [ -n "${WEB_PORT:-}" ] && curl -fsS "$WEB_URL" >/dev/null 2>&1; then
+    WEB_OK=1
+    break
+  fi
+  sleep 1
+done
+
+echo
+echo "===== OUTCOME REPORT ====="
+echo "tag: $TAG"
+echo "db_host_port: ${DB_PORT:-'(not mapped)'}"
+echo "api_url: ${API_URL:-'(not mapped)'}"
+echo "web_url: ${WEB_URL:-'(not mapped)'}"
+echo "api_health: $([ $API_OK -eq 1 ] && echo up || echo unknown)"
+echo "web_health: $([ $WEB_OK -eq 1 ] && echo up || echo unknown)"
+echo
+echo "commands:"
+echo "  docker compose logs -f api"
+echo "  docker compose logs -f dashboards"
+echo "  docker compose logs -f db"
+echo "  curl -fsS $API_URL/health"
+echo "  curl -fsS $API_URL/tickets"
+echo "  curl -fsS $API_URL/export/tickets.csv | head -n 5"
+echo
+echo "cleanup:"
+echo "  docker compose down"


### PR DESCRIPTION
## Summary
- add `scripts/server-up.sh` for production-like bring-up on canonical ports (DB 55433 / API 3000 / Web 5180)
- document local mock + DB mode + server workflows in README (still using existing scripts/compose)
- add `PORTS.md` as the single source of truth for host ports

No new workflows were introduced—these scripts wrap what we already ship.