### PR TITLE
Add markTicketEntered API helper and tests; wire into WorklistV2

### DIFF
--- a/apps/dashboard/src/__tests__/api.ticket-entry.test.ts
+++ b/apps/dashboard/src/__tests__/api.ticket-entry.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { markTicketEntered } from '../lib/api';
+
+describe('markTicketEntered', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('patches the encoded ticket-entered endpoint through the shared API client', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, ticketId: 'TICKET/123' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await markTicketEntered('TICKET/123');
+
+    expect(response).toEqual({ ok: true, ticketId: 'TICKET/123' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tickets/TICKET%2F123/entered',
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+  });
+
+  it('rejects blank ticket ids before issuing a request', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    let error: unknown = null;
+    try {
+      await markTicketEntered('   ');
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('Ticket id is required');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -321,6 +321,30 @@ export async function updateOperatorRiskSession(
   });
 }
 
+export type MarkTicketEnteredResponse = {
+  ok?: boolean;
+  ticketId?: string;
+  status?: string;
+  [key: string]: unknown;
+};
+
+export async function markTicketEntered(
+  ticketId: string,
+): Promise<MarkTicketEnteredResponse> {
+  const normalizedTicketId = ticketId.trim();
+  if (!normalizedTicketId) {
+    throw new Error('Ticket id is required');
+  }
+
+  return fetchJson<MarkTicketEnteredResponse>(
+    `/api/tickets/${encodeURIComponent(normalizedTicketId)}/entered`,
+    {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+    },
+  );
+}
+
 export async function fetchWorklistFeed(): Promise<WorklistApiResponse | null> {
   try {
     const payload = await fetchJson<WorklistApiResponse>('/api/worklist');

--- a/apps/dashboard/src/pages/WorklistV2.tsx
+++ b/apps/dashboard/src/pages/WorklistV2.tsx
@@ -43,6 +43,7 @@ import {
 import { logContractError, logPageLoad } from "../lib/contractTelemetry";
 import {
   fetchOperatorRiskSession,
+  markTicketEntered,
   updateOperatorRiskSession,
   type OperatorRiskSession,
 } from "../lib/api";
@@ -208,17 +209,7 @@ export default function WorklistV2() {
     setEnterLoading(true);
     setEnterError(null);
     try {
-      const resp = await fetch(
-        `/api/tickets/${encodeURIComponent(selected.ticketId)}/entered`,
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-        },
-      );
-      if (!resp.ok) {
-        const text = await resp.text();
-        throw new Error(text || "Failed to mark ticket as entered");
-      }
+      await markTicketEntered(selected.ticketId);
       const latestRisk = await fetchOperatorRiskSession();
       setOperatorRisk(latestRisk);
       setSelected(null);

--- a/packages/shared/src/contracts.ts
+++ b/packages/shared/src/contracts.ts
@@ -1,4 +1,4 @@
-import rawContractsSpec from '../config/contracts-spec.json' assert { type: 'json' };
+import rawContractsSpec from '../config/contracts-spec.json' with { type: 'json' };
 
 export type ContractType = 'standard' | 'micro' | 'spot' | 'index';
 


### PR DESCRIPTION
### Motivation

- Centralize the logic for marking a ticket as entered so callers reuse the shared API client and input validation is consistent.
- Update JSON import syntax to the `with { type: 'json' }` form to satisfy the environment's module loader expectations.

### Description

- Add `MarkTicketEnteredResponse` type and implement `markTicketEntered(ticketId)` which trims/validates the id and calls `fetchJson` against `/api/tickets/:id/entered` with `PATCH` and JSON headers. 
- Replace the inline `fetch` call in `WorklistV2` with a call to the new `markTicketEntered` helper and keep the existing post-entry refresh logic. 
- Add unit tests in `apps/dashboard/src/__tests__/api.ticket-entry.test.ts` that verify successful request shape and blank-id rejection. 
- Change the JSON import syntax in `packages/shared/src/contracts.ts` from `assert { type: 'json' }` to `with { type: 'json' }`.

### Testing

- Ran the unit tests with `vitest`, and the new `api.ticket-entry.test.ts` passed. 
- Ran the repository test suite, and no regressions were reported by the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2324bdc568832ca10a9226df675474)