### PR TITLE
ops: nodeps gapfill override + runbook note

### DIFF
--- a/compose.gapfill-once.nodeps.yml
+++ b/compose.gapfill-once.nodeps.yml
@@ -1,0 +1,24 @@
+services:
+  gapfill-once:
+    image: prism-apex:ingress-dev
+    working_dir: /app
+    environment:
+      - TZ=UTC
+      - DATABASE_URL
+      - FROM_DATE
+      - TO_DATE
+      - SYMBOLS
+    command: >
+      /bin/sh -lc '
+        set -e;
+        echo "[gapfill-once] DB=${DATABASE_URL}";
+        corepack enable || true;
+        pnpm -r --filter @prism-apex/ingest build || true;
+        if [ -f apps/ingest/dist/gapfill.js ]; then
+          node apps/ingest/dist/gapfill.js --from "$FROM_DATE" --to "$TO_DATE" --symbols "$SYMBOLS" || \
+          npx -y ts-node apps/ingest/src/gapfill.ts --from "$FROM_DATE" --to "$TO_DATE" --symbols "$SYMBOLS";
+        else
+          npx -y ts-node apps/ingest/src/gapfill.ts --from "$FROM_DATE" --to "$TO_DATE" --symbols "$SYMBOLS";
+        fi
+      '
+    restart: "no"

--- a/docs/runbooks/data-recovery-gapfill.md
+++ b/docs/runbooks/data-recovery-gapfill.md
@@ -51,3 +51,19 @@ curl -sS "http://localhost:5190/api/tickets?limit=5" | jq .
 - If Yahoo returns data yet ceilings don’t move, verify schema/table names.
 
 No helper scripts required—compose overrides live with the repo.
+
+### If your compose file doesn’t define `db`
+Use `compose.gapfill-once.nodeps.yml` instead of `compose.gapfill-once.override.yml`.
+This variant removes `depends_on` so you can run gapfill against the live `DATABASE_URL` regardless of service names.
+Example:
+```bash
+API_ID=$(docker ps --format '{{.ID}} {{.Names}}' | awk 'tolower($0) ~ /(^|-)api(-| |$)/{print $1;exit}')
+DBURL=$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$API_ID" | awk -F= '$1=="DATABASE_URL"{print $2;exit}')
+export FROM_DATE="2025-10-31T00:00:00Z"
+export TO_DATE="2025-11-05T00:00:00Z"
+export SYMBOLS="ES=F,NQ=F,CL=F,EURUSD=X"
+docker compose -f docker-compose.yml \
+  -f compose.ingress-db.override.yml \
+  -f compose.gapfill-once.nodeps.yml \
+  run --rm -e DATABASE_URL="$DBURL" -e FROM_DATE -e TO_DATE -e SYMBOLS gapfill-once
+```


### PR DESCRIPTION
Adds compose.gapfill-once.nodeps.yml to run the existing gapfill job without depends_on. Updates runbook with usage. No strategy changes.