### PR TITLE
ops: existing-job gapfill + docs; optional cleanup

### DIFF
--- a/compose.gapfill-once.override.yml
+++ b/compose.gapfill-once.override.yml
@@ -1,0 +1,26 @@
+services:
+  gapfill-once:
+    image: prism-apex:ingress-dev
+    working_dir: /app
+    environment:
+      - TZ=UTC
+      - DATABASE_URL
+      - FROM_DATE
+      - TO_DATE
+      - SYMBOLS
+    command: >
+      /bin/sh -lc '
+        set -e;
+        echo "[gapfill-once] DB=${DATABASE_URL}";
+        corepack enable || true;
+        pnpm -r --filter @prism-apex/ingest build || true;
+        if [ -f apps/ingest/dist/gapfill.js ]; then
+          node apps/ingest/dist/gapfill.js --from "$FROM_DATE" --to "$TO_DATE" --symbols "$SYMBOLS" || \
+          npx -y ts-node apps/ingest/src/gapfill.ts --from "$FROM_DATE" --to "$TO_DATE" --symbols "$SYMBOLS";
+        else
+          npx -y ts-node apps/ingest/src/gapfill.ts --from "$FROM_DATE" --to "$TO_DATE" --symbols "$SYMBOLS";
+        fi
+      '
+    depends_on:
+      - db
+    restart: "no"

--- a/compose.ingress-db.override.yml
+++ b/compose.ingress-db.override.yml
@@ -1,0 +1,5 @@
+services:
+  ingress-yahoo:
+    environment:
+      - DATABASE_URL
+      - NODE_PATH=/app/apps/ingest/node_modules

--- a/docs/runbooks/data-recovery-gapfill.md
+++ b/docs/runbooks/data-recovery-gapfill.md
@@ -1,0 +1,53 @@
+# Data Recovery: Minute Bars Gapfill
+
+Use the existing ingress job and one-shot compose service to backfill minute bars so tickets advance.
+
+## Prerequisites
+- Stack running (`api`, `db`, `ingress-yahoo`, `tickets-cron`).
+- `compose.ingress-db.override.yml` and `compose.gapfill-once.override.yml` present.
+
+## 1. Capture `DATABASE_URL`
+```bash
+API_ID=$(docker ps --format '{{.ID}} {{.Names}}' | awk 'tolower($0) ~ /(^|-)api(-| |$)/{print $1;exit}')
+DBURL=$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$API_ID" | awk -F= '$1=="DATABASE_URL"{print $2;exit}')
+```
+
+## 2. Run one-shot gapfill
+```bash
+export FROM_DATE="2025-10-31T00:00:00Z"
+export TO_DATE="2025-11-05T00:00:00Z"
+export SYMBOLS="ES=F,NQ=F,CL=F,EURUSD=X"
+
+docker compose -f docker-compose.yml \
+  -f compose.ingress-db.override.yml \
+  -f compose.gapfill-once.override.yml \
+  run --rm \
+  -e DATABASE_URL="$DBURL" -e FROM_DATE -e TO_DATE -e SYMBOLS \
+  gapfill-once
+```
+
+Server example: swap base compose path to server bundle.
+
+## 3. Verify bar ceilings
+```bash
+DB_ID=$(docker ps --format '{{.ID}} {{.Names}}' | awk 'tolower($0) ~ /(^|-)db(-| |$)/{print $1;exit}')
+for s in ES=F NQ=F CL=F EURUSD=X; do
+  printf "%s: " "$s"
+  docker exec "$DB_ID" psql -U apex -d prismapex -t -A -c "select coalesce(max(ts_utc)::text,'NULL') from public.bars_1m where symbol = '$s';"
+done
+```
+
+## 4. Nudge tickets & check API
+```bash
+CRON_ID=$(docker ps --format '{{.ID}} {{.Names}}' | awk 'tolower($0) ~ /tickets.*cron/{print $1;exit}')
+[ -n "$CRON_ID" ] && docker restart "$(docker inspect "$CRON_ID" -f '{{.Name}}' | sed s,^/,,)"
+
+curl -sS "http://localhost:5190/api/tickets?limit=5" | jq .
+```
+
+## Troubleshooting
+- If JS build ignores flags, ts-node fallback runs automatically.
+- Ensure ingress receives the same `DATABASE_URL` as the API.
+- If Yahoo returns data yet ceilings don’t move, verify schema/table names.
+
+No helper scripts required—compose overrides live with the repo.


### PR DESCRIPTION
Standardize on overrides; no new app code. Runbook for local/server. Optional purge left dry-run.