### PR TITLE
Add markTicketEntered API helper and tests; tidy unused vars/imports

### DIFF
--- a/apps/api/src/jobs/barsFeed.ts
+++ b/apps/api/src/jobs/barsFeed.ts
@@ -152,9 +152,8 @@ async function poll(): Promise<void> {
   try {
     const client = await pool.connect();
     try {
-      let total = 0;
       for (const symbol of trackedSymbols) {
-        total += await drainSymbol(client, symbol);
+        await drainSymbol(client, symbol);
       }
       jobManager.beat(JOB_NAME);
     } finally {

--- a/apps/api/src/risk/contractMath.ts
+++ b/apps/api/src/risk/contractMath.ts
@@ -102,7 +102,7 @@ export function computePnlDollars(symbol: string, entryPrice: number, exitPrice:
     return 0;
   }
 
-  const spec = resolveContractSpec(symbol);
+  resolveContractSpec(symbol);
   const ticksMoved = specPriceDiffToTicks(symbol, entryPrice, exitPrice);
   const pnlPerContract = specTicksToDollars(symbol, ticksMoved);
   return pnlPerContract * contracts;

--- a/apps/api/src/routes/enginePreview.ts
+++ b/apps/api/src/routes/enginePreview.ts
@@ -1,7 +1,6 @@
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
 import {
   enginePreviewRequestSchema,
-  enginePreviewResponseSchema,
   type EnginePreviewRequest,
 } from '../dto/strategy-engine/index.js';
 import { runEnginePreview } from '../services/strategy-engine/index.js';

--- a/apps/api/src/routes/system-records.planner-rejects.ts
+++ b/apps/api/src/routes/system-records.planner-rejects.ts
@@ -3,11 +3,9 @@ import { z } from 'zod';
 
 import {
   canonicalizePlannerKey,
-  plannerKeys,
   rejectStages,
   type PlannerKey,
   type RejectStage,
-  mapRawReasonToPlannerRejectCode,
   plannerRejectReasonCodes,
   type PlannerRejectReasonCode,
 } from '../system-records/plannerRejectVocab.js';

--- a/apps/dashboard/src/__tests__/api.ticket-entry.test.ts
+++ b/apps/dashboard/src/__tests__/api.ticket-entry.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { markTicketEntered } from '../lib/api';
+
+describe('markTicketEntered', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('patches the encoded ticket-entered endpoint through the shared API client', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, ticketId: 'TICKET/123' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await markTicketEntered('TICKET/123');
+
+    expect(response).toEqual({ ok: true, ticketId: 'TICKET/123' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tickets/TICKET%2F123/entered',
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+  });
+
+  it('rejects blank ticket ids before issuing a request', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    let error: unknown = null;
+    try {
+      await markTicketEntered('   ');
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('Ticket id is required');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -321,6 +321,30 @@ export async function updateOperatorRiskSession(
   });
 }
 
+export type MarkTicketEnteredResponse = {
+  ok?: boolean;
+  ticketId?: string;
+  status?: string;
+  [key: string]: unknown;
+};
+
+export async function markTicketEntered(
+  ticketId: string,
+): Promise<MarkTicketEnteredResponse> {
+  const normalizedTicketId = ticketId.trim();
+  if (!normalizedTicketId) {
+    throw new Error('Ticket id is required');
+  }
+
+  return fetchJson<MarkTicketEnteredResponse>(
+    `/api/tickets/${encodeURIComponent(normalizedTicketId)}/entered`,
+    {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+    },
+  );
+}
+
 export async function fetchWorklistFeed(): Promise<WorklistApiResponse | null> {
   try {
     const payload = await fetchJson<WorklistApiResponse>('/api/worklist');

--- a/apps/dashboard/src/pages/WorklistV2.tsx
+++ b/apps/dashboard/src/pages/WorklistV2.tsx
@@ -43,6 +43,7 @@ import {
 import { logContractError, logPageLoad } from "../lib/contractTelemetry";
 import {
   fetchOperatorRiskSession,
+  markTicketEntered,
   updateOperatorRiskSession,
   type OperatorRiskSession,
 } from "../lib/api";
@@ -208,17 +209,7 @@ export default function WorklistV2() {
     setEnterLoading(true);
     setEnterError(null);
     try {
-      const resp = await fetch(
-        `/api/tickets/${encodeURIComponent(selected.ticketId)}/entered`,
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-        },
-      );
-      if (!resp.ok) {
-        const text = await resp.text();
-        throw new Error(text || "Failed to mark ticket as entered");
-      }
+      await markTicketEntered(selected.ticketId);
       const latestRisk = await fetchOperatorRiskSession();
       setOperatorRisk(latestRisk);
       setSelected(null);

--- a/packages/shared/src/contracts.ts
+++ b/packages/shared/src/contracts.ts
@@ -1,4 +1,4 @@
-import rawContractsSpec from '../config/contracts-spec.json' assert { type: 'json' };
+import rawContractsSpec from '../config/contracts-spec.json' with { type: 'json' };
 
 export type ContractType = 'standard' | 'micro' | 'spot' | 'index';
 


### PR DESCRIPTION
### Motivation
- Centralize and validate the ticket "entered" PATCH request in the dashboard API client and add unit coverage for it.
- Clean up unused variables and imports and update the JSON import assertion to address lint/TS warnings.

### Description
- Add `MarkTicketEnteredResponse` and `markTicketEntered` to `apps/dashboard/src/lib/api.ts`, which trims the ticket id, validates it, and calls `/api/tickets/:id/entered` with `PATCH`.
- Refactor `WorklistV2` to call `markTicketEntered` instead of inlining the `fetch` request.
- Add unit tests `apps/dashboard/src/__tests__/api.ticket-entry.test.ts` that mock `fetch` to assert the request and verify blank-id rejection.
- Misc cleanup: remove unused `total` accumulation in `apps/api/src/jobs/barsFeed.ts`, remove several unused imports in route files, and change the JSON import assertion in `packages/shared/src/contracts.ts` to `with { type: 'json' }`.

### Testing
- Ran the dashboard unit tests with `vitest`, including `api.ticket-entry.test.ts`, and they passed.
- No automated test failures were observed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2324bdc568832ca10a9226df675474)