### PR TITLE
Cleanup & small refactors: remove unused vars/imports, add markTicketEntered helper + test, improve runtime logging

### DIFF
--- a/apps/api/src/jobs/barsFeed.ts
+++ b/apps/api/src/jobs/barsFeed.ts
@@ -152,9 +152,8 @@ async function poll(): Promise<void> {
   try {
     const client = await pool.connect();
     try {
-      let total = 0;
       for (const symbol of trackedSymbols) {
-        total += await drainSymbol(client, symbol);
+        await drainSymbol(client, symbol);
       }
       jobManager.beat(JOB_NAME);
     } finally {

--- a/apps/api/src/risk/contractMath.ts
+++ b/apps/api/src/risk/contractMath.ts
@@ -102,7 +102,7 @@ export function computePnlDollars(symbol: string, entryPrice: number, exitPrice:
     return 0;
   }
 
-  const spec = resolveContractSpec(symbol);
+  resolveContractSpec(symbol);
   const ticksMoved = specPriceDiffToTicks(symbol, entryPrice, exitPrice);
   const pnlPerContract = specTicksToDollars(symbol, ticksMoved);
   return pnlPerContract * contracts;

--- a/apps/api/src/routes/enginePreview.ts
+++ b/apps/api/src/routes/enginePreview.ts
@@ -1,7 +1,6 @@
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
 import {
   enginePreviewRequestSchema,
-  enginePreviewResponseSchema,
   type EnginePreviewRequest,
 } from '../dto/strategy-engine/index.js';
 import { runEnginePreview } from '../services/strategy-engine/index.js';

--- a/apps/api/src/routes/system-records.planner-rejects.ts
+++ b/apps/api/src/routes/system-records.planner-rejects.ts
@@ -3,11 +3,9 @@ import { z } from 'zod';
 
 import {
   canonicalizePlannerKey,
-  plannerKeys,
   rejectStages,
   type PlannerKey,
   type RejectStage,
-  mapRawReasonToPlannerRejectCode,
   plannerRejectReasonCodes,
   type PlannerRejectReasonCode,
 } from '../system-records/plannerRejectVocab.js';

--- a/apps/api/src/system-records/plannerRejectRecorder.ts
+++ b/apps/api/src/system-records/plannerRejectRecorder.ts
@@ -42,13 +42,14 @@ export async function recordPlannerRejectCountBestEffort(input: RecordPlannerRej
       delta: input.delta ?? 1,
     });
   } catch (err) {
-    // eslint-disable-next-line no-console
+    const message = err instanceof Error ? err.message : String(err);
     console.warn('[plannerRejectRecorder] best-effort drop', {
       stage: input.rejectStage,
       sessionDate: input.sessionDate,
       symbol: input.symbol,
       requestedPlannerRaw: input.requestedPlannerRaw,
       rejectingPlannerRaw: input.rejectingPlannerRaw,
+      error: message,
     });
   }
 }

--- a/apps/api/src/tests/operator-actions.route.spec.ts
+++ b/apps/api/src/tests/operator-actions.route.spec.ts
@@ -1,7 +1,7 @@
 import { beforeAll, afterAll, describe, expect, it, vi, beforeEach } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import { buildServer } from '@prism-apex/app-api/server.js';
-import type { OperatorActionKind, RecordOperatorActionInput } from '@prism-apex/app-api/services/tickets/operatorAction.js';
+import type { RecordOperatorActionInput } from '@prism-apex/app-api/services/tickets/operatorAction.js';
 
 const { mockedRecordOperatorAction, TicketNotFoundError } = vi.hoisted(() => {
   class TicketNotFoundError extends Error {}

--- a/apps/api/start-runtime.cjs
+++ b/apps/api/start-runtime.cjs
@@ -1,18 +1,19 @@
 'use strict';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/no-unused-vars
+
 const path = require('node:path');
 
 function loadServerModule() {
   // 1) Deployed image via `pnpm deploy`: module is inside node_modules
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/no-unused-vars
-  try { return require('@prism-apex/api/dist/server.cjs'); } catch (_) { // no-op }
+  try {
+    return require('@prism-apex/api/dist/server.cjs');
+  } catch {
+    // Try the local development fallback below.
+  }
 
   // 2) Local dev fallback: relative to this file (when running from repo)
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, @typescript-eslint/no-unused-vars
-  try { return require(path.resolve(__dirname, 'dist/server.cjs')); } catch (err) {
+  try {
+    return require(path.resolve(__dirname, 'dist/server.cjs'));
+  } catch (err) {
     console.error('[api] Cannot locate dist/server.cjs in deployed or local paths:', err);
     process.exit(1);
   }
@@ -26,7 +27,7 @@ const { buildServer } = loadServerModule();
   const host = process.env.HOST || '0.0.0.0';
   try {
     await app.listen({ host, port });
-    console.log(`[api] listening on http://${host}:${port}`);
+    console.info(`[api] listening on http://${host}:${port}`);
   } catch (err) {
     console.error('[api] failed to listen', err);
     process.exit(1);

--- a/apps/dashboard/src/__tests__/api.ticket-entry.test.ts
+++ b/apps/dashboard/src/__tests__/api.ticket-entry.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { markTicketEntered } from '../lib/api';
+
+describe('markTicketEntered', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('patches the encoded ticket-entered endpoint through the shared API client', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, ticketId: 'TICKET/123' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await markTicketEntered('TICKET/123');
+
+    expect(response).toEqual({ ok: true, ticketId: 'TICKET/123' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tickets/TICKET%2F123/entered',
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+  });
+
+  it('rejects blank ticket ids before issuing a request', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    let error: unknown = null;
+    try {
+      await markTicketEntered('   ');
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('Ticket id is required');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -321,6 +321,30 @@ export async function updateOperatorRiskSession(
   });
 }
 
+export type MarkTicketEnteredResponse = {
+  ok?: boolean;
+  ticketId?: string;
+  status?: string;
+  [key: string]: unknown;
+};
+
+export async function markTicketEntered(
+  ticketId: string,
+): Promise<MarkTicketEnteredResponse> {
+  const normalizedTicketId = ticketId.trim();
+  if (!normalizedTicketId) {
+    throw new Error('Ticket id is required');
+  }
+
+  return fetchJson<MarkTicketEnteredResponse>(
+    `/api/tickets/${encodeURIComponent(normalizedTicketId)}/entered`,
+    {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+    },
+  );
+}
+
 export async function fetchWorklistFeed(): Promise<WorklistApiResponse | null> {
   try {
     const payload = await fetchJson<WorklistApiResponse>('/api/worklist');

--- a/apps/dashboard/src/pages/WorklistV2.tsx
+++ b/apps/dashboard/src/pages/WorklistV2.tsx
@@ -43,6 +43,7 @@ import {
 import { logContractError, logPageLoad } from "../lib/contractTelemetry";
 import {
   fetchOperatorRiskSession,
+  markTicketEntered,
   updateOperatorRiskSession,
   type OperatorRiskSession,
 } from "../lib/api";
@@ -208,17 +209,7 @@ export default function WorklistV2() {
     setEnterLoading(true);
     setEnterError(null);
     try {
-      const resp = await fetch(
-        `/api/tickets/${encodeURIComponent(selected.ticketId)}/entered`,
-        {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-        },
-      );
-      if (!resp.ok) {
-        const text = await resp.text();
-        throw new Error(text || "Failed to mark ticket as entered");
-      }
+      await markTicketEntered(selected.ticketId);
       const latestRisk = await fetchOperatorRiskSession();
       setOperatorRisk(latestRisk);
       setSelected(null);

--- a/packages/shared/src/contracts.ts
+++ b/packages/shared/src/contracts.ts
@@ -1,4 +1,4 @@
-import rawContractsSpec from '../config/contracts-spec.json' assert { type: 'json' };
+import rawContractsSpec from '../config/contracts-spec.json' with { type: 'json' };
 
 export type ContractType = 'standard' | 'micro' | 'spot' | 'index';
 


### PR DESCRIPTION
### Motivation
- Remove unused variables and imports to reduce noise and potential confusion and tighten error logging for best-effort recorders.
- Centralize the ticket-entered API call into a reusable client helper and cover it with a unit test.
- Improve startup/runtime messages and module-loading fallbacks for clearer diagnostics.

### Description
- Removed an unused `total` accumulator in `apps/api/src/jobs/barsFeed.ts` and simplified the per-symbol drain loop to discard the unused return value from `drainSymbol`.
- Simplified `computePnlDollars` in `apps/api/src/risk/contractMath.ts` by calling `resolveContractSpec(symbol)` for side effects only and removed an unused `spec` local.
- Dropped unused imports (e.g. response schema and vocab items) in route modules to eliminate dead imports in `apps/api/src/routes/enginePreview.ts` and `apps/api/src/routes/system-records.planner-rejects.ts`.
- Improved best-effort error logging in `apps/api/src/system-records/plannerRejectRecorder.ts` to include the error message instead of suppressing linter warnings.
- Updated tests to remove an unused type import in `apps/api/src/tests/operator-actions.route.spec.ts`.
- Added a new helper `markTicketEntered` in `apps/dashboard/src/lib/api.ts` to centralize the PATCH to `/api/tickets/:id/entered` and added `apps/dashboard/src/__tests__/api.ticket-entry.test.ts` to validate its behavior.
- Updated `apps/dashboard/src/pages/WorklistV2.tsx` to use the new `markTicketEntered` helper instead of inlining the `fetch` call.
- Adjusted the generated runtime loader `apps/api/start-runtime.cjs` to use clearer `try/catch` blocks and changed a startup `console.log` to `console.info` for consistency.
- Changed the JSON import assertion style in `packages/shared/src/contracts.ts` from `assert { type: 'json' }` to `with { type: 'json' }` to align with the targeted loader syntax.

### Testing
- Ran unit tests with Vitest focusing on the dashboard API client changes and the new `api.ticket-entry.test.ts` test, and the new test passed.
- Ran the existing test suite for the API package (Vitest) and no regressions were observed in the modified specs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2324bdc568832ca10a9226df675474)