### PR TITLE
Docs: tickets lifecycle + rejects ledger

### DIFF
--- a/docs/DOCS_CLASSIFICATION_V2.md
+++ b/docs/DOCS_CLASSIFICATION_V2.md
@@ -66,3 +66,9 @@ _Source of truth for what each doc is, how “live” it is, and whether it’s 
 ### Epic delivery logs
 
 - `docs/UPGRADE_DASHBOARD.md` now carries the canonical record for Epic 1 (A3 Dashboard Contract Hardening). Supporting scan output lives under `reports/upgrade_dashboard/epic1_contract_alignment/OUTCOME_REPORT_FINAL.txt` (ignored by git but referenced from the doc). Keep both in sync when future dashboard epics ship.
+
+## 2026-01-04 — Tickets lifecycle + Ticketizer rejects ledger
+
+New docs:
+- docs/TICKETS_LIFECYCLE_AND_REJECTS_LEDGER.md
+- docs/RUNBOOK_INGRESS_DNS_HARDENING.md

--- a/docs/REPO_INDEX_V2.md
+++ b/docs/REPO_INDEX_V2.md
@@ -1669,3 +1669,30 @@ Local development uses one entrypoint: http://localhost:5180. UI, API, and metad
 **Operational note**
 Shadow outcomes are *hypothetical projections* over the bar stream. CLOSED tickets allow later comparison to realized outcomes; OPEN tickets allow historical analysis of “what would have happened next”.
 
+## 2026-01-04 — Tickets lifecycle + Ticketizer rejects ledger
+
+This release adds an operator-grade ticket history model:
+
+- Ticketizer rejects are now persisted forward into a dedicated ledger:
+  - Migration: deploy/sql/036_ticket_candidates.sql
+  - Store: apps/api/src/store/ticketCandidates.ts
+  - Route: apps/api/src/routes/ticketCandidates.ts
+  - Endpoint: /api/ticket-candidates
+
+- A merged lifecycle endpoint is now the canonical feed for ticket history UI:
+  - Route: apps/api/src/routes/ticketsLifecycle.ts
+  - Endpoint: /api/tickets-lifecycle
+  - Merges accepted lifecycle tickets (tickets table) + Ticketizer rejects (ticket_candidates)
+  - Supports outcome toggle (ACCEPTED vs REJECTED)
+
+- /api/tickets totals are now invariant across limit values:
+  - Route: apps/api/src/routes/tickets.ts
+  - Store support: apps/api/src/store/tickets.ts
+
+- Tickets dashboard page moved to the lifecycle feed:
+  - apps/dashboard/src/pages/Tickets.tsx
+  - Adds Rejected operator toggle and rejection drilldown
+
+- Ingress DNS hardening prevents SPA 502s after dashboard recreation:
+  - deploy/ingress/local/default.conf
+  - Adds Docker DNS resolver + variable upstream proxy_pass

--- a/docs/RUNBOOK_INGRESS_DNS_HARDENING.md
+++ b/docs/RUNBOOK_INGRESS_DNS_HARDENING.md
@@ -1,0 +1,40 @@
+# Runbook: Ingress DNS hardening (prevent SPA 502 after dashboard rebuild)
+
+_Last updated: 2026-01-04_
+
+## 1) Symptom
+- `/api/*` routes return 200 OK
+- SPA routes like `/` or `/tickets` return **502 Bad Gateway**
+- Nginx error logs show upstream connectivity errors to a stale container IP
+
+## 2) Root cause (Docker DNS + long-lived Nginx upstream caching)
+When the dashboard container is recreated, its IP changes.
+If nginx is pinned to a stale upstream IP (or fails to re-resolve), SPA proxying breaks.
+
+## 3) Fix implemented
+We hardened ingress to re-resolve dashboard via Docker DNS:
+
+- `resolver 127.0.0.11 valid=10s ipv6=off;`
+- route SPA proxy_pass via a variable upstream (forces DNS re-resolution)
+
+File:
+- `deploy/ingress/local/default.conf`
+
+## 4) Operator verification (smoke)
+Expected: all 200.
+
+- `curl -i http://127.0.0.1:5180/ | head`
+- `curl -i http://127.0.0.1:5180/tickets | head`
+- `curl -i http://127.0.0.1:5180/api/status | head`
+
+Resiliency test:
+- recreate dashboard container
+- immediately re-run the curls above
+
+## 5) If it ever regresses
+Fast mitigation:
+- restart ingress container (forces fresh DNS resolution)
+
+Example:
+- `docker restart prismapex-ingress`
+

--- a/docs/TICKETS_LIFECYCLE_AND_REJECTS_LEDGER.md
+++ b/docs/TICKETS_LIFECYCLE_AND_REJECTS_LEDGER.md
@@ -1,0 +1,150 @@
+# Tickets lifecycle + Ticketizer rejects ledger
+
+_Last updated: 2026-01-04_
+
+## 1) Why this exists
+
+We had two operational gaps:
+
+1) **Operators could not see “why a ticket never appeared”** because Ticketizer-only rejects were not persisted as first-class history.
+2) **/api/tickets totals were numerically wrong** (total drifted with limit), undermining pagination and analytics trust.
+
+This implementation fixes both by:
+- persisting Ticketizer rejects into a dedicated ledger table (**ticket_candidates**),
+- exposing a merged “single-pane” endpoint (**/api/tickets-lifecycle**) for the dashboard,
+- fixing invariant totals in **/api/tickets**.
+
+Worklist behavior is explicitly **unchanged**.
+
+---
+
+## 2) Data model: ticket_candidates (Ticketizer rejects only)
+
+### 2.1 Purpose
+`ticket_candidates` is a forward-only ledger of **Ticketizer rejections**.  
+It is not meant to replace canonical lifecycle tickets; it exists to capture “dropped at the gate” decisions so operators can audit rejections.
+
+### 2.2 What gets written
+Only rows where Ticketizer produced `accepted=false` are recorded (best effort, non-blocking).
+Accepted tickets are not duplicated here.
+
+### 2.3 Key columns (operator-relevant)
+- `session_ts_utc` (TIMESTAMPTZ): authoritative session timestamp for ordering and filtering
+- `session_date` (generated): UTC date derived from `session_ts_utc`
+- `symbol`, `strategy`, `direction`
+- `entry_price`, `stop_price`, `target_price`
+- `qty` (0 for rejects, or post-sizing attempt if available)
+- `rr_multiple`, `risk_dollars` (when computable)
+- `rejection_reason` (primary reason string)
+- `reject_reasons` (TEXT[] reason codes; supports multi-reason rejects)
+- `meta` (JSONB): raw context (guardrails, risk evaluation, sizing context, etc.)
+- `source` default `'ticketizer'`
+
+### 2.4 Uniqueness / idempotency
+Uniqueness is enforced across `(symbol, strategy, direction, session_ts_utc)` to prevent duplicate ledger spam for the same candidate.
+
+### 2.5 Migration
+- `deploy/sql/036_ticket_candidates.sql`
+
+---
+
+## 3) APIs
+
+### 3.1 /api/ticket-candidates (raw ledger)
+Purpose: direct access to Ticketizer rejects ledger.
+
+Query parameters (typical):
+- `from`, `to` (ISO timestamps, applied to session_ts_utc)
+- `symbol`, `strategy`, `direction`
+- `limit` (page size)
+- `cursor` (offset cursor)
+
+Response shape (UI-compatible):
+- `{ total, rows, tickets, nextCursor }`
+
+---
+
+### 3.2 /api/tickets-lifecycle (merged accepted + rejected)
+Purpose: dashboard-grade merged view combining:
+- Accepted lifecycle tickets from `tickets`
+- Rejected Ticketizer candidates from `ticket_candidates`
+
+Key semantics:
+- Rejected ledger rows always surface with:
+  - `outcome = 'REJECTED'`
+  - `status = 'REJECTED'`
+  - `actionable = false`
+  - `rejection_reason` / `reject_reasons` populated
+- Accepted rows surface with:
+  - `outcome = 'ACCEPTED'`
+  - canonical lifecycle `status` from `tickets`
+  - canonical `actionable` from `tickets`
+
+Filters supported (operator-centric):
+- outcome toggle: `ACCEPTED` vs `REJECTED`
+- symbol / strategy / side(direction)
+- status (applies to accepted; rejected is always REJECTED)
+- from/to time range
+
+Response shape:
+- `{ total, rows, tickets, nextCursor }`
+- Total reflects the **full filtered unified dataset**, independent of `limit`.
+
+---
+
+## 4) /api/tickets totals invariance (trust fix)
+
+We fixed the prior failure mode where:
+- `total == page size` (i.e., total changed with limit)
+
+Now:
+- total is computed from the full dataset (count query / store count), and remains invariant across limit values.
+
+This restores trust for:
+- pagination UX
+- analytics (counts/ratios)
+- operator audit workflows
+
+---
+
+## 5) Dashboard: Tickets page behavior
+
+### 5.1 Primary UX
+Tickets is now a “single pane of glass” over `/api/tickets-lifecycle`.
+
+Operators get a top-level toggle:
+- **Accepted**
+- **Rejected (Ticketizer)**
+
+### 5.2 Columns (operator-grade, low-noise)
+We intentionally exclude low-value noise:
+- no ticket ID / candidate ID
+- no created_at display
+
+Recommended table columns:
+- Session timestamp (UTC)
+- Session date (derived)
+- Symbol
+- Strategy
+- Side/Direction
+- Outcome (Accepted / Rejected)
+- Status (Accepted: lifecycle status; Rejected: REJECTED)
+- Actionable (Accepted only; rejected forced false)
+- Entry / Stop / Target
+- RR multiple
+- Rejection reason (Rejected only; empty on Accepted)
+
+### 5.3 Drilldown
+Row selection shows:
+- full reason codes (`reject_reasons[]`)
+- primary `rejection_reason`
+- meta (JSON) for audit
+
+---
+
+## 6) Non-goals / guardrails
+
+- Worklist selection logic is untouched.
+- We do not backfill historical rejects unless explicitly planned as a later migration.
+- Reject ledger is Ticketizer-only (not planner envelope rejects unless later expanded).
+


### PR DESCRIPTION
## Summary
- add canonical doc covering ticket_candidates ledger, lifecycle API contract, and dashboard ux intent
- add ingress DNS hardening runbook for SPA 502 issue
- append dated delta to repo index + classification referencing new docs

## Details
### Added docs
1. 
   - captures the why/how for ticketizer reject persistence, , , invariant totals, and dashboard toggle behavior.
2. 
   - outlines the DNS resolver + variable upstream fix and operator smoke/resiliency checks to keep  +  healthy after dashboard rebuilds.

### Index / plan deltas
-  now includes the 2026‑01‑04 lifecycle/rejects entry linking to migration, store, routes, and UI consumption.
-  records the new doc locations for onboarding/reference.

No runtime code touched; this is a docs-only branch.  Ready for merge into Test once reviewed.