### PR TITLE
Add markTicketEntered API helper, wire it into WorklistV2, and add unit tests

### DIFF
--- a/apps/dashboard/src/__tests__/api.ticket-entry.test.ts
+++ b/apps/dashboard/src/__tests__/api.ticket-entry.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { markTicketEntered } from '../lib/api';
+
+describe('markTicketEntered', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('patches the encoded ticket-entered endpoint through the shared API client', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, ticketId: 'TICKET/123' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await markTicketEntered('TICKET/123');
+
+    expect(response).toEqual({ ok: true, ticketId: 'TICKET/123' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tickets/TICKET%2F123/entered',
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+  });
+
+  it('rejects blank ticket ids before issuing a request', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    let error: unknown = null;
+    try {
+      await markTicketEntered('   ');
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('Ticket id is required');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -321,6 +321,30 @@ export async function updateOperatorRiskSession(
   });
 }
 
+export type MarkTicketEnteredResponse = {
+  ok?: boolean;
+  ticketId?: string;
+  status?: string;
+  [key: string]: unknown;
+};
+
+export async function markTicketEntered(
+  ticketId: string,
+): Promise<MarkTicketEnteredResponse> {
+  const normalizedTicketId = ticketId.trim();
+  if (!normalizedTicketId) {
+    throw new Error('Ticket id is required');
+  }
+
+  return fetchJson<MarkTicketEnteredResponse>(
+    `/api/tickets/${encodeURIComponent(normalizedTicketId)}/entered`,
+    {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+    },
+  );
+}
+
 export async function fetchWorklistFeed(): Promise<WorklistApiResponse | null> {
   try {
     const payload = await fetchJson<WorklistApiResponse>('/api/worklist');

--- a/apps/dashboard/src/pages/WorklistV2.tsx
+++ b/apps/dashboard/src/pages/WorklistV2.tsx
@@ -43,6 +43,7 @@ import {
 import { logContractError, logPageLoad } from "../lib/contractTelemetry";
 import {
   fetchOperatorRiskSession,
+  markTicketEntered,
   updateOperatorRiskSession,
   type OperatorRiskSession,
 } from "../lib/api";
@@ -208,17 +209,7 @@ export default function WorklistV2() {
     setEnterLoading(true);
     setEnterError(null);
     try {
-      const resp = await fetch(
-        `/api/tickets/${encodeURIComponent(selected.ticketId)}/entered`,
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-        },
-      );
-      if (!resp.ok) {
-        const text = await resp.text();
-        throw new Error(text || "Failed to mark ticket as entered");
-      }
+      await markTicketEntered(selected.ticketId);
       const latestRisk = await fetchOperatorRiskSession();
       setOperatorRisk(latestRisk);
       setSelected(null);


### PR DESCRIPTION
### Motivation
- Provide a reusable client helper to mark tickets as entered and centralize request/validation logic. 
- Replace ad-hoc `fetch` usage in the worklist UI with the shared API client to reduce duplication.
- Ensure the new API helper behavior is covered by unit tests to prevent regressions.

### Description
- Added `MarkTicketEnteredResponse` type and `markTicketEntered(ticketId: string)` in `apps/dashboard/src/lib/api.ts`, which trims and validates the ticket id, encodes it, and issues a `PATCH` to `/api/tickets/<id>/entered` via `fetchJson`.
- Replaced inline `fetch` call in `apps/dashboard/src/pages/WorklistV2.tsx` with a call to `markTicketEntered` and imported the helper.
- Added unit tests in `apps/dashboard/src/__tests__/api.ticket-entry.test.ts` that verify a successful `PATCH` request is sent with the encoded id and that blank ticket ids are rejected before issuing a request.

### Testing
- Ran the new unit tests with `vitest` for `apps/dashboard` and both tests in `api.ticket-entry.test.ts` passed. 
- No existing automated tests were reported as failing after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2324bdc568832ca10a9226df675474)