### PR TITLE
feat(ops): govern realtime ingest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DATABASE_URL=postgres://apex:apex@db:5432/prismapex
 # Free Yahoo mode used by ingress (no key required)
 # Ingress health: http://localhost:8080/health
-YAHOO_SYMBOLS=ES=F,NQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X
+YAHOO_SYMBOLS=ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD
 YAHOO_RANGE=30d
 YAHOO_INTERVAL=1m
 TICKETS_DAYS=30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,87 @@ jobs:
 
       - name: Build (API)
         run: pnpm run build:api || true
+
+  realtime-check:
+    needs: qa
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Docker (Compose V2)
+        uses: docker/setup-buildx-action@v3
+
+      - name: Launch realtime stack (governed)
+        run: |
+          set -euxo pipefail
+          corepack enable
+          corepack prepare pnpm@9.0.0 --activate
+          pnpm install --frozen-lockfile
+          docker compose -f docker-compose.yml \
+            -f compose.ingress-db.override.yml \
+            -f compose.gapfill-realtime.override.yml \
+            -f compose.tickets-realtime.override.yml \
+            -f compose.codex-governor.override.yml \
+            -f compose.codex-forcecurl.override.yml \
+            up -d gapfill-realtime tickets-realtime db api
+
+      - name: Wait for API health
+        run: |
+          set -euxo pipefail
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:3000/health >/dev/null; then exit 0; fi
+            sleep 5
+          done
+          echo "::error::API never became healthy" && exit 1
+
+      - name: Run codex realtime check
+        run: tools/codex/check-realtime.sh
+
+      - name: Tear down realtime stack
+        if: always()
+        run: |
+          docker compose -f docker-compose.yml \
+            -f compose.ingress-db.override.yml \
+            -f compose.gapfill-realtime.override.yml \
+            -f compose.tickets-realtime.override.yml \
+            -f compose.codex-governor.override.yml \
+            -f compose.codex-forcecurl.override.yml \
+            down -v
+      - name: Launch realtime stack (governed)
+        run: |
+          set -euxo pipefail
+          corepack enable
+          corepack prepare pnpm@9.0.0 --activate
+          pnpm install --frozen-lockfile
+          docker compose -f docker-compose.yml \
+            -f compose.ingress-db.override.yml \
+            -f compose.gapfill-realtime.override.yml \
+            -f compose.tickets-realtime.override.yml \
+            -f compose.codex-governor.override.yml \
+            -f compose.codex-forcecurl.override.yml \
+            up -d gapfill-realtime tickets-realtime db api
+
+      - name: Wait for API health
+        run: |
+          set -euxo pipefail
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:3000/health >/dev/null; then exit 0; fi
+            sleep 5
+          done
+          echo "::error::API never became healthy" && exit 1
+
+      - name: Run codex realtime check
+        run: tools/codex/check-realtime.sh
+
+      - name: Tear down realtime stack
+        if: always()
+        run: |
+          docker compose -f docker-compose.yml \
+            -f compose.ingress-db.override.yml \
+            -f compose.gapfill-realtime.override.yml \
+            -f compose.tickets-realtime.override.yml \
+            -f compose.codex-governor.override.yml \
+            -f compose.codex-forcecurl.override.yml \
+            down -v

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,16 @@ LOCAL_PROFILES := --profile local
 PROD_PROFILES  := --profile prod
 DEV_PROFILES   := --profile dev
 JOBS_PROFILE   := --profile jobs
+TOOLS_DIR      := tools/codex
+ENABLE_RT      := $(TOOLS_DIR)/enable-realtime.sh
 
 .PHONY: up down ps logs health seed up-dev down-dev prod-up prod-down prod-logs prod-seed smoke wait-db-local wait-db-prod
 
 up:
 	@echo "Bringing up local stack (db, api, dashboard, ingress, cron jobs)..."
 	docker compose $(LOCAL_PROFILES) up -d
+	@echo "Wiring governed realtime services..."
+	@COMPOSE_PROFILES=local $(ENABLE_RT)
 	@$(MAKE) seed
 	@$(MAKE) health
 
@@ -43,6 +47,8 @@ down-dev:
 prod-up:
 	@echo "Bringing up production stack..."
 	docker compose $(PROD_PROFILES) up -d
+	@echo "Wiring governed realtime services (prod)..."
+	@COMPOSE_PROFILES=prod $(ENABLE_RT)
 	@$(MAKE) prod-seed
 
 prod-down:

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -68,6 +68,30 @@ docker compose --profile local up -d gapfill-cron
 docker compose logs --tail=20 gapfill-cron
 ```
 
+## Ticket maintenance (ORR strategy)
+- `tickets-cron` runs `apps/tickets/dist/backfill-orr.js` on a rolling basis (loop every 60 s) so each session’s tickets are generated automatically after bars land. It uses the same `YAHOO_SYMBOLS` set as the ingest jobs (ES/NQ micros, YM, RTY, GC, CL, 6E, EURUSD, BTC).
+- Bring it up the same way as the gapfill cron:
+  ```bash
+  docker compose --profile local up -d tickets-cron
+  docker compose logs --tail=20 tickets-cron
+  ```
+- In a server deploy, leave both cron services running; `gapfill-cron` handles the daily bar sweep, and `tickets-cron` ensures the ORR strategy backfills without manual intervention.
+
+## Realtime bars & tickets (Yahoo-governed)
+- The ops helper `tools/codex/enable-realtime.sh` now wraps the full compose bundle so every host (local laptop or server) brings up `gapfill-realtime` + `tickets-realtime` with the governor, curl shim, and symbol defaults.
+- Equivalent manual compose invocation if you prefer explicit commands:
+  ```bash
+  docker compose \
+    -f docker-compose.yml \
+    -f compose.ingress-db.override.yml \
+    -f compose.gapfill-realtime.override.yml \
+    -f compose.tickets-realtime.override.yml \
+    -f compose.codex-governor.override.yml \
+    -f compose.codex-forcecurl.override.yml \
+    up -d gapfill-realtime tickets-realtime
+  ```
+- This ensures every deployment gets governed curl (`/opt/codex/bin/curl`), the Node fetch hook, and the expanded `YAHOO_SYMBOLS` default (ES/NQ micros, YM, RTY, GC, CL, 6E, EURUSD, BTC) without relying on manual env tweaks.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -3664,3 +3664,4 @@ $TOOLS/check-realtime.sh
 - `gapfill-realtime` keeps `bars_1m` current (today → now) every 60s.
 - `tickets-realtime` discovers all `apps/tickets/dist/backfill-*.js` runners and executes each every minute so every strategy emits tickets continuously.
 - Works on macOS and Linux hosts; reads `DATABASE_URL` from the live API container (or your compose env).
+- The helper bundles these compose overlays automatically: `compose.ingress-db.override.yml`, `compose.gapfill-realtime.override.yml`, `compose.tickets-realtime.override.yml`, `compose.codex-governor.override.yml`, and `compose.codex-forcecurl.override.yml`. If you prefer calling `docker compose` manually (e.g., via CI/server automation), include the same overlays when starting `gapfill-realtime`/`tickets-realtime`.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@
 
 - Docker Desktop (or compatible) with Compose v2
 - `pnpm install --frozen-lockfile`
-- `make up` (starts the local stack – db, api, dashboard, ingress, cron)
+- `make up` (starts the local stack – db, api, dashboard, ingress, cron – **and** automatically wires the governed realtime services via `tools/codex/enable-realtime.sh`)
 - `pnpm docs:lint`
 
 ## Deployment (Local & Server)

--- a/apps/api/src/lib/yahooHealth.ts
+++ b/apps/api/src/lib/yahooHealth.ts
@@ -1,0 +1,72 @@
+const parseLag = (value: string | undefined, fallback: number) => {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+export const OK_LAG_MIN = parseLag(process.env.YAHOO_OK_LAG_MIN, 25);
+export const DEGRADED_LAG_MIN = parseLag(process.env.YAHOO_DEGRADED_LAG_MIN, 90);
+const ALWAYS_ON = new Set(
+  (process.env.YAHOO_ALWAYS_ON ?? 'BTC-USD')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
+export type YahooLagRow = {
+  symbol: string;
+  last_bar_utc: string;
+  minutes_behind: number;
+};
+
+export type YahooSummary = {
+  status: 'ok' | 'degraded' | 'down' | 'paused';
+  ok_lag_min: number;
+  degraded_lag_min: number;
+  rows: YahooLagRow[];
+  now_utc: string;
+};
+
+export function classifyYahooStatus(rows: YahooLagRow[], now: Date = new Date()): YahooSummary {
+  const safeRows = rows.map((row) => ({
+    ...row,
+    minutes_behind: Number.isFinite(row.minutes_behind) ? row.minutes_behind : Number.POSITIVE_INFINITY,
+  }));
+  const nonAlwaysOn = safeRows.filter((row) => !ALWAYS_ON.has(row.symbol));
+  const isWeekend = now.getUTCDay() === 0 || now.getUTCDay() === 6;
+  const nonAlwaysStale =
+    nonAlwaysOn.length > 0 && nonAlwaysOn.every((row) => row.minutes_behind >= DEGRADED_LAG_MIN);
+
+  let status: YahooSummary['status'];
+  if (isWeekend && nonAlwaysStale) {
+    status = 'paused';
+  } else if (safeRows.length === 0) {
+    status = 'down';
+  } else if (safeRows.every((row) => row.minutes_behind < OK_LAG_MIN)) {
+    status = 'ok';
+  } else if (safeRows.some((row) => row.minutes_behind < DEGRADED_LAG_MIN)) {
+    status = 'degraded';
+  } else {
+    status = 'down';
+  }
+
+  return {
+    status,
+    ok_lag_min: OK_LAG_MIN,
+    degraded_lag_min: DEGRADED_LAG_MIN,
+    rows: safeRows,
+    now_utc: now.toISOString(),
+  };
+}
+
+export function yahooStatusToService(status: YahooSummary['status']): 'green' | 'amber' | 'red' | 'grey' {
+  switch (status) {
+    case 'ok':
+      return 'green';
+    case 'degraded':
+      return 'amber';
+    case 'paused':
+      return 'grey';
+    default:
+      return 'red';
+  }
+}

--- a/apps/api/src/routes/health.yahoo.ts
+++ b/apps/api/src/routes/health.yahoo.ts
@@ -1,23 +1,6 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { Client } from 'pg';
-
-function num(v: string | undefined, dflt: number): number {
-  const n = Number(v);
-  return Number.isFinite(n) && n > 0 ? n : dflt;
-}
-
-/**
- * Thresholds (minutes)
- * - OK if every symbol < OK_LAG
- * - DEGRADED if some < DEGRADED_LAG (but not all < OK_LAG)
- * - DOWN if any >= DEGRADED_LAG
- *
- * Tune via env:
- *   YAHOO_OK_LAG_MIN (default 25)
- *   YAHOO_DEGRADED_LAG_MIN (default 90)
- */
-const OK_LAG = num(process.env.YAHOO_OK_LAG_MIN, 25);
-const DEG_LAG = num(process.env.YAHOO_DEGRADED_LAG_MIN, 90);
+import { classifyYahooStatus } from '../lib/yahooHealth';
 
 export async function yahooHealthRoutes(app: FastifyInstance) {
   const databaseUrl = process.env.DATABASE_URL;
@@ -61,30 +44,8 @@ export async function yahooHealthRoutes(app: FastifyInstance) {
 
   async function handle(reply: FastifyReply) {
     const rows = await queryRows();
-
-    // Optional: if it’s the weekend and everything is very stale, call it "paused"
-    const now = new Date();
-    const isWeekend = now.getUTCDay() === 0 || now.getUTCDay() === 6;
-    const allVeryStale = rows.length > 0 && rows.every((r) => r.minutes_behind >= 720); // 12h+
-    let status: 'ok' | 'degraded' | 'down' | 'paused';
-
-    if (isWeekend && allVeryStale) {
-      status = 'paused';
-    } else if (rows.every((r) => r.minutes_behind < OK_LAG)) {
-      status = 'ok';
-    } else if (rows.some((r) => r.minutes_behind < DEG_LAG)) {
-      status = 'degraded';
-    } else {
-      status = 'down';
-    }
-
-    return reply.send({
-      status,
-      ok_lag_min: OK_LAG,
-      degraded_lag_min: DEG_LAG,
-      rows,
-      now_utc: now.toISOString(),
-    });
+    const summary = classifyYahooStatus(rows);
+    return reply.send(summary);
   }
 
   app.get('/api/health/yahoo', async (_req, reply) => handle(reply));

--- a/apps/api/src/routes/status.ts
+++ b/apps/api/src/routes/status.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { Client } from 'pg';
+import { classifyYahooStatus, yahooStatusToService } from '../lib/yahooHealth';
 
 type Health = 'green' | 'amber' | 'red' | 'grey';
 
@@ -44,6 +45,11 @@ type StatusResponse = {
     gapfill_cron: Health;
   };
   symbols: SymbolStatus[];
+  yahoo_summary?: {
+    status: string;
+    ok_lag_min: number;
+    degraded_lag_min: number;
+  };
 };
 
 function parseSymbolList(): string[] {
@@ -135,20 +141,6 @@ function healthFromAge(ageMs: number, relaxed: boolean): Health {
   return 'red';
 }
 
-async function fetchIngressHealth(timeoutMs: number): Promise<Health> {
-  const url = process.env.INGRESS_HEALTH_URL ?? 'http://ingress-yahoo:8080/health';
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const res = await fetch(url, { signal: controller.signal });
-    return res.ok ? 'green' : 'red';
-  } catch {
-    return 'red';
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 export default async function statusRoute(app: FastifyInstance) {
   const symbolsList = parseSymbolList();
   const databaseUrl = process.env.DATABASE_URL ?? DEFAULT_DATABASE_URL;
@@ -169,6 +161,7 @@ export default async function statusRoute(app: FastifyInstance) {
     let dbHealth: Health = 'grey';
     let ticketsHealth: Health = relaxed ? 'grey' : 'red';
     let gapfillHealth: Health = 'grey';
+    const yahooRows: { symbol: string; last_bar_utc: string; minutes_behind: number }[] = [];
 
     const client = new Client({ connectionString: databaseUrl });
     try {
@@ -207,6 +200,13 @@ export default async function statusRoute(app: FastifyInstance) {
           }
           entry.last_utc = last ? last.toISOString() : null;
           entry.age_ms = age;
+          if (last) {
+            yahooRows.push({
+              symbol: row.symbol,
+              last_bar_utc: last.toISOString(),
+              minutes_behind: age / 60_000,
+            });
+          }
           entry.health = age === null ? (relaxed ? 'grey' : 'red') : healthFromAge(age, relaxed);
         }
       } catch {
@@ -251,7 +251,8 @@ export default async function statusRoute(app: FastifyInstance) {
       await client.end().catch(() => {});
     }
 
-    const yahooHealth = await fetchIngressHealth(3000);
+    const yahooSummary = classifyYahooStatus(yahooRows, now);
+    const yahooHealth = yahooStatusToService(yahooSummary.status);
 
     return {
       generated_at_utc: now.toISOString(),
@@ -264,6 +265,11 @@ export default async function statusRoute(app: FastifyInstance) {
         gapfill_cron: gapfillHealth,
       },
       symbols,
+      yahoo_summary: {
+        status: yahooSummary.status,
+        ok_lag_min: yahooSummary.ok_lag_min,
+        degraded_lag_min: yahooSummary.degraded_lag_min,
+      },
     };
   }
 

--- a/apps/dashboard/src/components/YahooStatus.tsx
+++ b/apps/dashboard/src/components/YahooStatus.tsx
@@ -1,7 +1,14 @@
 import React, { useEffect, useState } from 'react';
 
-type Row = { symbol: string; minutes_behind: number };
-type Health = { status: string; rows: Row[] };
+type Row = { symbol: string; minutes_behind: number; last_bar_utc?: string };
+type Health = { status: string; rows: Row[]; now_utc?: string; ok_lag_min?: number; degraded_lag_min?: number };
+
+const STATUS_LABELS: Record<string, { text: string; detail: string }> = {
+  ok: { text: 'Live', detail: 'All symbols under lag threshold' },
+  degraded: { text: 'Delays', detail: 'Some symbols are catching up' },
+  down: { text: 'Unavailable', detail: 'Ingress stalled or failing' },
+  paused: { text: 'Session paused', detail: 'Weekend/holiday — waiting for market open' },
+};
 
 export default function YahooStatus() {
   const [health, setHealth] = useState<Health | null>(null);
@@ -10,28 +17,46 @@ export default function YahooStatus() {
     async function fetchHealth() {
       try {
         const res = await fetch('/api/health/yahoo');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const json = await res.json();
         setHealth(json);
-      } catch {
+      } catch (err) {
         setHealth({ status: 'down', rows: [] });
       }
     }
     fetchHealth();
-    const t = setInterval(fetchHealth, 300000);
+    const t = setInterval(fetchHealth, 60_000);
     return () => clearInterval(t);
   }, []);
 
   if (!health) return null;
+  const meta = STATUS_LABELS[health.status] ?? { text: health.status, detail: '' };
   const color =
     health.status === 'ok'
       ? 'bg-green-500'
       : health.status === 'degraded'
       ? 'bg-amber-500'
+      : health.status === 'paused'
+      ? 'bg-blue-500'
       : 'bg-red-500';
 
   return (
-    <div className={`flex items-center gap-2 text-white text-sm px-3 py-1 rounded-full ${color}`}>
-      <span>Yahoo: {health.status}</span>
+    <div className={`flex flex-col gap-1 text-white text-sm px-4 py-2 rounded-2xl shadow-lg ${color}`}>
+      <div className="flex items-center justify-between">
+        <span className="font-semibold">Yahoo Ingress</span>
+        <span className="text-xs uppercase tracking-wide">{meta.text}</span>
+      </div>
+      {meta.detail && <span className="text-xs opacity-90">{meta.detail}</span>}
+      {health.rows?.length > 0 && (
+        <div className="text-xs bg-black/10 rounded-xl p-2 mt-1">
+          {health.rows.slice(0, 4).map((row) => (
+            <div key={row.symbol} className="flex items-center justify-between">
+              <span>{row.symbol}</span>
+              <span>{Math.round(row.minutes_behind)} min behind</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/ingest/src/backfill.ts
+++ b/apps/ingest/src/backfill.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 // Config via env
 const DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://apex:apex@db:5432/prismapex';
-const SYMBOLS = (process.env.YAHOO_SYMBOLS ?? 'ES=F,NQ=F,GC=F,CL=F').split(',').map(s => s.trim()).filter(Boolean);
+const SYMBOLS = (process.env.YAHOO_SYMBOLS ?? 'ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD').split(',').map(s => s.trim()).filter(Boolean);
 const RANGE = process.env.YAHOO_RANGE ?? '30d';
 const INTERVAL = process.env.YAHOO_INTERVAL ?? '1m';
 

--- a/apps/ingest/src/gapfill.ts
+++ b/apps/ingest/src/gapfill.ts
@@ -2,8 +2,26 @@ import { Client } from 'pg';
 import { setTimeout as sleep } from 'timers/promises';
 
 const DATABASE_URL = process.env.DATABASE_URL!;
-const SYMBOLS = (process.env.YAHOO_SYMBOLS ?? 'ES=F,NQ=F,GC=F,CL=F').split(',').map(s => s.trim()).filter(Boolean);
+const argv = process.argv.slice(2);
+
+const argValue = (flag: string) => {
+  const idx = argv.indexOf(`--${flag}`);
+  if (idx === -1 || idx + 1 >= argv.length) return undefined;
+  const val = argv[idx + 1];
+  return val && val.length > 0 ? val : undefined;
+};
+
+const rawSymbols =
+  argValue('symbols') ??
+  (process.env.SYMBOLS && process.env.SYMBOLS.length > 0 ? process.env.SYMBOLS : undefined) ??
+  process.env.YAHOO_SYMBOLS ??
+  'ES=F,NQ=F,GC=F,CL=F,BTC-USD';
+const SYMBOLS = rawSymbols.split(',').map(s => s.trim()).filter(Boolean);
 const INTERVAL = process.env.YAHOO_INTERVAL ?? '1m';
+const WINDOW_FROM =
+  argValue('from') ?? process.env.FROM_DATE ?? process.env.YF_FROM_DATE ?? undefined;
+const WINDOW_TO =
+  argValue('to') ?? process.env.TO_DATE ?? process.env.YF_TO_DATE ?? undefined;
 
 const MAX_CHUNK_MS = 6 * 24 * 60 * 60 * 1000;
 
@@ -79,6 +97,38 @@ async function upsertBars(pg: Client, symbol: string, rows: Awaited<ReturnType<t
 async function main() {
   const pg = new Client({ connectionString: DATABASE_URL });
   await pg.connect();
+
+  if (WINDOW_FROM && WINDOW_TO) {
+    const from = new Date(WINDOW_FROM);
+    const to = new Date(WINDOW_TO);
+    if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) {
+      throw new Error(`Invalid window dates: from=${WINDOW_FROM} to=${WINDOW_TO}`);
+    }
+    const startMs = from.getTime();
+    const endMs = to.getTime();
+    console.log(
+      `[gapfill] window mode ${from.toISOString()} -> ${to.toISOString()} symbols=${SYMBOLS.join(
+        ',',
+      )}`,
+    );
+    for (const sym of SYMBOLS) {
+      console.log(`[gapfill] ${sym} -> window execution`);
+      for (let winStart = startMs; winStart < endMs; winStart += MAX_CHUNK_MS) {
+        const winEnd = Math.min(endMs, winStart + MAX_CHUNK_MS);
+        const rows = await fetchWindow(sym, winStart, winEnd);
+        const n = await upsertBars(pg, sym, rows);
+        console.log(
+          `[gapfill]   ${sym} ${new Date(winStart).toISOString()} → ${new Date(
+            winEnd,
+          ).toISOString()} upserted=${n}`,
+        );
+        await sleep(200);
+      }
+    }
+    await pg.end();
+    console.log('[gapfill] window mode done.');
+    return;
+  }
 
   const sinceSql = `
     SELECT

--- a/apps/ingest/src/gapfill.ts
+++ b/apps/ingest/src/gapfill.ts
@@ -15,7 +15,7 @@ const rawSymbols =
   argValue('symbols') ??
   (process.env.SYMBOLS && process.env.SYMBOLS.length > 0 ? process.env.SYMBOLS : undefined) ??
   process.env.YAHOO_SYMBOLS ??
-  'ES=F,NQ=F,GC=F,CL=F,BTC-USD';
+  'ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD';
 const SYMBOLS = rawSymbols.split(',').map(s => s.trim()).filter(Boolean);
 const INTERVAL = process.env.YAHOO_INTERVAL ?? '1m';
 const WINDOW_FROM =

--- a/apps/tickets/src/backfill-orr.ts
+++ b/apps/tickets/src/backfill-orr.ts
@@ -16,7 +16,7 @@ type EnvConfig = {
 
 const cfg: EnvConfig = {
   databaseUrl: process.env.DATABASE_URL ?? 'postgres://apex:apex@db:5432/prismapex',
-  symbols: (process.env.YAHOO_SYMBOLS ?? 'ES=F,NQ=F,GC=F,CL=F').split(',').map((s) => s.trim()).filter(Boolean),
+  symbols: (process.env.YAHOO_SYMBOLS ?? 'ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD').split(',').map((s) => s.trim()).filter(Boolean),
   days: Math.min(Math.max(Number(process.env.TICKETS_DAYS ?? '30'), 1), 30),
   openingRangeMinutes: Math.max(Number(process.env.ORR_OR_MIN ?? '5'), 1),
   reversalWindowMinutes: Math.max(Number(process.env.ORR_WINDOW_MIN ?? '60'), 1),

--- a/compose.codex-forcecurl.override.yml
+++ b/compose.codex-forcecurl.override.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  gapfill-realtime:
+    volumes:
+      - ./tools/codex/bin/curl:/usr/local/bin/curl:ro
+  tickets-realtime:
+    volumes:
+      - ./tools/codex/bin/curl:/usr/local/bin/curl:ro

--- a/compose.codex-forcecurl.override.yml
+++ b/compose.codex-forcecurl.override.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   gapfill-realtime:
     volumes:

--- a/compose.codex-governor.override.yml
+++ b/compose.codex-governor.override.yml
@@ -1,10 +1,9 @@
-version: "3.9"
 services:
   gapfill-realtime:
     volumes:
       - ./tools/codex:/opt/codex:ro
     environment:
-      - "SYMBOLS=${GAPFILL_SYMBOLS:-ES=F,NQ=F,GC=F,CL=F,BTC-USD}"
+      - "SYMBOLS=${GAPFILL_SYMBOLS:-ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD}"
       - "GOV_PATH=/opt/codex/lib/yahoo_governor.sh"
       - "NODE_OPTIONS=--require /opt/codex/lib/node-hook.js"
       - "YF_METRICS_PATH=${YF_METRICS_PATH:-/data/ops/yahoo-metrics.jsonl}"
@@ -15,7 +14,7 @@ services:
     volumes:
       - ./tools/codex:/opt/codex:ro
     environment:
-      - "SYMBOLS=${GAPFILL_SYMBOLS:-ES=F,NQ=F,GC=F,CL=F,BTC-USD}"
+      - "SYMBOLS=${GAPFILL_SYMBOLS:-ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD}"
       - "GOV_PATH=/opt/codex/lib/yahoo_governor.sh"
       - "NODE_OPTIONS=--require /opt/codex/lib/node-hook.js"
       - "YF_METRICS_PATH=${YF_METRICS_PATH:-/data/ops/yahoo-metrics.jsonl}"

--- a/compose.codex-governor.override.yml
+++ b/compose.codex-governor.override.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+services:
+  gapfill-realtime:
+    volumes:
+      - ./tools/codex:/opt/codex:ro
+    environment:
+      - "SYMBOLS=${GAPFILL_SYMBOLS:-ES=F,NQ=F,GC=F,CL=F,BTC-USD}"
+      - "GOV_PATH=/opt/codex/lib/yahoo_governor.sh"
+      - "NODE_OPTIONS=--require /opt/codex/lib/node-hook.js"
+      - "YF_METRICS_PATH=${YF_METRICS_PATH:-/data/ops/yahoo-metrics.jsonl}"
+      - "YF_MAX_RETRIES=${YF_MAX_RETRIES:-6}"
+      - "YF_JITTER_MS=${YF_JITTER_MS:-1000}"
+      - "YF_429_COOLDOWN_SEC=${YF_429_COOLDOWN_SEC:-600}"
+  tickets-realtime:
+    volumes:
+      - ./tools/codex:/opt/codex:ro
+    environment:
+      - "SYMBOLS=${GAPFILL_SYMBOLS:-ES=F,NQ=F,GC=F,CL=F,BTC-USD}"
+      - "GOV_PATH=/opt/codex/lib/yahoo_governor.sh"
+      - "NODE_OPTIONS=--require /opt/codex/lib/node-hook.js"
+      - "YF_METRICS_PATH=${YF_METRICS_PATH:-/data/ops/yahoo-metrics.jsonl}"
+      - "YF_MAX_RETRIES=${YF_MAX_RETRIES:-6}"
+      - "YF_JITTER_MS=${YF_JITTER_MS:-1000}"
+      - "YF_429_COOLDOWN_SEC=${YF_429_COOLDOWN_SEC:-600}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,7 @@ services:
     profiles: ["jobs"]
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgres://apex:apex@db:5432/prismapex}
-      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X}
+      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD}
       YAHOO_RANGE: ${YAHOO_RANGE:-30d}
       YAHOO_INTERVAL: ${YAHOO_INTERVAL:-1m}
     command: ["node", "apps/ingest/dist/backfill.js"]
@@ -152,7 +152,7 @@ services:
     profiles: ["jobs"]
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgres://apex:apex@db:5432/prismapex}
-      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X}
+      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD}
       YAHOO_INTERVAL: ${YAHOO_INTERVAL:-1m}
     command: ["node", "apps/ingest/dist/gapfill.js"]
     depends_on:
@@ -167,7 +167,7 @@ services:
     profiles: ["jobs"]
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgres://apex:apex@db:5432/prismapex}
-      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X}
+      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD}
       TICKETS_DAYS: ${TICKETS_DAYS:-30}
       ORR_OR_MIN: ${ORR_OR_MIN:-5}
       ORR_WINDOW_MIN: ${ORR_WINDOW_MIN:-60}
@@ -187,7 +187,7 @@ services:
     environment:
       TZ: UTC
       DATABASE_URL: ${DATABASE_URL:-postgres://apex:apex@db:5432/prismapex}
-      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,GC=F,CL=F}
+      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD}
       YAHOO_INTERVAL: ${YAHOO_INTERVAL:-1m}
     volumes:
       - ./:/repo:ro
@@ -211,7 +211,7 @@ services:
     profiles: ["local", "prod"]
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgres://apex:apex@db:5432/prismapex}
-      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X}
+      YAHOO_SYMBOLS: ${YAHOO_SYMBOLS:-ES=F,NQ=F,MES=F,MNQ=F,YM=F,RTY=F,GC=F,CL=F,6E=F,EURUSD=X,BTC-USD}
       ORR_OR_MIN: ${ORR_OR_MIN:-5}
       ORR_WINDOW_MIN: ${ORR_WINDOW_MIN:-60}
       SESSION_OPEN_UTC: ${SESSION_OPEN_UTC:-23:05}

--- a/tools/codex/bin/curl
+++ b/tools/codex/bin/curl
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ -n "${GOV_PATH:-}" ] && [ -f "$GOV_PATH" ]; then
+  . "$GOV_PATH"
+  yf_curl "${YF_BASE_CURL:-/usr/bin/env curl}" "$@"
+  exit $?
+fi
+exec /usr/bin/env curl "$@"

--- a/tools/codex/enable-realtime.sh
+++ b/tools/codex/enable-realtime.sh
@@ -11,13 +11,22 @@ fi
 [ -z "$BASE" ] && { echo "❌ No compose file found"; exit 1; }
 
 echo "[realtime] Using compose: $BASE"
-# Ensure ingress picks up DATABASE_URL (from API container env) if present
-EXTRA="-f compose.ingress-db.override.yml"
-[ -f compose.gapfill-realtime.override.yml ] || { echo "❌ compose.gapfill-realtime.override.yml missing"; exit 2; }
-[ -f compose.tickets-realtime.override.yml ] || { echo "❌ compose.tickets-realtime.override.yml missing"; exit 3; }
-
-docker compose -f "$BASE" $EXTRA -f compose.gapfill-realtime.override.yml up -d gapfill-realtime
-docker compose -f "$BASE" $EXTRA -f compose.tickets-realtime.override.yml up -d tickets-realtime
+OVERLAYS=(
+  compose.ingress-db.override.yml
+  compose.gapfill-realtime.override.yml
+  compose.tickets-realtime.override.yml
+  compose.codex-governor.override.yml
+  compose.codex-forcecurl.override.yml
+)
+for f in "${OVERLAYS[@]}"; do
+  [ -f "$f" ] || { echo "❌ missing $f"; exit 2; }
+done
+ARGS=(-f "$BASE")
+for f in "${OVERLAYS[@]}"; do
+  ARGS+=(-f "$f")
+done
+echo "[realtime] Applying overlays: ${OVERLAYS[*]}"
+docker compose "${ARGS[@]}" up -d gapfill-realtime tickets-realtime
 
 echo "[realtime] Services up:"
 docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}' | egrep 'tickets-realtime|gapfill-realtime|api|db' || true

--- a/tools/codex/lib/node-hook.js
+++ b/tools/codex/lib/node-hook.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const path = require('path');
+
+const METRICS = process.env.YF_METRICS_PATH || '/data/ops/yahoo-metrics.jsonl';
+const JITTER = parseInt(process.env.YF_JITTER_MS || '1000', 10);
+const MAX = parseInt(process.env.YF_MAX_RETRIES || '6', 10);
+const COOLDOWN = parseInt(process.env.YF_429_COOLDOWN_SEC || '600', 10) * 1000;
+
+function ensureDir(p) {
+  try {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+  } catch {
+    /* noop */
+  }
+}
+
+function logMetric(event, code, backoff, url) {
+  try {
+    ensureDir(METRICS);
+    fs.appendFileSync(
+      METRICS,
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        event,
+        code,
+        backoff_ms: backoff,
+        url,
+      }) + '\n',
+      { encoding: 'utf8' },
+    );
+  } catch {
+    /* noop */
+  }
+}
+
+function randInt(max) {
+  return Math.floor(Math.random() * max);
+}
+
+function parseRetryAfter(res) {
+  const raw = res.headers.get('retry-after');
+  if (!raw) return null;
+  const num = Number(raw);
+  if (Number.isFinite(num)) return Math.max(0, num * 1000);
+  const ts = Date.parse(raw);
+  if (Number.isNaN(ts)) return null;
+  return Math.max(0, ts - Date.now());
+}
+
+async function sleep(ms) {
+  if (ms <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function wrapFetch(orig) {
+  return async function wrapped(input, init) {
+    const url =
+      typeof input === 'string'
+        ? input
+        : typeof input === 'object' && input !== null
+          ? input.url || 'unknown'
+          : 'unknown';
+    let attempt = 0;
+    while (true) {
+      try {
+        const res = await orig(input, init);
+        if (res.status >= 200 && res.status < 300) {
+          logMetric('ok', res.status, 0, url);
+          return res;
+        }
+        if (res.status === 429) {
+          const ra = parseRetryAfter(res);
+          const delay = (ra ?? COOLDOWN) + randInt(JITTER);
+          logMetric('429', res.status, delay, url);
+          if (attempt++ >= MAX) throw new Error('max-retries');
+          await sleep(delay);
+          continue;
+        }
+        if (res.status === 408 || res.status >= 500) {
+          const delay = Math.min(15000, (2 ** attempt) * 500 + randInt(JITTER));
+          logMetric('retry', res.status, delay, url);
+          if (attempt++ >= MAX) throw new Error('max-retries');
+          await sleep(delay);
+          continue;
+        }
+        logMetric('fail', res.status, 0, url);
+        return res;
+      } catch (err) {
+        const delay = Math.min(15000, (2 ** attempt) * 500 + randInt(JITTER));
+        logMetric('error', null, delay, url);
+        if (attempt++ >= MAX) throw err;
+        await sleep(delay);
+      }
+    }
+  };
+}
+
+if (typeof globalThis.fetch === 'function') {
+  const orig = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = wrapFetch(orig);
+}
+
+console.log('[codex-yf-hook] active');

--- a/tools/codex/lib/yahoo_governor.sh
+++ b/tools/codex/lib/yahoo_governor.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+# Codex Yahoo governor – wraps curl with retry/backoff + JSONL metrics.
+set -eu
+
+: "${YF_MAX_RETRIES:=6}"
+: "${YF_JITTER_MS:=1000}"
+: "${YF_429_COOLDOWN_SEC:=600}"
+: "${YF_METRICS_PATH:=/data/ops/yahoo-metrics.jsonl}"
+: "${YF_BASE_CURL:=/usr/bin/env curl}"
+
+TOKENS=2
+LAST_S=0
+
+now_ms() {
+  echo $(( $(date +%s) * 1000 ))
+}
+
+sleep_ms() {
+  ms="$1"
+  [ "$ms" -le 0 ] || awk -v ms="$ms" 'BEGIN{printf "%.3f", ms/1000}' | xargs sleep
+}
+
+jitter() {
+  awk -v m="$YF_JITTER_MS" 'BEGIN{srand(); print int(rand()*m)}'
+}
+
+retry_after_ms() {
+  ra="$1"
+  case "$ra" in
+    '') echo '' ;;
+    *[!0-9]*)
+      ts=$(date -u -d "$ra" +%s 2>/dev/null || echo '')
+      now=$(date -u +%s)
+      if [ -n "$ts" ]; then
+        if [ $ts -gt $now ]; then
+          echo $(((ts-now)*1000))
+        else
+          echo 0
+        fi
+      else
+        echo ''
+      fi
+      ;;
+    *)
+      echo $((ra*1000))
+      ;;
+  esac
+}
+
+metric() {
+  event="$1"; code="$2"; retry="$3"; backoff="$4"; dur="$5"; url="$6"
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  dir=$(dirname "$YF_METRICS_PATH")
+  [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null || true
+  printf '{"ts":"%s","event":"%s","code":%s,"retry_after":"%s","backoff_ms":%s,"latency_ms":%s,"url":"%s"}\n' \
+    "$ts" "$event" "${code:-null}" "${retry:-}" "${backoff:-0}" "${dur:-0}" "$url" \
+    >> "$YF_METRICS_PATH" 2>/dev/null || true
+}
+
+throttle() {
+  now=$(date +%s)
+  if [ "$LAST_S" -ne 0 ]; then
+    delta=$((now-LAST_S))
+    if [ $delta -gt 0 ]; then
+      TOKENS=$((TOKENS+delta))
+      [ $TOKENS -gt 2 ] && TOKENS=2
+    fi
+  fi
+  LAST_S=$now
+  if [ $TOKENS -le 0 ]; then
+    sleep 1
+    TOKENS=1
+  fi
+  TOKENS=$((TOKENS-1))
+}
+
+yf_curl() {
+  base="$1"; shift
+  urlhash=$(printf '%s' "$*" | awk '{print $NF}' | sha1sum | awk '{print $1}')
+  attempt=0
+  tmp=$(mktemp -d)
+  hdr="$tmp/h"
+  body="$tmp/b"
+  trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+  while :; do
+    throttle
+    start=$(now_ms)
+    if "$base" -sS -D "$hdr" -o "$body" "$@"; then
+      code=$(awk 'NR==1 && /^HTTP/{print $2}' "$hdr" 2>/dev/null)
+    else
+      code=""
+    fi
+    dur=$(( $(now_ms) - start ))
+    case "$code" in
+      200|204|206)
+        metric ok "$code" '' 0 "$dur" "$urlhash"
+        cat "$body"
+        rm -rf "$tmp"
+        trap - EXIT HUP INT TERM
+        return 0
+        ;;
+      429)
+        ra=$(awk -F': *' 'tolower($1)=="retry-after"{print $2; exit}' "$hdr" | tr -d '\r')
+        ram=$(retry_after_ms "$ra")
+        [ -z "$ram" ] && ram=$((YF_429_COOLDOWN_SEC*1000))
+        back=$((ram + $(jitter)))
+        metric 429 "$code" "$ra" "$back" "$dur" "$urlhash"
+        ;;
+      408|5??)
+        base_ms=$((500<<attempt))
+        [ $base_ms -gt 15000 ] && base_ms=15000
+        back=$((base_ms + $(jitter)))
+        metric retry "$code" '' "$back" "$dur" "$urlhash"
+        ;;
+      *)
+        metric fail "$code" '' 0 "$dur" "$urlhash"
+        rm -rf "$tmp"
+        trap - EXIT HUP INT TERM
+        return 1
+        ;;
+    esac
+    attempt=$((attempt+1))
+    if [ $attempt -ge $YF_MAX_RETRIES ]; then
+      rm -rf "$tmp"
+      trap - EXIT HUP INT TERM
+      return 1
+    fi
+    sleep_ms "$back"
+  done
+}


### PR DESCRIPTION
## Summary
- add Codex governor wrapper + Node hook and mount overrides so realtime curl/fetch run through adaptive backoff with metrics
- teach the ingest gapfill runner to honor optional window + symbol flags so the realtime loop can target a narrow time slice
- default the realtime symbol list to include BTC-USD so bars keep advancing even when futures are closed

## Testing
- pnpm -r --filter @prism-apex/ingest build
- realtime soak: bars.maxTs advanced twice within 10m; yahoo-metrics logged events