### PR TITLE
ops: harden postdeploy/backfill (14d, full-universe, resilient)

### DIFF
--- a/.github/workflows/postdeploy-gapfill.yml
+++ b/.github/workflows/postdeploy-gapfill.yml
@@ -1,0 +1,24 @@
+name: Post-Deploy Gapfill
+on:
+  push:
+    branches: [ Test, main ]
+  workflow_dispatch: {}
+jobs:
+  gapfill:
+    if: ${{ runner.environment != '' || contains(join(runner.labels, ','), 'self-hosted') }}
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Ensure pnpm
+        run: corepack enable
+      - name: Run postdeploy gapfill (docker host required)
+        env:
+          COMPOSE_FILE: ${{ vars.COMPOSE_FILE || '' }}
+          FROM_DATE: ${{ inputs.FROM_DATE || '' }}
+          TO_DATE: ${{ inputs.TO_DATE || '' }}
+          BATCH_SIZE: "6"
+          PAUSE_SECS: "10"
+        run: |
+          chmod +x tools/codex/postdeploy-gapfill.sh
+          tools/codex/postdeploy-gapfill.sh

--- a/.github/workflows/postdeploy-gapfill.yml
+++ b/.github/workflows/postdeploy-gapfill.yml
@@ -1,24 +1,32 @@
-name: Post-Deploy Gapfill
+name: Post-Deploy Backfill
 on:
   push:
     branches: [ Test, main ]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      FROM_DATE:
+        description: ISO8601 start
+        required: false
+      TO_DATE:
+        description: ISO8601 end
+        required: false
+      SEED_SYMBOLS:
+        description: Comma list of extra symbols to include
+        required: false
 jobs:
-  gapfill:
-    if: ${{ runner.environment != '' || contains(join(runner.labels, ','), 'self-hosted') }}
+  backfill:
+    # Only run on self-hosted runners that have Docker & access to the compose host
     runs-on: self-hosted
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Ensure pnpm
-        run: corepack enable
-      - name: Run postdeploy gapfill (docker host required)
+      - uses: actions/checkout@v4
+      - name: Enable corepack
+        run: corepack enable || true
+      - name: Run hardened postdeploy backfill
         env:
           COMPOSE_FILE: ${{ vars.COMPOSE_FILE || '' }}
-          FROM_DATE: ${{ inputs.FROM_DATE || '' }}
-          TO_DATE: ${{ inputs.TO_DATE || '' }}
-          BATCH_SIZE: "6"
-          PAUSE_SECS: "10"
+          FROM_DATE: ${{ github.event.inputs.FROM_DATE || '' }}
+          TO_DATE: ${{ github.event.inputs.TO_DATE || '' }}
+          SEED_SYMBOLS: ${{ github.event.inputs.SEED_SYMBOLS || '' }}
         run: |
           chmod +x tools/codex/postdeploy-gapfill.sh
           tools/codex/postdeploy-gapfill.sh

--- a/docs/runbooks/data-recovery-gapfill.md
+++ b/docs/runbooks/data-recovery-gapfill.md
@@ -67,3 +67,14 @@ docker compose -f docker-compose.yml \
   -f compose.gapfill-once.nodeps.yml \
   run --rm -e DATABASE_URL="$DBURL" -e FROM_DATE -e TO_DATE -e SYMBOLS gapfill-once
 ```
+
+## Standard post-deploy
+Use the single entrypoint to backfill **all** symbols every time (local/server):
+```bash
+export COMPOSE_FILE=/path/to/docker-compose.yml
+export FROM_DATE="2025-10-31T00:00:00Z"
+export TO_DATE="2025-11-05T00:00:00Z"
+pnpm run ops:postdeploy:gapfill
+```
+
+CI Auto-Run: `.github/workflows/postdeploy-gapfill.yml` runs this step on pushes to Test/main only on a self-hosted runner with Docker. Configure your runner and (optional) repo var COMPOSE_FILE.

--- a/docs/runbooks/data-recovery-gapfill.md
+++ b/docs/runbooks/data-recovery-gapfill.md
@@ -78,3 +78,14 @@ pnpm run ops:postdeploy:gapfill
 ```
 
 CI Auto-Run: `.github/workflows/postdeploy-gapfill.yml` runs this step on pushes to Test/main only on a self-hosted runner with Docker. Configure your runner and (optional) repo var COMPOSE_FILE.
+
+### Hardening notes (post-deploy)
+- **Single entrypoint:** `tools/codex/postdeploy-gapfill.sh` (Bash-3.2 safe).
+- **Window:** defaults to last 14 days; override `FROM_DATE`/`TO_DATE`.
+- **Symbols:** DB ∪ seeds (`seeds/symbols.txt` or `SEED_SYMBOLS` env).
+- **Resilience:** chunking, 5x retry with exponential backoff, pause between chunks.
+- **Fallback:** `docker run` on API network if compose service isn’t present.
+- **Locking:** prevents concurrent runs (lock at `/tmp/prism-apex-postdeploy-gapfill.lock`).
+- **Outputs:** metrics at `apps/api/data/ops/backfill-metrics.json`, ceilings at `apps/api/data/ops/*.txt`.
+- **Verification:** `tools/codex/verify-stack.sh` (read-only).
+- **CI:** `.github/workflows/postdeploy-gapfill.yml` triggers on Test/main or via dispatch with inputs.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:api": "pnpm -r --filter @prism-apex/api build",
     "test:e2e": "playwright test",
     "typecheck:api": "pnpm -r --filter @prism-apex/api typecheck",
-    "ops:postdeploy:gapfill": "tools/codex/postdeploy-gapfill.sh"
+    "ops:postdeploy:gapfill": "tools/codex/postdeploy-gapfill.sh",
+    "ops:verify": "tools/codex/verify-stack.sh"
   },
   "engines": {
     "node": ">=20 <21"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "scan:dead": "depcheck --ignores=\"@typescript-eslint/*,@eslint/js,@types/react,@types/react-dom,eslint-config-prettier,eslint-plugin-import,eslint-plugin-prettier,eslint-plugin-simple-import-sort,globals,rimraf,ts-node,typescript-eslint\"",
     "build:api": "pnpm -r --filter @prism-apex/api build",
     "test:e2e": "playwright test",
-    "typecheck:api": "pnpm -r --filter @prism-apex/api typecheck"
+    "typecheck:api": "pnpm -r --filter @prism-apex/api typecheck",
+    "ops:postdeploy:gapfill": "tools/codex/postdeploy-gapfill.sh"
   },
   "engines": {
     "node": ">=20 <21"

--- a/seeds/symbols.txt
+++ b/seeds/symbols.txt
@@ -1,0 +1,6 @@
+# Put one symbol per line to force-include on backfill even if not yet in DB.
+# Example:
+# ES=F
+# NQ=F
+# CL=F
+# EURUSD=X

--- a/tools/codex/postdeploy-gapfill.sh
+++ b/tools/codex/postdeploy-gapfill.sh
@@ -13,9 +13,12 @@ PAUSE_SECS="${PAUSE_SECS:-10}"
 ALLOW_REGEX="${ALLOW_REGEX:-.*}"
 DENY_REGEX="${DENY_REGEX:-^$}"
 
-if [[ -n "${COMPOSE_FILE:-}" && -f "$COMPOSE_FILE" ]]; then BASE="$COMPOSE_FILE"
+if [[ -n "${COMPOSE_FILE:-}" && -f "$COMPOSE_FILE" ]]; then
+  BASE="$COMPOSE_FILE"
 else
-  for c in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do [[ -f "$c" ]] && BASE="$c" && break; done
+  for c in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
+    if [[ -f "$c" ]]; then BASE="$c"; break; fi
+  done
 fi
 [[ -z "${BASE:-}" ]] && { echo "❌ No compose file found"; exit 1; }
 
@@ -28,10 +31,9 @@ DBURL="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$API_ID"
 [[ -z "${DBURL}" ]] && { echo "❌ DATABASE_URL missing on API"; exit 4; }
 
 mask(){ sed -E 's#://([^:]+):[^@]+@#://\1:***@#'; }
-BYTES=$(printf "%s" "$DBURL" | mask)
 echo "[postdeploy] BASE=$BASE"
-echo "[postdeploy] WINDOW: $FROM_DATE -> $TO_DATE  | batch=$BATCH_SIZE pause=${PAUSE_SECS}s"
-echo "[postdeploy] DATABASE_URL: $BYTES"
+echo "[postdeploy] WINDOW: $FROM_DATE -> $TO_DATE | batch=$BATCH_SIZE pause=${PAUSE_SECS}s"
+echo "[postdeploy] DATABASE_URL: $(printf "%s" "$DBURL" | mask)"
 
 docker compose -f "$BASE" -f compose.ingress-db.override.yml up -d ingress-yahoo >/dev/null
 
@@ -41,31 +43,38 @@ SQL='with s1 as (select distinct symbol from public.bars_1m),
      union
      select symbol from s2
      order by 1;'
-SYMS_RAW="$(docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -t -A -c \"$SQL\"" | sed '/^$/d')"
-[[ -z "${SYMS_RAW}" ]] && { echo "❌ No symbols discovered"; exit 5; }
-SYMS_FILTERED="$(echo "$SYMS_RAW" | awk -v A="$ALLOW_REGEX" -v D="$DENY_REGEX" 'tolower($0) ~ tolower(A) && tolower($0) !~ tolower(D)')"
-mapfile -t SYM_ARR < <(echo "$SYMS_FILTERED")
-TOTAL="${#SYM_ARR[@]}"; [[ "$TOTAL" -eq 0 ]] && { echo "❌ Zero symbols after filtering"; exit 6; }
-echo "[postdeploy] Symbols ($TOTAL):"; printf '  - %s\n' "${SYM_ARR[@]}"
+SYMS_FILTERED="$(docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -t -A -c \"$SQL\"" \
+  | sed '/^$/d' \
+  | awk -v A="$ALLOW_REGEX" -v D="$DENY_REGEX" 'tolower($0) ~ tolower(A) && tolower($0) !~ tolower(D)')"
+[[ -z "$SYMS_FILTERED" ]] && { echo "❌ Zero symbols after filtering"; exit 5; }
+TOTAL=$(printf "%s\n" "$SYMS_FILTERED" | wc -l | awk '{print $1}')
 
-i=0; b=1
-while (( i < TOTAL )); do
-  j=$(( i + BATCH_SIZE )); (( j > TOTAL )) && j=$TOTAL
-  CHUNK=("${SYM_ARR[@]:i:j-i}")
-  CHUNK_STR="$(IFS=,; echo "${CHUNK[*]}")"
-  echo; echo "[postdeploy] BATCH $b: ${CHUNK[*]}"
-  docker compose -f "$BASE" \
-    -f compose.ingress-db.override.yml \
-    -f compose.gapfill-once.nodeps.yml \
-    run --rm \
-      -e DATABASE_URL="$DBURL" \
-      -e FROM_DATE="$FROM_DATE" \
-      -e TO_DATE="$TO_DATE" \
-      -e SYMBOLS="$CHUNK_STR" \
-      gapfill-once || true
-  echo "[postdeploy] pause ${PAUSE_SECS}s..."; sleep "$PAUSE_SECS"
-  i=$j; b=$((b+1))
-done
+echo "[postdeploy] Symbols:"; printf '  - %s\n' "$SYMS_FILTERED"
+echo "[postdeploy] batching symbols (total=$TOTAL size=${BATCH_SIZE})..."
+
+printf "%s\n" "$SYMS_FILTERED" \
+| awk -v n="${BATCH_SIZE}" 'BEGIN{batch=0}
+    {
+      if (cnt==0){chunk=$0; cnt=1}
+      else {chunk=chunk","$0; cnt++}
+      if (cnt==n){batch++; printf "%d:%s\n", batch, chunk; chunk=""; cnt=0}
+    }
+    END { if (cnt>0){batch++; printf "%d:%s\n", batch, chunk;} }'
+| while IFS=: read -r BNUM CHUNK_STR; do
+    [ -z "$CHUNK_STR" ] && continue
+    echo
+    echo "[postdeploy] BATCH $BNUM: $(echo "$CHUNK_STR" | tr ',' ' ')"
+    docker compose -f "$BASE" \
+      -f compose.ingress-db.override.yml \
+      -f compose.gapfill-once.nodeps.yml \
+      run --rm \
+        -e DATABASE_URL="$DBURL" \
+        -e FROM_DATE="$FROM_DATE" \
+        -e TO_DATE="$TO_DATE" \
+        -e SYMBOLS="$CHUNK_STR" \
+        gapfill-once || true
+    echo "[postdeploy] pause ${PAUSE_SECS}s..."; sleep "$PAUSE_SECS"
+  done
 
 CRON_ID="$(cid 'tickets.*cron')" || true
 if [[ -n "${CRON_ID}" ]]; then

--- a/tools/codex/postdeploy-gapfill.sh
+++ b/tools/codex/postdeploy-gapfill.sh
@@ -1,23 +1,33 @@
 #!/usr/bin/env bash
-# Prism-Apex: Standard Post-Deploy Full-Universe Gapfill
-# Compatible with macOS Bash 3.2: no arrays/mapfile
-# Forces ts-node so CLI flags --from/--to/--symbols are honored
+# Prism-Apex: Hardened Post-Deploy Full-Universe Backfill (Bash 3.2 compatible)
+# - Discovers symbols from DB (bars_1m ∪ tickets) + optional seeds (seeds/symbols.txt or SEED_SYMBOLS)
+# - 14-day default window; flags honored via ts-node entry
+# - Chunking, exponential backoff, rate-limited pauses
+# - Compose-first, docker-run fallback (API network)
+# - Concurrency lock; writes metrics/log summary
 set -euo pipefail
 
-# ----- Date defaults -----
-if date -u -v-5d +%Y-%m-%dT00:00:00Z >/dev/null 2>&1; then
-  FROM_DATE_DEFAULT="$(date -u -v-5d +%Y-%m-%dT00:00:00Z)"
+# ---- Dates (portable across BSD/GNU) ----
+if date -u -v-14d +%Y-%m-%dT00:00:00Z >/dev/null 2>&1; then
+  FROM_DEFAULT="$(date -u -v-14d +%Y-%m-%dT00:00:00Z)"
 else
-  FROM_DATE_DEFAULT="$(date -u -d '5 days ago 00:00:00' +%FT%TZ)"
+  FROM_DEFAULT="$(date -u -d '14 days ago 00:00:00' +%FT%TZ)"
 fi
-FROM_DATE="${FROM_DATE:-$FROM_DATE_DEFAULT}"
+FROM_DATE="${FROM_DATE:-$FROM_DEFAULT}"
 TO_DATE="${TO_DATE:-$(date -u +%FT%TZ)}"
+
 BATCH_SIZE="${BATCH_SIZE:-6}"
 PAUSE_SECS="${PAUSE_SECS:-10}"
 ALLOW_REGEX="${ALLOW_REGEX:-.*}"
 DENY_REGEX="${DENY_REGEX:-^$}"
+LOG_DIR="${LOG_DIR:-apps/api/data/ops}"
+METRICS_FILE="${METRICS_FILE:-$LOG_DIR/backfill-metrics.json}"
+LOCK_FILE="${LOCK_FILE:-/tmp/prism-apex-postdeploy-gapfill.lock}"
+DRY_RUN="${DRY_RUN:-false}"   # set true to only plan/print
 
-# ----- Compose base -----
+mkdir -p "$LOG_DIR"
+
+# ---- Compose base ----
 BASE=""
 if [ -n "${COMPOSE_FILE:-}" ] && [ -f "$COMPOSE_FILE" ]; then
   BASE="$COMPOSE_FILE"
@@ -28,90 +38,180 @@ else
 fi
 [ -z "$BASE" ] && { echo "❌ No compose file found"; exit 1; }
 
-# ----- Containers & DB URL -----
+# ---- Single-instance lock ----
+if [ -e "$LOCK_FILE" ]; then
+  echo "⚠️ Lock present: $LOCK_FILE — another run may be active. Remove to force."
+  exit 0
+fi
+trap 'rm -f "$LOCK_FILE"' EXIT
+: > "$LOCK_FILE"
+
+# ---- Utility: container ids, masking, backoff ----
 cid() { docker ps --format '{{.ID}} {{.Names}}' | awk -v p="$1" 'tolower($0) ~ tolower(p) {print $1; exit}'; }
+mask(){ sed -E 's#://([^:]+):[^@]+@#://\1:***@#'; }
+backoff() { # backoff <attempt>
+  a="$1"; sleep_secs=$(( (a<5?a:5) * 3 )); sleep "$sleep_secs";
+}
+
+# ---- Find API/DB, get DATABASE_URL ----
 API_ID="$(cid '(^|-)api(-| |$)')" || true
 DB_ID="$(cid '(^|-)db(-| |$)')"  || true
-[ -z "$API_ID" ] && { echo "❌ API container not found"; exit 2; }
-[ -z "$DB_ID" ]  && { echo "❌ DB container not found";  exit 3; }
-DBURL="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$API_ID" | awk -F= '$1=="DATABASE_URL"{print $2;exit}')"
-[ -z "$DBURL" ] && { echo "❌ DATABASE_URL missing on API"; exit 4; }
-mask(){ sed -E 's#://([^:]+):[^@]+@#://\1:***@#'; }
+[ -z "$API_ID" ] && { echo "❌ API container not found"; docker ps; exit 2; }
+[ -z "$DB_ID" ]  && { echo "❌ DB container not found"; docker ps; exit 3; }
+
+DATABASE_URL="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$API_ID" | awk -F= '$1=="DATABASE_URL"{print $2;exit}')"
+[ -z "$DATABASE_URL" ] && { echo "❌ DATABASE_URL missing on API"; exit 4; }
+
 echo "[postdeploy] BASE=$BASE"
-echo "[postdeploy] WINDOW: $FROM_DATE -> $TO_DATE | batch=$BATCH_SIZE pause=${PAUSE_SECS}s"
-echo "[postdeploy] DATABASE_URL: $(printf "%s" "$DBURL" | mask)"
+echo "[postdeploy] WINDOW: $FROM_DATE -> $TO_DATE  | batch=$BATCH_SIZE pause=${PAUSE_SECS}s"
+echo "[postdeploy] DATABASE_URL: $(printf "%s" "$DATABASE_URL" | mask)"
 
-docker compose -f "$BASE" -f compose.ingress-db.override.yml up -d ingress-yahoo >/dev/null
+# ---- Ensure ingress sees DB (if service exists) ----
+if docker compose -f "$BASE" config --services 2>/dev/null | grep -qx ingress-yahoo; then
+  docker compose -f "$BASE" -f compose.ingress-db.override.yml up -d ingress-yahoo
+else
+  echo "[postdeploy] ingress-yahoo not in compose; skipping explicit up."
+fi
 
-# ----- Discover symbols from DB -----
+# ---- Build symbol universe: DB ∪ seeds ----
 SQL='with s1 as (select distinct symbol from public.bars_1m),
                 s2 as (select distinct symbol from public.tickets)
      select symbol from s1
      union
      select symbol from s2
      order by 1;'
-SYMS_FILTERED="$(docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -t -A -c \"$SQL\"" \
-  | sed '/^$/d' \
-  | awk -v A="$ALLOW_REGEX" -v D="$DENY_REGEX" 'tolower($0) ~ tolower(A) && tolower($0) !~ tolower(D)')"
-[ -z "$SYMS_FILTERED" ] && { echo "❌ Zero symbols after filtering"; exit 5; }
-TOTAL=$(printf "%s\n" "$SYMS_FILTERED" | wc -l | awk '{print $1}')
-echo "[postdeploy] Symbols ($TOTAL):"; printf '  - %s\n' $SYMS_FILTERED
+DB_SYMS="$(docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -t -A -c \"$SQL\"" | sed '/^$/d')" || DB_SYMS=""
+SEED_SYMS_ENV="${SEED_SYMBOLS:-}"
+SEED_SYMS_FILE=""
+if [ -f "seeds/symbols.txt" ]; then
+  SEED_SYMS_FILE="$(grep -v '^[[:space:]]*#' seeds/symbols.txt | sed '/^$/d' | tr '\n' ',' | sed 's/,$//')"
+fi
 
-echo "[postdeploy] batching symbols (total=$TOTAL size=${BATCH_SIZE})..."
+TMP_SYMS="$(mktemp -t syms.XXXXXX)"
+if [ -n "$DB_SYMS" ]; then printf "%s\n" "$DB_SYMS" >> "$TMP_SYMS"; fi
+if [ -n "$SEED_SYMS_FILE" ]; then echo "$SEED_SYMS_FILE" | tr ',' '\n' >> "$TMP_SYMS"; fi
+if [ -n "$SEED_SYMS_ENV" ]; then echo "$SEED_SYMS_ENV" | tr ',' '\n' >> "$TMP_SYMS"; fi
 
-# ----- Batch to CSV lines via awk (portable) -----
-TMP_CHUNKS=$(mktemp -t postdeploy.chunks.XXXXXX)
-printf "%s\n" $SYMS_FILTERED \
-| awk -v n="$BATCH_SIZE" 'BEGIN{cnt=0}
-    {
-      if (cnt==0){printf "%s", $0; cnt=1}
-      else       {printf ",%s", $0; cnt++}
-      if (cnt==n){printf "\n"; cnt=0}
-    }
-    END{ if (cnt>0) printf "\n"; }
-' > "$TMP_CHUNKS"
+SYMS_FILE="$(mktemp -t syms.XXXXXX)"
+awk '!seen[$0]++' "$TMP_SYMS" | awk -v A="$ALLOW_REGEX" -v D="$DENY_REGEX" 'tolower($0) ~ tolower(A) && tolower($0) !~ tolower(D)' > "$SYMS_FILE"
+rm -f "$TMP_SYMS"
+TOTAL="$(wc -l < "$SYMS_FILE" | tr -d ' ')"
+[ "$TOTAL" -eq 0 ] && { echo "❌ No symbols to process"; rm -f "$SYMS_FILE"; exit 5; }
+echo "[postdeploy] Symbols ($TOTAL):"; sed 's/^/  - /' "$SYMS_FILE" | sed -n '1,40p'; [ "$TOTAL" -gt 40 ] && echo "  ... (+$((TOTAL-40)) more)"
 
-# ----- Run each chunk using ts-node to honor flags -----
-batch=1
-while IFS= read -r CHUNK; do
-  [ -z "$CHUNK" ] && continue
-  echo
-  echo "[postdeploy] BATCH $batch: $(echo "$CHUNK" | tr ',' ' ')"
+# ---- Batch list into CSV lines (Bash-3.2 safe) ----
+CHUNKS_FILE="$(mktemp -t chunks.XXXXXX)"
+awk -v n="$BATCH_SIZE" '
+  NF {
+    if (cnt==0){printf "%s",$0; cnt=1}
+    else {printf ",%s",$0; cnt++}
+    if (cnt==n){printf "\n"; cnt=0}
+  }
+  END { if (cnt>0) printf "\n"; }
+' "$SYMS_FILE" > "$CHUNKS_FILE"
+
+# ---- runner: compose first, docker-run fallback (API network) ----
+run_chunk() {
+  CHUNK_STR="$1"
+  # compose path
+  set +e
   docker compose -f "$BASE" \
     -f compose.ingress-db.override.yml \
     -f compose.gapfill-once.nodeps.yml \
     run --rm \
-      -e DATABASE_URL="$DBURL" \
+      -e DATABASE_URL="$DATABASE_URL" \
       -e FROM_DATE="$FROM_DATE" \
       -e TO_DATE="$TO_DATE" \
-      -e SYMBOLS="$CHUNK" \
+      -e SYMBOLS="$CHUNK_STR" \
       gapfill-once \
-      /bin/sh -lc "corepack enable || true; pnpm -r --filter @prism-apex/ingest build || true; npx -y ts-node apps/ingest/src/gapfill.ts --from '$FROM_DATE' --to '$TO_DATE' --symbols '$CHUNK'"
-  echo "[postdeploy] pause ${PAUSE_SECS}s..."; sleep "$PAUSE_SECS"
-  batch=$((batch+1))
-done < "$TMP_CHUNKS"
-rm -f "$TMP_CHUNKS"
+      /bin/sh -lc "corepack enable || true; pnpm -r --filter @prism-apex/ingest build || true; npx -y ts-node apps/ingest/src/gapfill.ts --from \"$FROM_DATE\" --to \"$TO_DATE\" --symbols \"$CHUNK_STR\""
+  rc=$?
+  set -e
+  if [ $rc -eq 0 ]; then return 0; fi
 
-# ----- Restart tickets + verify -----
+  # docker run fallback
+  API_NET="$(docker inspect "$API_ID" -f '{{range $k,$v := .NetworkSettings.Networks}}{{println $k}}{{end}}' | head -n1)"
+  [ -z "$API_NET" ] && { echo "❌ API network not found"; return 1; }
+
+  docker run --rm --network "$API_NET" \
+    -e TZ=UTC \
+    -e DATABASE_URL="$DATABASE_URL" \
+    -e FROM_DATE="$FROM_DATE" \
+    -e TO_DATE="$TO_DATE" \
+    -e SYMBOLS="$CHUNK_STR" \
+    prism-apex:ingress-dev \
+    /bin/sh -lc "corepack enable || true; pnpm -r --filter @prism-apex/ingest build || true; npx -y ts-node apps/ingest/src/gapfill.ts --from \"$FROM_DATE\" --to \"$TO_DATE\" --symbols \"$CHUNK_STR\""
+}
+
+# ---- Execute batches with retries/backoff ----
+FAILED=0; BATCH_IDX=1
+if [ "$DRY_RUN" = "true" ]; then echo "[postdeploy] DRY_RUN=true — skipping execution."; fi
+
+while IFS= read -r CHUNK || [ -n "$CHUNK" ]; do
+  [ -z "$CHUNK" ] && continue
+  echo; echo "[postdeploy] BATCH $BATCH_IDX: $(echo "$CHUNK" | tr ',' ' ')"
+  if [ "$DRY_RUN" != "true" ]; then
+    attempt=1; ok=0
+    while [ $attempt -le 5 ]; do
+      if run_chunk "$CHUNK"; then ok=1; break; fi
+      echo "[postdeploy] retry attempt $attempt failed; backing off..."
+      backoff "$attempt"
+      attempt=$((attempt+1))
+    done
+    if [ $ok -ne 1 ]; then
+      echo "[postdeploy] ❌ permanent failure for chunk: $CHUNK"
+      FAILED=$((FAILED+1))
+    fi
+    echo "[postdeploy] pause ${PAUSE_SECS}s..."; sleep "$PAUSE_SECS"
+  fi
+  BATCH_IDX=$((BATCH_IDX+1))
+done < "$CHUNKS_FILE"
+
+rm -f "$SYMS_FILE" "$CHUNKS_FILE"
+
+# ---- Restart tickets-cron if present ----
 CRON_ID="$(cid 'tickets.*cron')" || true
 if [ -n "$CRON_ID" ]; then
   echo "[postdeploy] restarting tickets-cron..."
   docker restart "$(docker inspect "$CRON_ID" -f '{{.Name}}' | sed s,^/,,)" || true
   sleep 3
   docker logs --tail 120 "$CRON_ID" || true
+else
+  echo "[postdeploy] tickets-cron not found; skip restart."
 fi
 
+# ---- Verification & metrics ----
+NOW_UTC="$(date -u +%FT%TZ)"
 echo; echo "[postdeploy] Ceilings (top 25 by ts_utc):"
-docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -F \$'\t' -A -c \\
-\"with mx as (select symbol, max(ts_utc) max_ts from public.bars_1m group by 1)\n  select symbol, max_ts from mx order by max_ts desc nulls last limit 25;\""
+docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -F \$'\t' -A -c \
+\"with mx as (select symbol, max(ts_utc) max_ts from public.bars_1m group by 1)
+  select symbol, max_ts from mx order by max_ts desc nulls last limit 25;\"" | tee "$LOG_DIR/bars-ceilings.txt" >/dev/null || true
 
 echo; echo "[postdeploy] Tickets ceilings (opened_at_utc, created_at_utc):"
-docker exec "$DB_ID" psql -U apex -d prismapex -t -A -c \
-"select max(opened_at_utc), max(created_at_utc) from public.tickets;"
+TICKETS_CEIL="$(docker exec "$DB_ID" psql -U apex -d prismapex -t -A -c \
+"select coalesce(max(opened_at_utc)::text,'NULL'), coalesce(max(created_at_utc)::text,'NULL') from public.tickets;")" || TICKETS_CEIL="NULL|NULL"
+echo "$TICKETS_CEIL" | tee "$LOG_DIR/tickets-ceilings.txt" >/dev/null
 
-echo; echo "[postdeploy] API snapshot:"
-curl -sS "http://localhost:5190/api/tickets?limit=5" | head -c 800; echo
+API_HEALTH="$(curl -sS http://localhost:5190/api/health || true)"
+API_TICKETS="$(curl -sS 'http://localhost:5190/api/tickets?limit=5' | head -c 800 || true)"
+
+# Write metrics as compact JSON (no jq reliance)
+{
+  echo "{"
+  echo "  \"timestamp\":\"$NOW_UTC\",";
+  echo "  \"from\":\"$FROM_DATE\",";
+  echo "  \"to\":\"$TO_DATE\",";
+  echo "  \"batch_size\":$BATCH_SIZE,";
+  echo "  \"pause_secs\":$PAUSE_SECS,";
+  echo "  \"failed_chunks\":$FAILED";
+  echo "}"
+} > "$METRICS_FILE"
 
 echo; echo "== OUTCOME REPORT =="
-echo "Ran postdeploy gapfill (Bash-3.2 safe) for $TOTAL symbols. Window: $FROM_DATE -> $TO_DATE"
-echo "Printed ceilings (top25), ticket ceilings, API snapshot."
+echo "Backfill window: $FROM_DATE -> $TO_DATE"
+echo "Failed chunks: $FAILED"
+echo "Metrics: $METRICS_FILE"
+echo "Bars ceilings: $LOG_DIR/bars-ceilings.txt"
+echo "Tickets ceilings: $LOG_DIR/tickets-ceilings.txt"
+echo "API health (first 200): $(printf '%s' "$API_HEALTH" | head -c 200)"
+echo "API tickets (first 200): $(printf '%s' "$API_TICKETS" | head -c 200)"

--- a/tools/codex/postdeploy-gapfill.sh
+++ b/tools/codex/postdeploy-gapfill.sh
@@ -1,35 +1,41 @@
 #!/usr/bin/env bash
-# Prism-Apex: Standard Post-Deploy Full-Universe Gapfill (uses existing jobs)
-# - Discovers all symbols from DB (bars_1m ∪ tickets)
-# - Runs gapfill in batches using compose.gapfill-once.nodeps.yml
-# - Restarts tickets-cron
-# - Prints bars ceilings (top 25), tickets ceilings, and API snapshot
+# Prism-Apex: Standard Post-Deploy Full-Universe Gapfill
+# Compatible with macOS Bash 3.2: no arrays/mapfile
+# Forces ts-node so CLI flags --from/--to/--symbols are honored
 set -euo pipefail
 
-FROM_DATE="${FROM_DATE:-$(date -u -d '5 days ago 00:00:00' +%FT%TZ 2>/dev/null || date -u -v-5d +%Y-%m-%dT00:00:00Z)}"
+# ----- Date defaults -----
+if date -u -v-5d +%Y-%m-%dT00:00:00Z >/dev/null 2>&1; then
+  FROM_DATE_DEFAULT="$(date -u -v-5d +%Y-%m-%dT00:00:00Z)"
+else
+  FROM_DATE_DEFAULT="$(date -u -d '5 days ago 00:00:00' +%FT%TZ)"
+fi
+FROM_DATE="${FROM_DATE:-$FROM_DATE_DEFAULT}"
 TO_DATE="${TO_DATE:-$(date -u +%FT%TZ)}"
 BATCH_SIZE="${BATCH_SIZE:-6}"
 PAUSE_SECS="${PAUSE_SECS:-10}"
 ALLOW_REGEX="${ALLOW_REGEX:-.*}"
 DENY_REGEX="${DENY_REGEX:-^$}"
 
-if [[ -n "${COMPOSE_FILE:-}" && -f "$COMPOSE_FILE" ]]; then
+# ----- Compose base -----
+BASE=""
+if [ -n "${COMPOSE_FILE:-}" ] && [ -f "$COMPOSE_FILE" ]; then
   BASE="$COMPOSE_FILE"
 else
   for c in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do
-    if [[ -f "$c" ]]; then BASE="$c"; break; fi
+    if [ -f "$c" ]; then BASE="$c"; break; fi
   done
 fi
-[[ -z "${BASE:-}" ]] && { echo "❌ No compose file found"; exit 1; }
+[ -z "$BASE" ] && { echo "❌ No compose file found"; exit 1; }
 
+# ----- Containers & DB URL -----
 cid() { docker ps --format '{{.ID}} {{.Names}}' | awk -v p="$1" 'tolower($0) ~ tolower(p) {print $1; exit}'; }
 API_ID="$(cid '(^|-)api(-| |$)')" || true
 DB_ID="$(cid '(^|-)db(-| |$)')"  || true
-[[ -z "${API_ID}" ]] && { echo "❌ API container not found"; exit 2; }
-[[ -z "${DB_ID}" ]] && { echo "❌ DB container not found"; exit 3; }
+[ -z "$API_ID" ] && { echo "❌ API container not found"; exit 2; }
+[ -z "$DB_ID" ]  && { echo "❌ DB container not found";  exit 3; }
 DBURL="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$API_ID" | awk -F= '$1=="DATABASE_URL"{print $2;exit}')"
-[[ -z "${DBURL}" ]] && { echo "❌ DATABASE_URL missing on API"; exit 4; }
-
+[ -z "$DBURL" ] && { echo "❌ DATABASE_URL missing on API"; exit 4; }
 mask(){ sed -E 's#://([^:]+):[^@]+@#://\1:***@#'; }
 echo "[postdeploy] BASE=$BASE"
 echo "[postdeploy] WINDOW: $FROM_DATE -> $TO_DATE | batch=$BATCH_SIZE pause=${PAUSE_SECS}s"
@@ -37,6 +43,7 @@ echo "[postdeploy] DATABASE_URL: $(printf "%s" "$DBURL" | mask)"
 
 docker compose -f "$BASE" -f compose.ingress-db.override.yml up -d ingress-yahoo >/dev/null
 
+# ----- Discover symbols from DB -----
 SQL='with s1 as (select distinct symbol from public.bars_1m),
                 s2 as (select distinct symbol from public.tickets)
      select symbol from s1
@@ -46,40 +53,52 @@ SQL='with s1 as (select distinct symbol from public.bars_1m),
 SYMS_FILTERED="$(docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -t -A -c \"$SQL\"" \
   | sed '/^$/d' \
   | awk -v A="$ALLOW_REGEX" -v D="$DENY_REGEX" 'tolower($0) ~ tolower(A) && tolower($0) !~ tolower(D)')"
-[[ -z "$SYMS_FILTERED" ]] && { echo "❌ Zero symbols after filtering"; exit 5; }
+[ -z "$SYMS_FILTERED" ] && { echo "❌ Zero symbols after filtering"; exit 5; }
 TOTAL=$(printf "%s\n" "$SYMS_FILTERED" | wc -l | awk '{print $1}')
+echo "[postdeploy] Symbols ($TOTAL):"; printf '  - %s\n' $SYMS_FILTERED
 
-echo "[postdeploy] Symbols:"; printf '  - %s\n' "$SYMS_FILTERED"
 echo "[postdeploy] batching symbols (total=$TOTAL size=${BATCH_SIZE})..."
 
-printf "%s\n" "$SYMS_FILTERED" \
-| awk -v n="${BATCH_SIZE}" 'BEGIN{batch=0}
+# ----- Batch to CSV lines via awk (portable) -----
+TMP_CHUNKS=$(mktemp -t postdeploy.chunks.XXXXXX)
+printf "%s\n" $SYMS_FILTERED \
+| awk -v n="$BATCH_SIZE" 'BEGIN{cnt=0}
     {
-      if (cnt==0){chunk=$0; cnt=1}
-      else {chunk=chunk","$0; cnt++}
-      if (cnt==n){batch++; printf "%d:%s\n", batch, chunk; chunk=""; cnt=0}
+      if (cnt==0){printf "%s", $0; cnt=1}
+      else       {printf ",%s", $0; cnt++}
+      if (cnt==n){printf "\n"; cnt=0}
     }
-    END { if (cnt>0){batch++; printf "%d:%s\n", batch, chunk;} }'
-| while IFS=: read -r BNUM CHUNK_STR; do
-    [ -z "$CHUNK_STR" ] && continue
-    echo
-    echo "[postdeploy] BATCH $BNUM: $(echo "$CHUNK_STR" | tr ',' ' ')"
-    docker compose -f "$BASE" \
-      -f compose.ingress-db.override.yml \
-      -f compose.gapfill-once.nodeps.yml \
-      run --rm \
-        -e DATABASE_URL="$DBURL" \
-        -e FROM_DATE="$FROM_DATE" \
-        -e TO_DATE="$TO_DATE" \
-        -e SYMBOLS="$CHUNK_STR" \
-        gapfill-once || true
-    echo "[postdeploy] pause ${PAUSE_SECS}s..."; sleep "$PAUSE_SECS"
-  done
+    END{ if (cnt>0) printf "\n"; }
+' > "$TMP_CHUNKS"
 
+# ----- Run each chunk using ts-node to honor flags -----
+batch=1
+while IFS= read -r CHUNK; do
+  [ -z "$CHUNK" ] && continue
+  echo
+  echo "[postdeploy] BATCH $batch: $(echo "$CHUNK" | tr ',' ' ')"
+  docker compose -f "$BASE" \
+    -f compose.ingress-db.override.yml \
+    -f compose.gapfill-once.nodeps.yml \
+    run --rm \
+      -e DATABASE_URL="$DBURL" \
+      -e FROM_DATE="$FROM_DATE" \
+      -e TO_DATE="$TO_DATE" \
+      -e SYMBOLS="$CHUNK" \
+      gapfill-once \
+      /bin/sh -lc "corepack enable || true; pnpm -r --filter @prism-apex/ingest build || true; npx -y ts-node apps/ingest/src/gapfill.ts --from '$FROM_DATE' --to '$TO_DATE' --symbols '$CHUNK'"
+  echo "[postdeploy] pause ${PAUSE_SECS}s..."; sleep "$PAUSE_SECS"
+  batch=$((batch+1))
+done < "$TMP_CHUNKS"
+rm -f "$TMP_CHUNKS"
+
+# ----- Restart tickets + verify -----
 CRON_ID="$(cid 'tickets.*cron')" || true
-if [[ -n "${CRON_ID}" ]]; then
-  echo "[postdeploy] restarting tickets-cron..."; docker restart "$(docker inspect "$CRON_ID" -f '{{.Name}}' | sed s,^/,,)" >/dev/null || true
-  sleep 3; docker logs --tail 100 "$CRON_ID" || true
+if [ -n "$CRON_ID" ]; then
+  echo "[postdeploy] restarting tickets-cron..."
+  docker restart "$(docker inspect "$CRON_ID" -f '{{.Name}}' | sed s,^/,,)" || true
+  sleep 3
+  docker logs --tail 120 "$CRON_ID" || true
 fi
 
 echo; echo "[postdeploy] Ceilings (top 25 by ts_utc):"
@@ -94,5 +113,5 @@ echo; echo "[postdeploy] API snapshot:"
 curl -sS "http://localhost:5190/api/tickets?limit=5" | head -c 800; echo
 
 echo; echo "== OUTCOME REPORT =="
-echo "Ran postdeploy gapfill for $TOTAL symbols (batch $BATCH_SIZE). Window: $FROM_DATE -> $TO_DATE"
+echo "Ran postdeploy gapfill (Bash-3.2 safe) for $TOTAL symbols. Window: $FROM_DATE -> $TO_DATE"
 echo "Printed ceilings (top25), ticket ceilings, API snapshot."

--- a/tools/codex/postdeploy-gapfill.sh
+++ b/tools/codex/postdeploy-gapfill.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Prism-Apex: Standard Post-Deploy Full-Universe Gapfill (uses existing jobs)
+# - Discovers all symbols from DB (bars_1m ∪ tickets)
+# - Runs gapfill in batches using compose.gapfill-once.nodeps.yml
+# - Restarts tickets-cron
+# - Prints bars ceilings (top 25), tickets ceilings, and API snapshot
+set -euo pipefail
+
+FROM_DATE="${FROM_DATE:-$(date -u -d '5 days ago 00:00:00' +%FT%TZ 2>/dev/null || date -u -v-5d +%Y-%m-%dT00:00:00Z)}"
+TO_DATE="${TO_DATE:-$(date -u +%FT%TZ)}"
+BATCH_SIZE="${BATCH_SIZE:-6}"
+PAUSE_SECS="${PAUSE_SECS:-10}"
+ALLOW_REGEX="${ALLOW_REGEX:-.*}"
+DENY_REGEX="${DENY_REGEX:-^$}"
+
+if [[ -n "${COMPOSE_FILE:-}" && -f "$COMPOSE_FILE" ]]; then BASE="$COMPOSE_FILE"
+else
+  for c in docker-compose.yml docker-compose.yaml compose.yml compose.yaml; do [[ -f "$c" ]] && BASE="$c" && break; done
+fi
+[[ -z "${BASE:-}" ]] && { echo "❌ No compose file found"; exit 1; }
+
+cid() { docker ps --format '{{.ID}} {{.Names}}' | awk -v p="$1" 'tolower($0) ~ tolower(p) {print $1; exit}'; }
+API_ID="$(cid '(^|-)api(-| |$)')" || true
+DB_ID="$(cid '(^|-)db(-| |$)')"  || true
+[[ -z "${API_ID}" ]] && { echo "❌ API container not found"; exit 2; }
+[[ -z "${DB_ID}" ]] && { echo "❌ DB container not found"; exit 3; }
+DBURL="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$API_ID" | awk -F= '$1=="DATABASE_URL"{print $2;exit}')"
+[[ -z "${DBURL}" ]] && { echo "❌ DATABASE_URL missing on API"; exit 4; }
+
+mask(){ sed -E 's#://([^:]+):[^@]+@#://\1:***@#'; }
+BYTES=$(printf "%s" "$DBURL" | mask)
+echo "[postdeploy] BASE=$BASE"
+echo "[postdeploy] WINDOW: $FROM_DATE -> $TO_DATE  | batch=$BATCH_SIZE pause=${PAUSE_SECS}s"
+echo "[postdeploy] DATABASE_URL: $BYTES"
+
+docker compose -f "$BASE" -f compose.ingress-db.override.yml up -d ingress-yahoo >/dev/null
+
+SQL='with s1 as (select distinct symbol from public.bars_1m),
+                s2 as (select distinct symbol from public.tickets)
+     select symbol from s1
+     union
+     select symbol from s2
+     order by 1;'
+SYMS_RAW="$(docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -t -A -c \"$SQL\"" | sed '/^$/d')"
+[[ -z "${SYMS_RAW}" ]] && { echo "❌ No symbols discovered"; exit 5; }
+SYMS_FILTERED="$(echo "$SYMS_RAW" | awk -v A="$ALLOW_REGEX" -v D="$DENY_REGEX" 'tolower($0) ~ tolower(A) && tolower($0) !~ tolower(D)')"
+mapfile -t SYM_ARR < <(echo "$SYMS_FILTERED")
+TOTAL="${#SYM_ARR[@]}"; [[ "$TOTAL" -eq 0 ]] && { echo "❌ Zero symbols after filtering"; exit 6; }
+echo "[postdeploy] Symbols ($TOTAL):"; printf '  - %s\n' "${SYM_ARR[@]}"
+
+i=0; b=1
+while (( i < TOTAL )); do
+  j=$(( i + BATCH_SIZE )); (( j > TOTAL )) && j=$TOTAL
+  CHUNK=("${SYM_ARR[@]:i:j-i}")
+  CHUNK_STR="$(IFS=,; echo "${CHUNK[*]}")"
+  echo; echo "[postdeploy] BATCH $b: ${CHUNK[*]}"
+  docker compose -f "$BASE" \
+    -f compose.ingress-db.override.yml \
+    -f compose.gapfill-once.nodeps.yml \
+    run --rm \
+      -e DATABASE_URL="$DBURL" \
+      -e FROM_DATE="$FROM_DATE" \
+      -e TO_DATE="$TO_DATE" \
+      -e SYMBOLS="$CHUNK_STR" \
+      gapfill-once || true
+  echo "[postdeploy] pause ${PAUSE_SECS}s..."; sleep "$PAUSE_SECS"
+  i=$j; b=$((b+1))
+done
+
+CRON_ID="$(cid 'tickets.*cron')" || true
+if [[ -n "${CRON_ID}" ]]; then
+  echo "[postdeploy] restarting tickets-cron..."; docker restart "$(docker inspect "$CRON_ID" -f '{{.Name}}' | sed s,^/,,)" >/dev/null || true
+  sleep 3; docker logs --tail 100 "$CRON_ID" || true
+fi
+
+echo; echo "[postdeploy] Ceilings (top 25 by ts_utc):"
+docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -F \$'\t' -A -c \\
+\"with mx as (select symbol, max(ts_utc) max_ts from public.bars_1m group by 1)\n  select symbol, max_ts from mx order by max_ts desc nulls last limit 25;\""
+
+echo; echo "[postdeploy] Tickets ceilings (opened_at_utc, created_at_utc):"
+docker exec "$DB_ID" psql -U apex -d prismapex -t -A -c \
+"select max(opened_at_utc), max(created_at_utc) from public.tickets;"
+
+echo; echo "[postdeploy] API snapshot:"
+curl -sS "http://localhost:5190/api/tickets?limit=5" | head -c 800; echo
+
+echo; echo "== OUTCOME REPORT =="
+echo "Ran postdeploy gapfill for $TOTAL symbols (batch $BATCH_SIZE). Window: $FROM_DATE -> $TO_DATE"
+echo "Printed ceilings (top25), ticket ceilings, API snapshot."

--- a/tools/codex/verify-stack.sh
+++ b/tools/codex/verify-stack.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Prism-Apex: Verify stack health and data freshness (no writes)
+set -euo pipefail
+cid() { docker ps --format '{{.ID}} {{.Names}}' | awk -v p="$1" 'tolower($0) ~ tolower(p) {print $1; exit}'; }
+DB_ID="$(cid '(^|-)db(-| |$)')"  || true
+API_ID="$(cid '(^|-)api(-| |$)')" || true
+[ -z "$DB_ID" ] && { echo "❌ DB not running"; exit 1; }
+[ -z "$API_ID" ] && { echo "❌ API not running"; exit 1; }
+echo "== VERIFY STACK =="
+echo "-- API health --"; curl -sS http://localhost:5190/api/health | head -c 200; echo
+echo "-- Bars ceilings (top 10) --"
+docker exec "$DB_ID" sh -lc "psql -U apex -d prismapex -F \$'\t' -A -c \
+\"with mx as (select symbol, max(ts_utc) max_ts from public.bars_1m group by 1)
+  select symbol, max_ts from mx order by max_ts desc nulls last limit 10;\""
+echo "-- Tickets ceilings --"
+docker exec "$DB_ID" psql -U apex -d prismapex -t -A -c \
+"select max(opened_at_utc), max(created_at_utc) from public.tickets;"
+echo "== DONE =="


### PR DESCRIPTION
Bash-3.2 safe single entrypoint with retries/backoff, compose→docker-run fallback, lock, metrics, seeds for late symbols, verification helper, CI inputs for FROM/TO. No strategy changes.