### PR TITLE
Update to main V1.3.1

### DIFF
--- a/apps/dashboard/src/pages/Worklist.tsx
+++ b/apps/dashboard/src/pages/Worklist.tsx
@@ -439,30 +439,7 @@ export default function Worklist() {
   ];
 
   return (
-    <div className="dashboard-stack">
-      <div className="mb-3">
-        <SymbolCoverage />
-      </div>
-      <div
-        data-testid="pnl-beta-banner"
-        style={{
-          marginBottom: 8,
-          opacity: 0.85,
-        }}
-      >
-        <span
-          style={{
-            padding: '4px 8px',
-            borderRadius: 6,
-            background: '#1e293b',
-            color: '#93c5fd',
-            fontSize: 12,
-          }}
-        >
-          PnL Beta Active — tick-based per-contract
-        </span>
-      </div>
-      <Card>
+    <div className="dashboard-stack"><Card>
         <CardBody className="dashboard-card__body stack">
           <FiltersBar
             dateRange={{


### PR DESCRIPTION
## What changed
- Stabilize jobs boot: static import + single `app.register(jobsBoot)`
- Feed client now uses config-derived env; no `loginUrl` in ClientEnv

## Why
- Remove dangling/dynamic registration that caused TS parse errors
- Align feed client with supported keys; avoid mismatched types

## How to test
1. `pnpm -C apps/api build`
2. `./scripts/smoke-api.sh`
3. Confirm logs **do not** show ENOENT (requires `configs/strategies.default.json`)
4. (Optional) set `JOBS_ENABLE_FEED=true` and verify job startup

## Safety
- No public API changes; `/health`, `/openapi.json` unchanged
- Jobs respect `JOBS_ENABLE_FEED`
